### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for Javascript packages
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Changes

- Enables Dependabot dependency updates for Javascript packages

## Context

After merging you'll need to add a "dependencies" label, so that pulls from Dependabot have a label.

## References:
[GitHub docs on Dependabot](https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically)

