### PR TITLE
Restructure headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix the asset sheet ([#45](https://github.com/ben/foundry-ironsworn/pull/45))
 - Unify and update the progress/vow sheets ([#46](https://github.com/ben/foundry-ironsworn/pull/46))
+- Restructure the use of headers ([#47](https://github.com/ben/foundry-ironsworn/pull/47))
 
 ## 0.4.3
 

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -5,7 +5,7 @@
   h4,
   h5,
   h6 {
-    font-variant: all-small-caps;
+    text-transform: uppercase;
   }
 
   .window-content {
@@ -93,9 +93,6 @@
     position: relative;
   }
 
-  h4 {
-    font-size: 22px;
-  }
 
   .asset-summary {
     transition: all 0.5s ease;
@@ -130,9 +127,10 @@
     }
   }
 
-  h4.vertical {
-    padding-left: 5px;
+  .vertical {
+    padding: 0 5px;
     writing-mode: vertical-lr;
+    border: none;
   }
 
   .stack {
@@ -145,7 +143,6 @@
       border-top: none;
       text-align: center;
       line-height: 28px;
-      font-size: 18px;
 
       &:first-child {
         border-top: 1px solid;
@@ -288,7 +285,6 @@
       border: 1px solid;
       border-radius: 3px;
       padding: 5px;
-      font-size: smaller;
       margin: 5px;
     }
   }
@@ -398,7 +394,6 @@
   text-align: center;
   border: 1px solid;
   margin-bottom: 5px;
-  font-size: 22px;
   font-weight: bold;
   line-height: 30px;
   font-variant: all-small-caps;
@@ -416,7 +411,6 @@
 
 .ironsworn-roll {
   .hit-type {
-    font-size: 20px;
     font-weight: bold;
     font-variant: all-small-caps;
   }
@@ -429,7 +423,6 @@
     background-image: url('/icons/svg/d6-grey.svg');
     background-repeat: no-repeat;
     background-size: 24px 24px;
-    font-size: 18px;
     font-weight: bold;
     text-align: center;
   }

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -20,6 +20,7 @@
       border-top: none;
     }
     margin: 5px;
+    padding-top: 7px;
 
     h1,
     h2,

--- a/system/templates/actor/character.hbs
+++ b/system/templates/actor/character.hbs
@@ -36,7 +36,7 @@
         <i class="fas fa-check"></i>
       </div>
     </div>
-    <h2>{{name}}</h2>
+    <h3>{{name}}</h3>
   </div>
   <div class="flexrow">
     <div class="flexrow track">
@@ -88,7 +88,7 @@
           {{localize 'IRONSWORN.Reset'}}: {{data.data.momentumReset}}
           {{localize 'IRONSWORN.Max'}}: {{data.data.momentumMax}}
         </div>
-        <h4 class="vertical">{{localize 'IRONSWORN.Momentum'}}</h4>
+        <h3 class="vertical">{{localize 'IRONSWORN.Momentum'}}</h3>
       </div>
     </div>
     <div class="flexcol">
@@ -127,7 +127,7 @@
 
           <div class="flexcol">
             <section class="sheet-area" style="flex-grow: 0;">
-              <h1 style="text-align:center">{{localize 'IRONSWORN.Bonds'}}</h1>
+              <h2 style="text-align:center">{{localize 'IRONSWORN.Bonds'}}</h2>
               <div class="flexrow">
                 <div class="flexrow track">
                   {{#each (progressCharacters bonds.count)}}
@@ -142,14 +142,14 @@
             </section>
 
             <section class="sheet-area">
-              <h1 style="text-align:center">{{localize 'IRONSWORN.Assets'}}</h1>
+              <h2 style="text-align:center">{{localize 'IRONSWORN.Assets'}}</h2>
               <div class="flexcol item-list">
                 <ol>
                   {{#each assets}}
                   <li class="item-row ironsworn__asset" data-item="{{id}}">
                     <div class="asset-entry ironsworn__asset__expand" data-item="{{id}}">
                       <div class="flexrow">
-                        <h4> {{name}} </h4>
+                        <h3> {{name}} </h3>
                         {{#if actor.data.flags.foundry-ironsworn.edit-mode}}
                         <div class="clickable block nogrow ironsworn__{{type}}__delete" data-item="{{id}}"
                           style="margin: 0 5px;">
@@ -183,9 +183,9 @@
 
                       {{#if data.data.track.enabled}}
                       <div class="flexcol">
-                        <label class="clickable text ironsworn__assettrack__roll">
+                        <h4 class="clickable text ironsworn__assettrack__roll">
                           {{data.data.track.name}}
-                        </label>
+                        </h4>
                         <div class="flexrow track">
                           {{#rangeEach from=0 to=data.data.track.max
                           current=data.data.track.current}}
@@ -209,7 +209,7 @@
 
           <div class="flexcol">
             <section class="sheet-area progresses">
-              <h1 style="text-align:center">{{localize 'IRONSWORN.Vows'}}</h1>
+              <h2 style="text-align:center">{{localize 'IRONSWORN.Vows'}}</h2>
               {{#each vows}}
               {{>progress}}
               {{/each}}
@@ -219,7 +219,7 @@
 
             </section>
             <section class="sheet-area progresses">
-              <h1 style="text-align:center">{{localize 'IRONSWORN.Progress'}}</h1>
+              <h2 style="text-align:center">{{localize 'IRONSWORN.Progress'}}</h2>
               {{#each progresses}}
               {{>progress}}
               {{/each}}
@@ -231,7 +231,7 @@
 
         </div>
         <section class="sheet-area" style="flex-grow: 0;">
-          <h1 style="text-align:center">{{localize 'IRONSWORN.Debilities'}}</h1>
+          <h2 style="text-align:center">{{localize 'IRONSWORN.Debilities'}}</h2>
 
           {{#*inline "debility"}}
           <label class="checkbox">
@@ -272,27 +272,27 @@
     </div>
     <div class="flexcol margin-right">
       <div class="flexrow nogrow" style="flex-wrap: nowrap;">
-        <h4 class="vertical clickable text ironsworn__stat__roll" data-stat="health">
+        <h3 class="vertical clickable text ironsworn__stat__roll" data-stat="health">
           {{localize 'IRONSWORN.Health'}}
-        </h4>
+        </h3>
         <div class="flexcol stack health">
           {{>stack stat="health" from=5 to=0}}
         </div>
       </div>
       <hr class="nogrow" />
       <div class="flexrow nogrow" style="flex-wrap: nowrap;">
-        <h4 class="vertical clickable text ironsworn__stat__roll" data-stat="spirit">
+        <h3 class="vertical clickable text ironsworn__stat__roll" data-stat="spirit">
           {{localize 'IRONSWORN.Spirit'}}
-        </h4>
+        </h3>
         <div class="flexcol stack spirit">
           {{>stack stat="spirit" from=5 to=0}}
         </div>
       </div>
       <hr class="nogrow" />
       <div class="flexrow nogrow" style="flex-wrap: nowrap;">
-        <h4 class="vertical clickable text ironsworn__stat__roll" data-stat="supply">
+        <h3 class="vertical clickable text ironsworn__stat__roll" data-stat="supply">
           {{localize 'IRONSWORN.Supply'}}
-        </h4>
+        </h3>
         <div class="flexcol stack supply">
           {{>stack stat="supply" from=5 to=0}}
         </div>

--- a/system/templates/actor/moves.hbs
+++ b/system/templates/actor/moves.hbs
@@ -14,7 +14,7 @@
           <h2>{{title}}</h2>
           {{else}}
           <li class='item-row ironsworn__builtin__move' data-name='{{title}}'>
-            <div class='ironsworn__builtin__move__expand'>{{title}}</div>
+            <h4 class='ironsworn__builtin__move__expand' style="margin: 0;">{{title}}</h4>
             <div class='move-summary' style='display: none;'>{{{enrichHtml description}}}</div>
           </li>
           {{/if}}
@@ -28,7 +28,7 @@
 
         {{#*inline "oracle"}}
         <li class="item">
-          <h3 class="clickable text move ironsworn__oracle" data-table="Oracle: {{name}}">{{name}}</h3>
+          <h4 class="clickable text move ironsworn__oracle" data-table="Oracle: {{name}}">{{name}}</h4>
         </li>
         {{/inline}}
 


### PR DESCRIPTION
This changes our use of headers to be more semantically appropriate, and a little nicer-looking to boot. This way we don't have to change `font-size` all over the place.