### PR TITLE
Negative momentum cancels the action die

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Negative momentum cancels action die ([#81](https://github.com/ben/foundry-ironsworn/pull/81))
+
 ## 1.1.0
 
 - "Burn momentum" button in chat cards ([#78](https://github.com/ben/foundry-ironsworn/pull/78))

--- a/src/module/chat/rolls.ts
+++ b/src/module/chat/rolls.ts
@@ -45,18 +45,18 @@ enum HIT_TYPE {
   STRONG = 'STRONG',
 }
 
-function hitType(roll: Roll, override?: number): HIT_TYPE {
+function hitType(roll: Roll, momentum?: number): HIT_TYPE {
   const { action, challenge1, challenge2 } = dieTotals(roll)
-  const realAction = override || action
+  const realAction = momentum || action
 
   if (realAction <= Math.min(challenge1, challenge2)) return HIT_TYPE.MISS
   if (realAction > Math.max(challenge1, challenge2)) return HIT_TYPE.STRONG
   return HIT_TYPE.WEAK
 }
 
-function hitTypeText(roll: Roll, override?: number) {
+function hitTypeText(roll: Roll, momentum?: number) {
   const { match } = dieTotals(roll)
-  const hit = hitType(roll, override)
+  const hit = hitType(roll, momentum)
   if (hit === HIT_TYPE.MISS) {
     return game.i18n.localize(match ? 'IRONSWORN.Complication' : 'IRONSWORN.Miss')
   }
@@ -97,10 +97,10 @@ function generateCardTitle(params: RollMessageParams) {
   return rollText
 }
 
-function generateResultText(roll: Roll, move?: EnhancedDataswornMove, override?: number): string | undefined {
+function generateResultText(roll: Roll, move?: EnhancedDataswornMove, momentum?: number): string | undefined {
   if (!move) return undefined
 
-  switch (hitType(roll, override)) {
+  switch (hitType(roll, momentum)) {
     case HIT_TYPE.MISS: return move.Miss
     case HIT_TYPE.WEAK: return move.Weak
     case HIT_TYPE.STRONG: return move.Strong

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -336,6 +336,7 @@
     "Burn": "Burn",
     "BurnForUpgrade": "Burn momentum: <strong>{type}</strong>",
     "MomentumBurnt": "Momentum Burn",
+    "NegativeMomentumCancel": "Negative momentum canceled action die",
     "Reset": "Reset",
     "Max": "Max",
     "Name": "Name",

--- a/system/templates/chat/roll.hbs
+++ b/system/templates/chat/roll.hbs
@@ -21,7 +21,7 @@ title: "Face Danger (iron)"
     </div>
     <div class="roll-result">
       {{#if negativeMomentumCancel}}
-      <h3>Negative Momentum Canceled Action Die</h3>
+      <p><em>{{localize 'IRONSWORN.NegativeMomentumCancel'}}</em></p>
       {{/if}}
 
       {{#if resultText}}

--- a/system/templates/chat/roll.hbs
+++ b/system/templates/chat/roll.hbs
@@ -20,6 +20,10 @@ title: "Face Danger (iron)"
       <p>{{{actionDieFormula}}} {{localize 'IRONSWORN.Versus'}} {{{challengeDice}}}</p>
     </div>
     <div class="roll-result">
+      {{#if negativeMomentumCancel}}
+      <h3>Negative Momentum Canceled Action Die</h3>
+      {{/if}}
+
       {{#if resultText}}
       {{{resultText}}}
       {{else}}


### PR DESCRIPTION
This implements the negative-momentum rule: if momentum is negative, it cancels an action die that matches the momentum number. For example:

- Challenge dice are 1 and 3
- Action die is a 3, with a +2 from iron
- Momentum is -3

Before, this would result in a **strong hit**, since the action total is 5. But since momentum is -3, the action die is canceled (turns to 0), and the action result is now a 2, converting this into a **weak hit**.

- [x] Implement this for calculating the final result
- [x] Update chat card display to notate what happened
- [x] Update CHANGELOG.md
