### PR TITLE
Shared sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Add a shared sheet ([#55](https://github.com/ben/foundry-ironsworn/pull/55))
+
 ## 0.4.7
 
 - Fix the move sheet's description ([#54](https://github.com/ben/foundry-ironsworn/pull/54))

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { IRONSWORN } from './config'
 import { IronswornActor } from './module/actor/actor'
 import { IronswornCharacterSheet } from './module/actor/sheets/charactersheet'
 import { IronswornCompactCharacterSheet } from './module/actor/sheets/compactsheet'
+import { IronswornSharedSheet } from './module/actor/sheets/sharedsheet'
 import { IronswornHandlebarsHelpers } from './module/helpers/handlebars'
 import { IronswornSettings } from './module/helpers/settings'
 import { TemplatePreloader } from './module/helpers/templatepreloader'
@@ -44,6 +45,10 @@ Hooks.once('init', async () => {
   })
   Actors.registerSheet('ironsworn', IronswornCompactCharacterSheet, {
     types: ['character'],
+  })
+  Actors.registerSheet('ironsworn', IronswornSharedSheet, {
+    types: ['shared'],
+    makeDefault: true,
   })
 
   Items.registerSheet('ironsworn', AssetSheet, {

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -10,28 +10,18 @@ export class IronswornActor extends Actor<IronswornActorData, IronswornItem> {
   moveSheet?: CharacterMoveSheet
 
   /** @override */
-  getRollData() {
-    const data = super.getRollData()
-    return data
-  }
-
-  /** @override */
   prepareDerivedData() {
     // Calculate momentum max/reset from debilities
     const data = this.data.data as any
-    const numDebilitiesMarked = Object.values(data.debility).filter((x) => x).length
-    data.momentumMax = 10 - numDebilitiesMarked
-    data.momentumReset = Math.max(0, 2 - numDebilitiesMarked)
-  }
 
-  async addDefaultItems() {
-    // Every character needs a bondset
-    await this.createOwnedItem({ type: 'bondset', name: 'bonds' })
+    if (this.data.type === 'character') {
+      const numDebilitiesMarked = Object.values(data.debility).filter((x) => x).length
+      data.momentumMax = 10 - numDebilitiesMarked
+      data.momentumReset = Math.max(0, 2 - numDebilitiesMarked)
+    }
   }
 }
 
 Hooks.on('createActor', async (actor) => {
-  if (actor.data.type === 'character') {
-    await actor.addDefaultItems()
-  }
+  await actor.createOwnedItem({ type: 'bondset', name: 'bonds' })
 })

--- a/src/module/actor/sheets/charactersheet.ts
+++ b/src/module/actor/sheets/charactersheet.ts
@@ -135,6 +135,9 @@ export class IronswornCharacterSheet extends ActorSheet<ActorSheet.Data<Ironswor
       if (resource !== 'momentum' || newValue <= momentumMax) {
         this.actor.update({ data: { [resource]: newValue } })
       }
+      if (resource === 'supply') {
+        IronswornSettings.maybeSetGlobalSupply(newValue)
+      }
     }
   }
 }

--- a/src/module/actor/sheets/compactsheet.ts
+++ b/src/module/actor/sheets/compactsheet.ts
@@ -117,6 +117,9 @@ export class IronswornCompactCharacterSheet extends ActorSheet<ActorSheet.Data<I
     value += amt
     if (value >= min && value <= max) {
       this.actor.update({ data: { [stat]: value } })
+      if (stat === 'supply') {
+        IronswornSettings.maybeSetGlobalSupply(value)
+      }
     }
   }
 

--- a/src/module/actor/sheets/sharedsheet.ts
+++ b/src/module/actor/sheets/sharedsheet.ts
@@ -1,15 +1,13 @@
 import { IronswornRollDialog } from '../../helpers/roll'
 import { IronswornSettings } from '../../helpers/settings'
-import { capitalize } from '../../helpers/util'
 import { IronswornActor } from '../actor'
-import { IronswornCharacterData } from '../actortypes'
 
 export class IronswornSharedSheet extends ActorSheet<ActorSheet.Data<IronswornActor>, IronswornActor> {
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
       classes: ['ironsworn', 'sheet', 'shared', `theme-${IronswornSettings.theme}`],
-      width: 325,
-      height: 500,
+      width: 350,
+      height: 700,
       template: 'systems/foundry-ironsworn/templates/actor/shared.hbs',
     } as BaseEntitySheet.Options)
   }
@@ -17,8 +15,8 @@ export class IronswornSharedSheet extends ActorSheet<ActorSheet.Data<IronswornAc
   activateListeners(html: JQuery) {
     super.activateListeners(html)
 
-    html.find('.ironsworn__stat__roll').on('click', (e) => this._onStatRoll.call(this, e))
-    html.find('.ironsworn__stat__value').on('click', (e) => this._onStatSet.call(this, e))
+    html.find('.ironsworn__supply__roll').on('click', (e) => this._onSupplyRoll.call(this, e))
+    html.find('.ironsworn__supply__value').on('click', (e) => this._onSupplySet.call(this, e))
 
     // Custom sheet listeners for every ItemType
     for (const itemClass of CONFIG.IRONSWORN.itemClasses) {
@@ -60,30 +58,21 @@ export class IronswornSharedSheet extends ActorSheet<ActorSheet.Data<IronswornAc
     this.actor.setFlag('foundry-ironsworn', 'edit-mode', !currentValue)
   }
 
-  _onStatRoll(ev: JQuery.ClickEvent) {
+  _onSupplyRoll(ev: JQuery.ClickEvent) {
     ev.preventDefault()
 
-    const el = ev.currentTarget
-    const stat = el.dataset.stat
-    if (stat) {
-      const rollText = game.i18n.localize('IRONSWORN.Roll')
-      const statText = game.i18n.localize(`IRONSWORN.${capitalize(stat)}`)
-      IronswornRollDialog.showDialog(this.actor.data.data, stat, `${rollText} +${statText}`)
-    }
+    const rollText = game.i18n.localize('IRONSWORN.Roll')
+    const statText = game.i18n.localize('IRONSWORN.Supply')
+    IronswornRollDialog.showDialog(this.actor.data.data, 'supply', `${rollText} +${statText}`)
   }
 
-  _onStatSet(ev: JQuery.ClickEvent) {
+  _onSupplySet(ev: JQuery.ClickEvent) {
     ev.preventDefault()
 
     const el = ev.currentTarget
-    const { resource, value } = el.dataset
-    if (resource) {
-      // Clicked a value in momentum/health/etc, set the value
-      const newValue = parseInt(value)
-      const { momentumMax } = this.actor.data.data as IronswornCharacterData
-      if (resource !== 'momentum' || newValue <= momentumMax) {
-        this.actor.update({ data: { [resource]: newValue } })
-      }
-    }
+    const { value } = el.dataset
+    // Clicked a value in momentum/health/etc, set the value
+    const newValue = parseInt(value)
+    this.actor.update({ data: { supply: newValue } })
   }
 }

--- a/src/module/actor/sheets/sharedsheet.ts
+++ b/src/module/actor/sheets/sharedsheet.ts
@@ -74,5 +74,6 @@ export class IronswornSharedSheet extends ActorSheet<ActorSheet.Data<IronswornAc
     // Clicked a value in momentum/health/etc, set the value
     const newValue = parseInt(value)
     this.actor.update({ data: { supply: newValue } })
+    IronswornSettings.maybeSetGlobalSupply(newValue)
   }
 }

--- a/src/module/actor/sheets/sharedsheet.ts
+++ b/src/module/actor/sheets/sharedsheet.ts
@@ -1,0 +1,55 @@
+import { IronswornSettings } from '../../helpers/settings'
+import { IronswornActor } from '../actor'
+
+export class IronswornSharedSheet extends ActorSheet<ActorSheet.Data<IronswornActor>, IronswornActor> {
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      classes: ['ironsworn', 'sheet', 'shared', `theme-${IronswornSettings.theme}`],
+      width: 350,
+      height: 600,
+      template: 'systems/foundry-ironsworn/templates/actor/shared.hbs',
+    } as BaseEntitySheet.Options)
+  }
+
+  activateListeners(html: JQuery) {
+    super.activateListeners(html)
+
+    // Custom sheet listeners for every ItemType
+    for (const itemClass of CONFIG.IRONSWORN.itemClasses) {
+      itemClass.activateActorSheetListeners(html, this)
+    }
+  }
+
+  getData() {
+    let data: any = super.getData()
+
+    data.vows = this.actor.items.filter((x) => x.type === 'vow')
+    data.progresses = this.actor.items.filter((x) => x.type === 'progress')
+
+    // Allow every itemtype to add data to the actorsheet
+    for (const itemType of CONFIG.IRONSWORN.itemClasses) {
+      data = itemType.getActorSheetData(data, this)
+    }
+
+    return data
+  }
+
+  _getHeaderButtons() {
+    return [
+      {
+        class: 'ironsworn-toggle-edit-mode',
+        label: 'Edit',
+        icon: 'fas fa-edit',
+        onclick: (e) => this._toggleEditMode(e),
+      },
+      ...super._getHeaderButtons(),
+    ]
+  }
+
+  _toggleEditMode(e: JQuery.ClickEvent) {
+    e.preventDefault()
+
+    const currentValue = this.actor.getFlag('foundry-ironsworn', 'edit-mode')
+    this.actor.setFlag('foundry-ironsworn', 'edit-mode', !currentValue)
+  }
+}

--- a/src/module/helpers/settings.ts
+++ b/src/module/helpers/settings.ts
@@ -15,9 +15,28 @@ export class IronswornSettings {
         window.location.reload()
       },
     })
+
+    game.settings.register('foundry-ironsworn', 'shared-supply', {
+      name: 'IRONSWORN.Settings.SharedSupply.Name',
+      hint: 'IRONSWORN.Settings.SharedSupply.Hint',
+      scope: 'world',
+      config: true,
+      type: Boolean,
+      default: true,
+    })
   }
 
   static get theme(): string {
     return game.settings.get('foundry-ironsworn', 'theme') as string
+  }
+
+  static async maybeSetGlobalSupply(value: number) {
+    if (!game.settings.get('foundry-ironsworn', 'shared-supply')) return
+
+    // TODO: use game.actors.contents instead when types update
+    const actorsToUpdate = game.actors?.entities?.filter((x) => ['character', 'shared'].includes(x.data.type)) || []
+    for (const actor of actorsToUpdate) {
+      await actor.update({ data: { supply: value } })
+    }
   }
 }

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -257,33 +257,35 @@
   }
 
   .compact {
-    h3, h4, h5 {
+    h3,
+    h4,
+    h5 {
       margin: 3px 0;
     }
+  }
 
-    .boxgroup {
-      border: 1px solid;
-      border-radius: 5px;
+  .boxgroup {
+    border: 1px solid;
+    border-radius: 5px;
 
-      .boxrow {
-        border-top: 1px solid;
-        &:first-child {
-          border-top: none;
-        }
-
-        &.small {
-          flex-basis: 25px;
-          line-height: 25px;
-          flex-grow: 0;
-        }
+    .boxrow {
+      border-top: 1px solid;
+      &:first-child {
+        border-top: none;
       }
 
-      .box {
-        text-align: center;
-        border-left: 1px solid;
-        &:first-child {
-          border-left: none;
-        }
+      &.small {
+        flex-basis: 25px;
+        line-height: 25px;
+        flex-grow: 0;
+      }
+    }
+
+    .box {
+      text-align: center;
+      border-left: 1px solid;
+      &:first-child {
+        border-left: none;
       }
     }
   }

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -262,6 +262,10 @@
         "Hint": "Select the visual look for this game. Requires a reload.",
         "Ironsworn": "Ironsworn Classic",
         "Starforged": "Starforged (experimental)"
+      },
+      "SharedSupply": {
+        "Name": "Shared Supply Tracker",
+        "Hint": "If on, changing any character/shared supply tracker changes all other actors' supply trackers as well."
       }
     }
   }

--- a/system/template.json
+++ b/system/template.json
@@ -28,7 +28,9 @@
       },
       "xp": 0
     },
-    "shared": {}
+    "shared": {
+      "supply": 5
+    }
   },
   "Item": {
     "types": [

--- a/system/templates/actor/character.hbs
+++ b/system/templates/actor/character.hbs
@@ -216,8 +216,8 @@
               <div class="block clickable ironsworn__vow__add">
                 <i class="fas fa-plus"></i>
               </div>
-
             </section>
+
             <section class="sheet-area progresses">
               <h2 style="text-align:center">{{localize 'IRONSWORN.Progress'}}</h2>
               {{#each progresses}}

--- a/system/templates/actor/shared.hbs
+++ b/system/templates/actor/shared.hbs
@@ -1,0 +1,2 @@
+<form class="{{cssClass}} flexcol" autocomplete="off">
+</form>

--- a/system/templates/actor/shared.hbs
+++ b/system/templates/actor/shared.hbs
@@ -37,20 +37,24 @@
 <form class="{{cssClass}} flexcol" autocomplete="off">
 
   <section class="sheet-area" style="flex-grow: 0;">
-    <h2 class="clickable text ironsworn__stat__roll" data-stat="supply">{{localize 'IRONSWORN.Supply'}}</h2>
+    <h2 class="clickable text ironsworn__supply__roll">
+      {{localize 'IRONSWORN.Supply'}}
+    </h2>
     <div class="boxgroup" style="line-height: 25px;">
       <div class="flexrow boxrow">
         {{#rangeEach from=0 to=5 current=data.data.supply}}
         <div class="
-          box clickable block ironsworn__stat__value supply
+          box clickable block ironsworn__supply__value
           {{#if isCurrent}} selected {{/if}}
-        " data-resource="supply" data-value="{{value}}">
+        " data-value="{{value}}">
           {{valueStr}}
         </div>
         {{/rangeEach}}
       </div>
     </div>
+  </section>
 
+  <section class="sheet-area" style="flex-grow: 0;">
     <h2>{{localize 'IRONSWORN.Bonds'}}</h2>
     <div class="flexrow">
       <div class="flexrow track">

--- a/system/templates/actor/shared.hbs
+++ b/system/templates/actor/shared.hbs
@@ -1,2 +1,88 @@
+{{#*inline "progress"}}
+<div class="flexcol item-row" data-id="{{id}}">
+  <div class="flexcol">
+    <div class="flexrow">
+      <div class="flexrow">{{>rankHexes rank=data.data.rank id=id}}</div>
+
+      {{#if actor.data.flags.foundry-ironsworn.edit-mode}}
+      <div class="clickable block nogrow ironsworn__{{type}}__delete" data-item="{{id}}">
+        <i class="fas fa-trash"></i>
+      </div>
+      {{/if}}
+
+      <div class="clickable block nogrow ironsworn__{{type}}__settings" data-item="{{id}}">
+        <i class="fas fa-edit"></i>
+      </div>
+      <div class="clickable block nogrow ironsworn__progress__mark" {{! This works for vows too }}
+        title="{{localize 'IRONSWORN.MarkProgress'}}" data-item="{{id}}">
+        <i class="fas fa-play"></i>
+      </div>
+      <div class="clickable block ironsworn__progress__fulfill" title="{{localize 'IRONSWORN.FulfillVow'}}"
+        style="flex-grow: 0;" data-item="{{id}}">
+        <i class="fas fa-check"></i>
+      </div>
+    </div>
+    <h3>{{name}}</h3>
+  </div>
+  <div class="flexrow">
+    <div class="flexrow track">
+      {{#each (progressCharacters data.data.current)}}
+      <div class="track-box">{{{this}}}</div>
+      {{/each}}
+    </div>
+  </div>
+</div>
+{{/inline}}
+
 <form class="{{cssClass}} flexcol" autocomplete="off">
+
+  <section class="sheet-area" style="flex-grow: 0;">
+    <h2 class="clickable text ironsworn__stat__roll" data-stat="supply">{{localize 'IRONSWORN.Supply'}}</h2>
+    <div class="boxgroup" style="line-height: 25px;">
+      <div class="flexrow boxrow">
+        {{#rangeEach from=0 to=5 current=data.data.supply}}
+        <div class="
+          box clickable block ironsworn__stat__value supply
+          {{#if isCurrent}} selected {{/if}}
+        " data-resource="supply" data-value="{{value}}">
+          {{valueStr}}
+        </div>
+        {{/rangeEach}}
+      </div>
+    </div>
+
+    <h2>{{localize 'IRONSWORN.Bonds'}}</h2>
+    <div class="flexrow">
+      <div class="flexrow track">
+        {{#each (progressCharacters bonds.count)}}
+        <div class="track-box">{{{this}}}</div>
+        {{/each}}
+      </div>
+      <div data-item="{{bonds.id}}" class="ironsworn__bondset__settings block clickable"
+        style="flex-grow: 0; padding: 5px; margin: 2px;">
+        <i class="fas fa-edit"></i>
+      </div>
+    </div>
+  </section>
+
+  <section class="sheet-area progresses">
+    <h2>{{localize 'IRONSWORN.Vows'}}</h2>
+    {{#each vows}}
+    {{>progress}}
+    {{/each}}
+    <div class="block clickable ironsworn__vow__add">
+      <i class="fas fa-plus"></i>
+    </div>
+  </section>
+
+  <section class="sheet-area progresses">
+    <h2>{{localize 'IRONSWORN.Progress'}}</h2>
+    {{#each progresses}}
+    {{>progress}}
+    {{/each}}
+    <div class="block clickable ironsworn__progress__add">
+      <i class="fas fa-plus"></i>
+    </div>
+  </section>
+
 </form>


### PR DESCRIPTION
This adds a sheet for a "shared" type actor. This is mostly a convenience so that all of the players can 

- [x] New sheet with vows, progress, bonds, and supply
- [x] System option: shared supply mode
- [x] Update CHANGELOG.md
