### PR TITLE
Bonds as items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In progress
 
+- Use `bond` items instead of `bondset` items ([#73](https://github.com/ben/foundry-ironsworn/pull/73))
 - Update move item structure and allow custom moves in move sheet ([#72](https://github.com/ben/foundry-ironsworn/pull/72))
 
 ## 0.5.4

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { importFromDatasworn } from './module/datasworn'
 import { AssetItem } from './module/item/asset/assetitem'
 import { BaseItem } from './module/item/baseitem'
+import { BondItem } from './module/item/bond/bonditem'
 import { BondsetItem } from './module/item/bondset/bondsetitem'
 import { MoveItem } from './module/item/move/moveitem'
 import { ProgressItem } from './module/item/progress/progressitem'
@@ -12,7 +13,7 @@ export interface IronswornConfig {
 }
 
 export const IRONSWORN: IronswornConfig = {
-  itemClasses: [AssetItem, BondsetItem, MoveItem, ProgressItem, VowItem],
+  itemClasses: [AssetItem, BondItem, BondsetItem, MoveItem, ProgressItem, VowItem],
 
   importFromDatasworn,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { IronswornCharacterSheet } from './module/actor/sheets/charactersheet'
 import { IronswornCompactCharacterSheet } from './module/actor/sheets/compactsheet'
 import { IronswornSharedSheet } from './module/actor/sheets/sharedsheet'
 import { IronswornHandlebarsHelpers } from './module/helpers/handlebars'
+import { maybeMigrateData } from './module/helpers/migration'
 import { IronswornSettings } from './module/helpers/settings'
 import { TemplatePreloader } from './module/helpers/templatepreloader'
 import { AssetSheet } from './module/item/asset/assetsheet'
@@ -73,6 +74,10 @@ Hooks.once('init', async () => {
 
   // Register Handlebars helpers
   IronswornHandlebarsHelpers.registerHelpers()
+})
+
+Hooks.once('ready', async () => {
+  await maybeMigrateData()
 })
 
 Hooks.once('setup', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ Hooks.once('init', async () => {
     types: ['asset'],
     makeDefault: true,
   })
+  // TODO: bond sheet
   Items.registerSheet('ironsworn', BondsetSheet, {
     types: ['bondset'],
     makeDefault: true,

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -1,5 +1,6 @@
 import { IronswornItem } from '../item/item'
 import { IronswornActorData } from './actortypes'
+import { CharacterBondSheet } from './sheets/characterbondsheet'
 import { CharacterMoveSheet } from './sheets/charactermovesheet'
 
 /**
@@ -8,6 +9,7 @@ import { CharacterMoveSheet } from './sheets/charactermovesheet'
  */
 export class IronswornActor extends Actor<IronswornActorData, IronswornItem> {
   moveSheet?: CharacterMoveSheet
+  bondSheet?: CharacterBondSheet
 
   /** @override */
   prepareDerivedData() {
@@ -24,4 +26,5 @@ export class IronswornActor extends Actor<IronswornActorData, IronswornItem> {
 
 Hooks.on('createActor', async (actor) => {
   await actor.createOwnedItem({ type: 'bondset', name: 'bonds' })
+  // TODO: await (Item as any).createDocument({type: 'bond', name: 'A community'}, {parent: actor})
 })

--- a/src/module/actor/sheets/characterbondsheet.ts
+++ b/src/module/actor/sheets/characterbondsheet.ts
@@ -1,0 +1,39 @@
+import { IronswornSettings } from '../../helpers/settings'
+import { IronswornActor } from '../actor'
+
+export class CharacterBondSheet extends FormApplication<any, any, IronswornActor> {
+  get actor() {
+    return this.object
+  }
+
+  constructor(...args) {
+    super(...args)
+    this.actor.bondSheet = this
+  }
+
+  async close(...args) {
+    this.actor.bondSheet = undefined
+    return super.close(...args)
+  }
+
+  async _updateObject() {
+    // No update necessary.
+  }
+
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      template: 'systems/foundry-ironsworn/templates/actor/bonds.hbs',
+      resizable: true,
+      classes: ['ironsworn', 'sheet', 'moves', `theme-${IronswornSettings.theme}`],
+      width: 350,
+      height: 800,
+      left: 755,
+      tabs: [
+        {
+          navSelector: '.ironsworn__tabs__selector',
+          contentSelector: '.ironsworn__tabs__content',
+        },
+      ],
+    } as FormApplication.Options)
+  }
+}

--- a/src/module/actor/sheets/charactersheet.ts
+++ b/src/module/actor/sheets/charactersheet.ts
@@ -54,7 +54,8 @@ export class IronswornCharacterSheet extends ActorSheet<ActorSheet.Data<Ironswor
     data.assets = this.actor.items.filter((x) => x.type === 'asset')
     data.vows = this.actor.items.filter((x) => x.type === 'vow')
     data.progresses = this.actor.items.filter((x) => x.type === 'progress')
-    data.bonds = this.actor.items.find((x) => x.type === 'bondset')
+    data.bondset = this.actor.items.find((x) => x.type === 'bondset')
+    data.bonds = this.actor.items.filter((x) => x.type === 'bond')
 
     // Allow every itemtype to add data to the actorsheet
     for (const itemType of CONFIG.IRONSWORN.itemClasses) {

--- a/src/module/actor/sheets/sharedsheet.ts
+++ b/src/module/actor/sheets/sharedsheet.ts
@@ -29,7 +29,8 @@ export class IronswornSharedSheet extends ActorSheet<ActorSheet.Data<IronswornAc
 
     data.vows = this.actor.items.filter((x) => x.type === 'vow')
     data.progresses = this.actor.items.filter((x) => x.type === 'progress')
-    data.bonds = this.actor.items.find((x) => x.type === 'bondset')
+    data.bondset = this.actor.items.find((x) => x.type === 'bondset')
+    data.bonds = this.actor.items.filter((x) => x.type === 'bond')
 
     // Allow every itemtype to add data to the actorsheet
     for (const itemType of CONFIG.IRONSWORN.itemClasses) {
@@ -62,7 +63,7 @@ export class IronswornSharedSheet extends ActorSheet<ActorSheet.Data<IronswornAc
     ev.preventDefault()
     RollDialog.show({
       actor: this.actor,
-      stat: 'supply'
+      stat: 'supply',
     })
   }
 

--- a/src/module/helpers/migration.ts
+++ b/src/module/helpers/migration.ts
@@ -1,0 +1,31 @@
+import { isEmpty } from 'lodash'
+import { IronswornActor } from '../actor/actor'
+import { IronswornActorData } from '../actor/actortypes'
+import { IronswornSettings } from './settings'
+
+const CURRENT_DATA_VERSION = 1
+
+export async function maybeMigrateData() {
+  if (IronswornSettings.dataVersion >= CURRENT_DATA_VERSION) {
+    return
+  }
+
+  for (const a of (game.actors as any)?.contents as IronswornActor[]) {
+    try {
+      const updatedData = migrateActorData(a.data)
+      if (!isEmpty(updatedData)) {
+        console.log(`Migrating actor ${a.name} (${a.id})`)
+        await a.update(updatedData, { enforceTypes: false })
+      }
+    } catch (err) {
+      err.message = `Failed dnd5e system migration for Actor ${a.name}: ${err.message}`
+      console.error(err)
+    }
+  }
+}
+
+function migrateActorData(_data: IronswornActorData): { [key: string]: string | number } {
+  const ret = {}
+
+  return ret
+}

--- a/src/module/helpers/settings.ts
+++ b/src/module/helpers/settings.ts
@@ -24,10 +24,21 @@ export class IronswornSettings {
       type: Boolean,
       default: true,
     })
+
+    game.settings.register('foundry-ironsworn', 'data-version', {
+      scope: 'world',
+      config: false,
+      type: Number,
+      default: 1,
+    })
   }
 
   static get theme(): string {
     return game.settings.get('foundry-ironsworn', 'theme') as string
+  }
+
+  static get dataVersion(): number {
+    return game.settings.get('foundry-ironsworn', 'data-version') as number
   }
 
   static async maybeSetGlobalSupply(value: number) {

--- a/src/module/item/bond/bonditem.ts
+++ b/src/module/item/bond/bonditem.ts
@@ -1,0 +1,10 @@
+import { IronswornCharacterSheet } from "../../actor/sheets/charactersheet";
+import { BaseItem } from "../baseitem";
+
+export class BondItem extends BaseItem {
+  static entityName = 'bond'
+
+  static activateActorSheetListeners(html: JQuery, sheet: IronswornCharacterSheet) {
+    super.activateActorSheetListeners(html, sheet)
+  }
+}

--- a/src/module/item/bond/bondsheet.ts
+++ b/src/module/item/bond/bondsheet.ts
@@ -1,0 +1,3 @@
+import { IronswornItemSheet } from '../item-sheet'
+
+export class BondSheet extends IronswornItemSheet {}

--- a/src/module/item/itemtypes.ts
+++ b/src/module/item/itemtypes.ts
@@ -61,17 +61,28 @@ export interface VowItemData extends Item.Data<VowData> {
 
 ///////////////////////////////
 
-interface Bond {
+interface BondsetBond {
   name: string
   notes: string
 }
 
 interface BondsetData {
-  bonds: Bond[]
+  bonds: BondsetBond[]
 }
 
 export interface BondsetItemData extends Item.Data<BondsetData> {
   type: 'bondset'
+}
+
+///////////////////////////////
+
+interface Bond {
+  name: string
+  description: string
+}
+
+export interface BondItemData extends Item.Data<Bond> {
+  type: 'bond'
 }
 
 ///////////////////////////////
@@ -103,4 +114,4 @@ export interface MoveItemData extends Item.Data<MoveData> {
 
 ///////////////////////////////
 
-export type IronswornItemData = AssetItemData | ProgressItemData | VowItemData | BondsetItemData | SiteItemData | MoveItemData
+export type IronswornItemData = AssetItemData | ProgressItemData | VowItemData | BondItemData | BondsetItemData | SiteItemData | MoveItemData

--- a/system/template.json
+++ b/system/template.json
@@ -67,6 +67,10 @@
         "notes": ""
       }]
     },
+    "bond": {
+      "description": "",
+      "notes": ""
+    },
     "site": {
       "templates": [
         "progress"

--- a/system/template.json
+++ b/system/template.json
@@ -37,6 +37,7 @@
       "asset",
       "progress",
       "vow",
+      "bond",
       "bondset",
       "site",
       "move"
@@ -68,8 +69,7 @@
       }]
     },
     "bond": {
-      "description": "",
-      "notes": ""
+      "description": ""
     },
     "site": {
       "templates": [

--- a/system/templates/actor/bonds.hbs
+++ b/system/templates/actor/bonds.hbs
@@ -1,0 +1,23 @@
+<form class="{{cssClass}}" autocomplete="off">
+  <header class="sheet-header">
+    <h1 class="charname">{{localize 'IRONSWORN.Bonds'}}</h1>
+  </header>
+
+  {{#each bonds}}
+  <div class="item-row" data-idx="{{@index}}">
+    <div class="flexrow">
+      <input class="attribute-value" type="text" name="bonds.{{@index}}.name" value="{{name}}" />
+      <div class="block clickable item-row-control delete-bond" data-index="{{@index}}" style="flex-grow: 0;">
+        <i class="fas fa-trash"></i>
+      </div>
+
+    </div>
+    <textarea name="bonds.{{@index}}.notes">{{notes}}</textarea>
+  </div>
+  {{/each}}
+
+  <div class="block clickable add-bond" style="padding: 5px; text-align: center;">
+    <i class="fas fa-plus"></i>
+  </div>
+
+</form>

--- a/system/templates/actor/character.hbs
+++ b/system/templates/actor/character.hbs
@@ -130,11 +130,11 @@
               <h2 style="text-align:center">{{localize 'IRONSWORN.Bonds'}}</h2>
               <div class="flexrow">
                 <div class="flexrow track">
-                  {{#each (progressCharacters bonds.count)}}
+                  {{#each (progressCharacters bondset.count)}}
                   <div class="track-box">{{{this}}}</div>
                   {{/each}}
                 </div>
-                <div data-item="{{bonds.id}}" class="ironsworn__bondset__settings block clickable"
+                <div data-item="{{bondset.id}}" class="ironsworn__bondset__settings block clickable"
                   style="flex-grow: 0; padding: 5px; margin: 2px;">
                   <i class="fas fa-edit"></i>
                 </div>

--- a/system/templates/actor/shared.hbs
+++ b/system/templates/actor/shared.hbs
@@ -64,11 +64,11 @@
     <h2>{{localize 'IRONSWORN.Bonds'}}</h2>
     <div class="flexrow">
       <div class="flexrow track">
-        {{#each (progressCharacters bonds.count)}}
+        {{#each (progressCharacters bondset.count)}}
         <div class="track-box">{{{this}}}</div>
         {{/each}}
       </div>
-      <div data-item="{{bonds.id}}" class="ironsworn__bondset__settings block clickable"
+      <div data-item="{{bondset.id}}" class="ironsworn__bondset__settings block clickable"
         style="flex-grow: 0; padding: 5px; margin: 2px;">
         <i class="fas fa-edit"></i>
       </div>


### PR DESCRIPTION
Currently, the "bonds" sheet is a registered top-level sheet for an item of type `bondset`. That's pretty clunky, so this creates `bond` type items, and uses a `FormApplication` attached to the actor to edit them. No data should be lost, as this also adds a migration framework to update the data format.

- [ ] `bond` item type
- [ ] Form application sheet
- [ ] Data migrations and default items
- [x] Update CHANGELOG.md
