### PR TITLE
Momentum boxes that are above max are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Momentum boxes above max are disabled ([#32](https://github.com/ben/foundry-ironsworn/pull/32))
+
 ## 0.4.1
 
 - More code reorganization, and a couple of aesthetic changes ([#31](https://github.com/ben/foundry-ironsworn/pull/31))

--- a/src/module/helpers/handlebars.ts
+++ b/src/module/helpers/handlebars.ts
@@ -85,7 +85,7 @@ export class IronswornHandlebarsHelpers {
 
     Handlebars.registerHelper('rangeEach', function (context, _options) {
       const results = [] as string[]
-      const { from, to, current } = context.hash
+      const { from, to, current, min, max } = context.hash
 
       // Enable both directions of iteration
       const increment = from > to ? -1 : 1
@@ -95,6 +95,9 @@ export class IronswornHandlebarsHelpers {
         const valueStr = value > 0 ? `+${value}` : value.toString()
         const isCurrent = value === current
         const lteCurrent = value <= current
+        const isAboveMax = max === undefined ? false : value > max
+        const isBelowMin = min === undefined ? false : value < min
+
         results.push(
           context.fn({
             ...this,
@@ -102,6 +105,9 @@ export class IronswornHandlebarsHelpers {
             value,
             isCurrent,
             lteCurrent,
+            isAboveMax,
+            isBelowMin,
+            isOutOfBounds: isAboveMax || isBelowMin,
           })
         )
       }

--- a/src/styles/ironsworn.less
+++ b/src/styles/ironsworn.less
@@ -158,7 +158,18 @@
     }
   }
 
-  .clickable {
+  .clickable.disabled {
+    background: #ccc;
+    color: #888;
+    cursor: not-allowed;
+
+    &.selected {
+      color: white;
+      background: black;
+    }
+  }
+
+  .clickable:not(.disabled) {
     transition: 0.5s ease;
     cursor: pointer;
 

--- a/system/templates/actor/character.hbs
+++ b/system/templates/actor/character.hbs
@@ -1,10 +1,11 @@
 {{#*inline "stack"}}
-{{#rangeEach from=from to=to current=(lookup data.data stat)}}
+{{#rangeEach from=from to=to current=(lookup data.data stat) min=min max=max}}
 <div class="
         clickable block stack-row
         ironsworn__stat__value
         {{stat}}
         {{#if isCurrent}} selected {{/if}}
+        {{#if isOutOfBounds}} disabled {{/if}}
     " data-resource="{{stat}}" data-value="{{value}}">
     {{valueStr}}
 </div>
@@ -68,7 +69,7 @@
         <div class="flexcol margin-left">
             <div class="flexrow" style="flex-wrap:nowrap;">
                 <div class="flexcol stack momentum">
-                    {{>stack stat="momentum" from=10 to=-6}}
+                    {{>stack stat="momentum" from=10 to=-6 max=data.data.momentumMax}}
                     <hr style="flex-grow: 0;" />
                     <div class="clickable block stack-row ironsworn__momentum__burn" style="padding: 0 5px;">
                         {{localize 'IRONSWORN.Burn'}}


### PR DESCRIPTION
Turning off "click me" affordances for momentum boxes above max.