### PR TITLE
CSS Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Restructure i18n files ([#37](https://github.com/ben/foundry-ironsworn/pull/37))
 - Edit mode for assets ([#38](https://github.com/ben/foundry-ironsworn/pull/38))
+- Visual tweaks ([#39](https://github.com/ben/foundry-ironsworn/pull/39))
 
 ## 0.4.2
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,10 @@ import './styles/styles.less'
 
 Hooks.once('init', async () => {
   console.log('Ironsworn | initializing system')
+  
+  // Bootstrap settings and pull in theme
   IronswornSettings.registerSettings()
-
+  require(`./styles/themes/${IronswornSettings.theme}.less`)
 
   CONFIG.IRONSWORN = IRONSWORN
 

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -1,6 +1,3 @@
-@import './themes/ironsworn.less';
-@import './themes/starforged.less';
-
 .ironsworn {
   h1,
   h2,

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -130,10 +130,20 @@
       flex: 0 0 auto;
       min-width: 50px;
       border: 1px solid;
-      margin-bottom: -1px;
+      border-top: none;
       text-align: center;
       line-height: 28px;
       font-size: 18px;
+
+      &:first-child {
+        border-top: 1px solid;
+        border-top-left-radius: 5px;
+        border-top-right-radius: 5px;
+      }
+      &:last-child {
+        border-bottom-left-radius: 5px;
+        border-bottom-right-radius: 5px;
+      }
 
       input[type='radio'] {
         appearance: none;

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -176,7 +176,7 @@
     justify-content: space-around;
 
     .stat {
-      flex: 0 0 100px;
+      flex: 0 0 75px;
       border: 1px solid;
       text-align: center;
 

--- a/src/styles/themes/ironsworn.less
+++ b/src/styles/themes/ironsworn.less
@@ -1,5 +1,5 @@
 .theme-ironsworn {
-  @background-color: #eee;
+  @background-color: white;
   @dark-color: #888;
   @medium-color: darkgray;
   @light-color: #ccc;
@@ -86,14 +86,25 @@
 
     &:not(.disabled) {
       &:hover {
-        background: @light-color;
+        &.block {
+          background: @medium-color;
+        }
+        &.text {
+          color: @medium-color;
+        }
       }
       &:active {
-        background-color: @medium-color;
+        &.block {
+          background: @light-color;
+        }
+        &.text {
+          color: @light-color;
+        }
       }
 
       &.selected {
         color: white;
+        border-color: black;
         background: black;
       }
     }

--- a/src/styles/themes/starforged.less
+++ b/src/styles/themes/starforged.less
@@ -91,8 +91,6 @@
   }
 
   .clickable {
-    border-radius: 8px;
-    
     &.disabled {
       color: @dark-color;
 
@@ -104,10 +102,20 @@
 
     &:not(.disabled) {
       &:hover {
-        background: @light-color;
+        &.block {
+          background: @light-color;
+        }
+        &.text {
+          color: @light-color;
+        }
       }
       &:active {
-        background-color: @medium-color;
+        &.block {
+          background: @medium-color;
+        }
+        &.text {
+          color: @medium-color;
+        }
       }
 
       &.selected {

--- a/system/templates/actor/character.hbs
+++ b/system/templates/actor/character.hbs
@@ -69,10 +69,14 @@
     <div class="flexcol margin-left">
       <div class="flexrow" style="flex-wrap:nowrap;">
         <div class="flexcol stack momentum">
-          {{>stack stat="momentum" from=10 to=-6 max=data.data.momentumMax}}
+          <div class="nogrow">
+            {{>stack stat="momentum" from=10 to=-6 max=data.data.momentumMax}}
+          </div>
           <hr style="flex-grow: 0;" />
-          <div class="clickable block stack-row ironsworn__momentum__burn" style="padding: 0 5px;">
-            {{localize 'IRONSWORN.Burn'}}
+          <div class="nogrow">
+            <div class="clickable block stack-row ironsworn__momentum__burn" style="padding: 0 5px;">
+              {{localize 'IRONSWORN.Burn'}}
+            </div>
           </div>
           {{localize 'IRONSWORN.Reset'}}: {{data.data.momentumReset}}
           {{localize 'IRONSWORN.Max'}}: {{data.data.momentumMax}}


### PR DESCRIPTION
Some small tweaks with styling:

- [x] Only import stylesheet for selected theme. This allows the theme to have broader impact without colliding with other themes.
- [x] Make momentum/health/spirit/supply stacks softer with border radii, and fix the interior borders.
- [x] Adjust the layout and fix a couple of bugs.