### PR TITLE
Paper over array weirdnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Fix the asset sheet ([#45](https://github.com/ben/foundry-ironsworn/pull/45))
+
 ## 0.4.3
 
 - Restructure i18n files ([#37](https://github.com/ben/foundry-ironsworn/pull/37))

--- a/src/module/item/asset/assetsheet.ts
+++ b/src/module/item/asset/assetsheet.ts
@@ -9,6 +9,8 @@ export class AssetSheet extends IronswornItemSheet {
   }
 
   activateListeners(html: JQuery) {
+    if (!this.options.editable) return
+
     html.find('.ironsworn__ability__enable').on('click', (ev) => this._abilityToggle.call(this, ev))
     html.find('.ironsworn__field__add').on('click', (ev) => this._addField.call(this, ev))
     html.find('.ironsworn__field__label').on('blur', (ev) => this._updateFieldLabel.call(this, ev))

--- a/src/module/item/asset/assetsheet.ts
+++ b/src/module/item/asset/assetsheet.ts
@@ -10,6 +10,10 @@ export class AssetSheet extends IronswornItemSheet {
 
   activateListeners(html: JQuery) {
     html.find('.ironsworn__ability__enable').on('click', (ev) => this._abilityToggle.call(this, ev))
+    html.find('.ironsworn__field__add').on('click', (ev) => this._addField.call(this, ev))
+    html.find('.ironsworn__field__label').on('blur', (ev) => this._updateFieldLabel.call(this, ev))
+    html.find('.ironsworn__field__value').on('blur', (ev) => this._updateFieldValue.call(this, ev))
+    html.find('.ironsworn__field__delete').on('click', (ev) => this._deleteField.call(this, ev))
   }
 
   _getHeaderButtons() {
@@ -40,5 +44,42 @@ export class AssetSheet extends IronswornItemSheet {
     const abilities = Object.values(assetData.data.abilities)
     abilities[idx].enabled = !abilities[idx].enabled
     this.item.update({ data: { abilities } })
+  }
+
+  _addField(ev: JQuery.ClickEvent) {
+    ev.preventDefault()
+
+    const assetData = this.item.data as AssetItemData
+    const fields = Object.values(assetData.data.fields || [])
+    fields.push({ name: '', value: '' })
+    this.item.update({ data: { fields } })
+  }
+
+  _deleteField(ev: JQuery.ClickEvent) {
+    ev.preventDefault()
+
+    const { idx } = ev.currentTarget.dataset
+    const assetData = this.item.data as AssetItemData
+    const fields = Object.values(assetData.data.fields || [])
+    fields.splice(idx, 1)
+    this.item.update({ data: { fields } })
+  }
+
+  _updateFieldLabel(ev: JQuery.BlurEvent) {
+    const assetData = this.item.data as AssetItemData
+    const fields = Object.values(assetData.data.fields)
+    const { idx } = ev.currentTarget.dataset
+    const val = $(ev.currentTarget).val()?.toString() || ''
+    fields[idx].name = val
+    this.item.update({ data: { fields } })
+  }
+  
+  _updateFieldValue(ev: JQuery.BlurEvent) {
+    const assetData = this.item.data as AssetItemData
+    const fields = Object.values(assetData.data.fields)
+    const { idx } = ev.currentTarget.dataset
+    const val = $(ev.currentTarget).val()?.toString() || ''
+    fields[idx].value = val
+    this.item.update({ data: { fields } })
   }
 }

--- a/src/module/item/asset/assetsheet.ts
+++ b/src/module/item/asset/assetsheet.ts
@@ -1,10 +1,15 @@
 import { IronswornItemSheet } from '../item-sheet'
+import { AssetItemData } from '../itemtypes'
 
 export class AssetSheet extends IronswornItemSheet {
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
       height: 600,
     } as BaseEntitySheet.Options)
+  }
+
+  activateListeners(html: JQuery) {
+    html.find('.ironsworn__ability__enable').on('click', (ev) => this._abilityToggle.call(this, ev))
   }
 
   _getHeaderButtons() {
@@ -25,5 +30,15 @@ export class AssetSheet extends IronswornItemSheet {
 
     const currentValue = this.item.getFlag('foundry-ironsworn', 'edit-mode')
     this.item.setFlag('foundry-ironsworn', 'edit-mode', !currentValue)
+  }
+
+  _abilityToggle(ev: JQuery.ClickEvent) {
+    ev.preventDefault()
+
+    const { idx } = ev.currentTarget.dataset
+    const assetData = this.item.data as AssetItemData
+    const abilities = Object.values(assetData.data.abilities)
+    abilities[idx].enabled = !abilities[idx].enabled
+    this.item.update({ data: { abilities } })
   }
 }

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -63,14 +63,6 @@ export class IronswornItemSheet extends ItemSheet<ItemSheet.Data<IronswornItem>,
     // Everything below here is only needed if the sheet is editable
     if (!this.options.editable) return
 
-    html.find('.delete-field').click(async (ev) => {
-      ev.preventDefault()
-      const idx = parseInt($(ev.target).parents('.item-row').data('idx'))
-      const fields = Object.values((this.item.data.data as any).fields)
-      fields.splice(idx, 1)
-      await this.item.update({ 'data.fields': fields })
-    })
-
     html.find('.track-target').click(async (ev) => {
       const newValue = parseInt(ev.currentTarget.dataset.value)
       await this.item.update({ 'data.track.current': newValue })

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -70,11 +70,6 @@ export class IronswornItemSheet extends ItemSheet<ItemSheet.Data<IronswornItem>,
       fields.splice(idx, 1)
       await this.item.update({ 'data.fields': fields })
     })
-    html.find('.add-field').click(async (_ev) => {
-      const fields = Object.values((this.item.data.data as any).fields)
-      fields.push({ name: '', value: '' })
-      await this.item.update({ 'data.fields': fields })
-    })
 
     html.find('.track-target').click(async (ev) => {
       const newValue = parseInt(ev.currentTarget.dataset.value)

--- a/system/templates/item/asset.hbs
+++ b/system/templates/item/asset.hbs
@@ -41,7 +41,7 @@
     {{#each data.data.abilities}}
     <div class="flexcol item">
         <div class="flexrow">
-            <input type="checkbox" name="data.abilities.{{@index}}.enabled" {{checked enabled}} style="flex-grow: 0;" />
+            <input type="checkbox" class="ironsworn__ability__enable" data-idx="{{@index}}" {{checked enabled}} style="flex-grow: 0;" />
             {{#if ../item.data.flags.foundry-ironsworn.edit-mode}}
             <input class="attribute-value" type="textarea" name="data.abilities.{{@index}}.description"
                 value="{{description}}" />

--- a/system/templates/item/asset.hbs
+++ b/system/templates/item/asset.hbs
@@ -18,20 +18,20 @@
                 <div class="flexrow">
                     <label style="flex-grow: 0; align-self: center;">{{localize 'IRONSWORN.Label'}}:</label>
                     &nbsp;
-                    <input class="attribute-value" type="text" name="data.fields.{{@index}}.name" value="{{name}}" />
+                    <input class="attribute-value ironsworn__field__label" data-idx="{{@index}}" type="text" value="{{name}}" />
                 </div>
                 <div class="flexrow">
                     <label style="flex-grow: 0; align-self: center;">{{localize 'IRONSWORN.Value'}}:</label>
                     &nbsp;
-                    <input class="attribute-value" type="text" name="data.fields.{{@index}}.value" value="{{value}}" />
+                    <input class="attribute-value ironsworn__field__value" data-idx="{{@index}}" type="text" value="{{value}}" />
                 </div>
             </div>
-            <div class="block clickable item-row-control delete-field" data-index="{{@index}}">
+            <div class="block clickable item-row-control ironsworn__field__delete" data-idx="{{@index}}">
                 <i class="fas fa-trash"></i>
             </div>
         </div>
         {{/each}}
-        <div class="block clickable add-field" style="padding: 5px; text-align: center;">
+        <div class="block clickable ironsworn__field__add" style="padding: 5px; text-align: center;">
             <i class="fas fa-plus"></i>
         </div>
     </div>


### PR DESCRIPTION
As per #43, it looks like most assets in the compendium have their data structured properly:

```js
{
  abilities: [
    { enabled: true, description: "..." },
    { enabled: false, description: "..." },
    { enabled: false, description: "..." },
  ]
}
```

I.e., `abilities` should be an array. But others seem to have data that looks like this:

```js
{
  abilities: {
    0: { enabled: true, description: "..." },
    1: { enabled: false, description: "..." },
    2: { enabled: false, description: "..." },
  }
}
```

`abilities` is an object with integer keys. This is probably left over from early development when I was still figuring out how to do editors and toggles, and honestly Foundry still sometimes screws this up. 

This PR fixes it by using a custom handler for the checkboxes that will ensure the data ends up in the proper format. I'm also fixing a couple of other bugs with field edits on this sheet. Fixes #43.