### PR TITLE
I18n fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Fix some i18n issues ([#26](https://github.com/ben/foundry-ironsworn/issues/26))
+
 ## 0.3.1
 
 - Fix choice oracles ([#21](https://github.com/ben/foundry-ironsworn/issues/21))

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -1,4 +1,4 @@
-import { ironswornRollDialog } from './ironsworn.js'
+import { ironswornRollDialog, capitalize } from './ironsworn.js'
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
@@ -227,7 +227,9 @@ export class IronswornActorSheet extends ActorSheet {
     const stat = el.dataset.stat
     if (stat) {
       // Clicked a non-edit stat; trigger a roll
-      ironswornRollDialog(this.actor.data.data, stat, `Roll +${stat}`)
+      const rollText = game.i18n.localize('IRONSWORN.Roll')
+      const statText = game.i18n.localize(`IRONSWORN.${capitalize(stat)}`)
+      ironswornRollDialog(this.actor.data.data, stat, `${rollText} +${statText}`)
     }
 
     const resource = el.dataset.resource

--- a/module/ironsworn.js
+++ b/module/ironsworn.js
@@ -196,10 +196,11 @@ Handlebars.registerHelper('rangeEach', function (context, options) {
 
 Handlebars.registerHelper('concat', (...args) => args.slice(0, -1).join(''))
 
-Handlebars.registerHelper('capitalize', txt => {
+export function capitalize (txt) {
   const [first, ...rest] = txt
   return `${first.toUpperCase()}${rest.join('')}`
-})
+}
+Handlebars.registerHelper('capitalize', capitalize)
 
 Handlebars.registerHelper('progressCharacters', current => {
   const tickChar = [' ', '-', '+', '*'][current % 4]

--- a/styles/ironsworn.css
+++ b/styles/ironsworn.css
@@ -77,7 +77,6 @@
   flex: 0;
   border-right: 1px solid black;
   margin-right: 5px;
-  padding-right: 25px;
   position: relative;
 }
 .ironsworn .margin-right {
@@ -119,21 +118,17 @@
   background-color: #aaa;
   color: white;
 }
+.ironsworn h4.vertical {
+  padding-left: 5px;
+  writing-mode: vertical-lr;
+}
 .ironsworn .stack {
   margin-bottom: 20px;
   flex-grow: 0;
 }
-.ironsworn .stack h4.vertical {
-  transform: rotate(90deg);
-  transform-origin: 0 0;
-  float: right;
-  position: absolute;
-  left: 78px;
-  padding-left: 5px;
-}
 .ironsworn .stack .stack-row {
   flex: 0 0 auto;
-  width: 50px;
+  min-width: 50px;
   border: 1px solid black;
   margin-bottom: -1px;
   text-align: center;

--- a/styles/ironsworn.less
+++ b/styles/ironsworn.less
@@ -84,7 +84,6 @@
     flex: 0;
     border-right: 1px solid black;
     margin-right: 5px;
-    padding-right: 25px;
     position: relative;
   }
 
@@ -135,22 +134,18 @@
     }
   }
 
+  h4.vertical {
+    padding-left: 5px;
+    writing-mode: vertical-lr;
+  }
+
   .stack {
     margin-bottom: 20px;
     flex-grow: 0;
 
-    h4.vertical {
-      transform: rotate(90deg);
-      transform-origin: 0 0;
-      float: right;
-      position: absolute;
-      left: 78px;
-      padding-left: 5px;
-    }
-
     .stack-row {
       flex: 0 0 auto;
-      width: 50px;
+      min-width: 50px;
       border: 1px solid black;
       margin-bottom: -1px;
       text-align: center;

--- a/templates/actor/character.hbs
+++ b/templates/actor/character.hbs
@@ -55,29 +55,37 @@
 
     <div class="flexrow">
         <div class="flexcol margin-left">
-            <div class="flexcol stack momentum">
-                <h4 class="vertical">{{localize 'IRONSWORN.Momentum'}}</h4>
-                {{>stack stat="momentum" from=10 to=-6}}
-                <hr />
-                <div class="clickable block stack-row" id="burn">
-                    {{localize 'IRONSWORN.Burn'}}
+            <div class="flexrow" style="flex-wrap:nowrap;">
+                <div class="flexcol stack momentum">
+                    {{>stack stat="momentum" from=10 to=-6}}
+                    <hr style="flex-grow: 0;" />
+                    <div class="clickable block stack-row" style="padding: 0 5px;" id="burn">
+                        {{localize 'IRONSWORN.Burn'}}
+                    </div>
+                    {{localize 'IRONSWORN.Reset'}}: {{data.data.momentumReset}}
+                    {{localize 'IRONSWORN.Max'}}: {{data.data.momentumMax}}
                 </div>
-                {{localize 'IRONSWORN.Reset'}}: {{data.data.momentumReset}}
-                {{localize 'IRONSWORN.Max'}}: {{data.data.momentumMax}}
+                <h4 class="vertical">{{localize 'IRONSWORN.Momentum'}}</h4>
             </div>
         </div>
         <div class="flexcol margin-left">
-            <div class="flexcol stack health">
+            <div class="flexrow" style="flex-wrap: nowrap;">
+                <div class="flexcol stack health">
+                    {{>stack stat="health" from=5 to=0}}
+                </div>
                 <h4 class="vertical clickable text" data-stat="health">{{localize 'IRONSWORN.Health'}}</h4>
-                {{>stack stat="health" from=5 to=0}}
             </div>
-            <div class="flexcol stack spirit">
+            <div class="flexrow" style="flex-wrap: nowrap;">
+                <div class="flexcol stack spirit">
+                    {{>stack stat="spirit" from=5 to=0}}
+                </div>
                 <h4 class="vertical clickable text" data-stat="spirit">{{localize 'IRONSWORN.Spirit'}}</h4>
-                {{>stack stat="spirit" from=5 to=0}}
             </div>
-            <div class="flexcol stack supply">
+            <div class="flexrow" style="flex-wrap: nowrap;">
+                <div class="flexcol stack supply">
+                    {{>stack stat="supply" from=5 to=0}}
+                </div>
                 <h4 class="vertical clickable text" data-stat="supply">{{localize 'IRONSWORN.Supply'}}</h4>
-                {{>stack stat="supply" from=5 to=0}}
             </div>
         </div>
         <div class="flexcol">
@@ -165,7 +173,8 @@
                                                 {{value}}
                                             </div>
                                             {{/rangeEach}}
-                                            <div class="clickable block roll-asset-track" style="text-align: center; line-height: 40px;">
+                                            <div class="clickable block roll-asset-track"
+                                                style="text-align: center; line-height: 40px;">
                                                 <i class="fas fa-dice-d6"></i>
                                             </div>
                                         </div>
@@ -194,10 +203,8 @@
 
                         {{#*inline "debility"}}
                         <label class="checkbox">
-                            <input type="checkbox"
-                                   name="data.debility.{{name}}"
-                                   {{checked (lookup data.data.debility name)}}
-                            >
+                            <input type="checkbox" name="data.debility.{{name}}" {{checked (lookup data.data.debility
+                                name)}}>
                             {{capitalize name}}
                         </label>
                         {{/inline}}

--- a/templates/actor/character.hbs
+++ b/templates/actor/character.hbs
@@ -13,7 +13,7 @@
 {{#*inline "progress"}}
 <div class="flexcol item-row" data-id="{{id}}">
     <div class="flexrow">
-        <h2>{{name}} ({{data.data.rank}})</h2>
+        <h2>{{name}} ({{localize (concat 'IRONSWORN.' (capitalize data.data.rank))}})</h2>
         <div class="block clickable" style="flex-grow: 0;">
             <i class="edit-item fas fa-edit"></i>
         </div>


### PR DESCRIPTION
As noted in #24, there were a couple of issues with i18n text. This should fix them.

- [x] Translate "Roll +edge" and friends in dialog and chat-card titles
- [x] Translate vow and progress ranks in character sheet display
- [x] Allow for translations of "burn" longer than 50px
- [x] Update the changelog