### PR TITLE
Add edit/delete buttons to custom moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Update to newest Foundry types ([#76](https://github.com/ben/foundry-ironsworn/pull/76))
+- Add edit/delete buttons to move sheet ([#77](https://github.com/ben/foundry-ironsworn/pull/77))
 
 ## 1.0.0
 

--- a/src/module/actor/sheets/charactermovesheet.ts
+++ b/src/module/actor/sheets/charactermovesheet.ts
@@ -1,6 +1,7 @@
 import { cachedMoves, moveDataByName } from '../../helpers/data'
 import { attachInlineRollListeners, RollDialog } from '../../helpers/roll'
 import { IronswornSettings } from '../../helpers/settings'
+import { IronswornItem } from '../../item/item'
 import { IronswornActor } from '../actor'
 
 function translateOrEmpty(key: string): string {
@@ -152,3 +153,12 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
     ;(table as any)?.draw()
   }
 }
+
+function rerenderMoveSheet(item: IronswornItem) {
+  if (item.data.type === 'move' && item.parent?.moveSheet) {
+    item.parent.moveSheet.render(true)
+  }
+}
+Hooks.on('updateItem', rerenderMoveSheet)
+Hooks.on('createItem', rerenderMoveSheet)
+Hooks.on('deleteItem', rerenderMoveSheet)

--- a/src/module/actor/sheets/charactermovesheet.ts
+++ b/src/module/actor/sheets/charactermovesheet.ts
@@ -65,6 +65,11 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
         attachInlineRollListeners($(el), { actor: this.actor, name: move.name || '' })
       }
     })
+
+    // Custom sheet listeners for every ItemType
+    for (const itemClass of CONFIG.IRONSWORN.itemClasses) {
+      itemClass.activateActorSheetListeners(html, this)
+    }
   }
 
   async getData() {
@@ -144,6 +149,6 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
         }
       }
     }
-    (table as any)?.draw()
+    ;(table as any)?.draw()
   }
 }

--- a/src/module/actor/sheets/compactsheet.ts
+++ b/src/module/actor/sheets/compactsheet.ts
@@ -94,7 +94,7 @@ export class IronswornCompactCharacterSheet extends ActorSheet<CompactCharacterS
       await RollDialog.show({
         actor: this.actor,
         stat,
-        bonus
+        bonus,
       })
       this.options.statRollBonus = 0
       this.render(true)

--- a/src/module/actor/sheets/sharedsheet.ts
+++ b/src/module/actor/sheets/sharedsheet.ts
@@ -61,7 +61,7 @@ export class IronswornSharedSheet extends ActorSheet {
     ev.preventDefault()
     RollDialog.show({
       actor: this.actor,
-      stat: 'supply'
+      stat: 'supply',
     })
   }
 

--- a/src/module/item/move/movesheet.ts
+++ b/src/module/item/move/movesheet.ts
@@ -12,7 +12,7 @@ export class MoveSheet extends IronswornItemSheet {
     super.activateListeners(html)
 
     this._setChecks(html)
-    html.find('.ironsworn__move__stat').on('click', ev => this._checked.call(this, ev))
+    html.find('.ironsworn__move__stat').on('click', (ev) => this._checked.call(this, ev))
   }
 
   _checked(ev: JQuery.ClickEvent) {
@@ -25,9 +25,9 @@ export class MoveSheet extends IronswornItemSheet {
     if ($(ev.currentTarget).prop('checked')) {
       stats = uniq([...this.item.data.data.stats, stat])
     } else {
-      stats = stats.filter(x => x !== stat)
+      stats = stats.filter((x) => x !== stat)
     }
-    this.item.update({data: {stats}})
+    this.item.update({ data: { stats } })
   }
 
   _setChecks(html: JQuery) {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -347,6 +347,7 @@
     "Enabled": "Enabled",
     "Rank": "Rank",
     "DeleteItem": "Delete Item",
+    "DeleteMove": "Delete Move",
     "DeleteVow": "Delete Vow",
     "DeleteProgress": "Delete Progress",
     "DeleteAsset": "Delete Asset",

--- a/system/templates/actor/moves.hbs
+++ b/system/templates/actor/moves.hbs
@@ -54,6 +54,12 @@
               <span style="flex: 1" class='ironsworn__move__expand'>
                 {{name}}
               </span>
+              <i class="nogrow fa fa-edit clickable text ironsworn__{{type}}__settings"
+                style="padding: 1px; margin-right: 5px;" data-item="{{id}}">
+              </i>
+              <i class="nogrow fa fa-trash clickable text ironsworn__{{type}}__delete"
+                style="padding: 1px; margin-right: 5px;" data-item="{{id}}">
+              </i>
             </h4>
             <div class='move-summary' style='display: none;'>
               <p>


### PR DESCRIPTION
Adds management to custom moves in the move sheet.

- [x] Add buttons
- [x] Re-render sheet when a move is changed/added/deleted
- [x] Small cleanup
- [x] Update CHANGELOG.md
