### PR TITLE
SVGs for tick marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Negative momentum cancels action die ([#81](https://github.com/ben/foundry-ironsworn/pull/81))
+- Better display for tick marks ([#82](https://github.com/ben/foundry-ironsworn/pull/82))
 
 ## 1.1.0
 

--- a/src/module/helpers/handlebars.ts
+++ b/src/module/helpers/handlebars.ts
@@ -1,3 +1,4 @@
+import { range } from 'lodash'
 import { RANKS } from '../constants'
 import { capitalize } from './util'
 
@@ -64,19 +65,22 @@ export class IronswornHandlebarsHelpers {
       return game.i18n.localize('IRONSWORN.WeakHit')
     })
 
+    function tickMarkSvg(ticks: number): string {
+      let ret = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">'
+      if (ticks > 0) ret += '<line x1="15" y1="15" x2="85" y2="85" />'
+      if (ticks > 1) ret += '<line x1="85" y1="15" x2="15" y2="85" />'
+      if (ticks > 2) ret += '<line x1="15" y1="50" x2="85" y2="50" />'
+      if (ticks > 3) ret += '<line x1="50" y1="15" x2="50" y2="85" />'
+      return ret + "</svg>"
+    }
+
     Handlebars.registerHelper('progressCharacters', (current) => {
-      const tickChar = [' ', '-', '+', '*'][current % 4]
-      const characters: string[] = []
-      for (let i = 0; i < Math.floor(current / 4); i++) {
-        characters.push('#')
-      }
-      if (characters.length < 10) {
-        characters.push(tickChar)
-      }
-      while (characters.length < 10) {
-        characters.push('&nbsp;')
-      }
-      return characters
+      const ret: string[] = []
+      range(10).forEach(() => {
+        ret.push(tickMarkSvg(current))
+        current -= 4
+      })
+      return ret
     })
 
     Handlebars.registerHelper('enrichHtml', (text) => {

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -168,26 +168,17 @@
   .track {
     flex-wrap: nowrap;
     flex-grow: 1;
+    align-items: center;
+    justify-content: center;
 
     .track-box {
-      flex: 1 0;
-      min-width: 20px;
-      line-height: 25px;
+      flex: 1 0 20px;
       border: 1px solid;
-      border-left: none;
+      margin-right: -1px;
+      stroke-width: 5;
       text-align: center;
       align-items: center;
       justify-items: center;
-
-      &:first-child {
-        border-left: 1px solid;
-        // border-top-left-radius: 5px;
-        // border-bottom-left-radius: 5px;
-      }
-      // &:last-child {
-      //   border-top-right-radius: 5px;
-      //   border-bottom-right-radius: 5px;
-      // }
     }
   }
 

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -173,6 +173,7 @@
 
     .track-box {
       flex: 1 0 20px;
+      max-height: 30px;
       border: 1px solid;
       margin-right: -1px;
       stroke-width: 5;

--- a/src/styles/themes/ironsworn.less
+++ b/src/styles/themes/ironsworn.less
@@ -74,6 +74,10 @@
     border-color: @dark-color;
   }
 
+  .track-box {
+    stroke: black;
+  }
+
   .rank-pip {
     fill: transparent;
     stroke: black;

--- a/src/styles/themes/starforged.less
+++ b/src/styles/themes/starforged.less
@@ -65,6 +65,10 @@ body {
     border-color: @light-color;
   }
 
+  .track-box {
+    stroke: @text-medium-color;
+  }
+
   .rank-pip {
     fill: @medium-color;
 

--- a/system/templates/actor/character.hbs
+++ b/system/templates/actor/character.hbs
@@ -44,7 +44,7 @@
   <div class="flexrow">
     <div class="flexrow track">
       {{#each (progressCharacters data.data.current)}}
-      <div class="track-box">{{{this}}}</div>
+      <div class="flexcol track-box">{{{this}}}</div>
       {{/each}}
     </div>
   </div>
@@ -134,7 +134,7 @@
               <div class="flexrow">
                 <div class="flexrow track">
                   {{#each (progressCharacters bonds.count)}}
-                  <div class="track-box">{{{this}}}</div>
+                  <div class="flexcol track-box">{{{this}}}</div>
                   {{/each}}
                 </div>
                 <div data-item="{{bonds.id}}" class="ironsworn__bondset__settings block clickable"

--- a/system/templates/actor/shared.hbs
+++ b/system/templates/actor/shared.hbs
@@ -30,7 +30,7 @@
   <div class="flexrow">
     <div class="flexrow track">
       {{#each (progressCharacters data.data.current)}}
-      <div class="track-box">{{{this}}}</div>
+      <div class="flexcol track-box">{{{this}}}</div>
       {{/each}}
     </div>
   </div>
@@ -68,7 +68,7 @@
     <div class="flexrow">
       <div class="flexrow track">
         {{#each (progressCharacters bonds.count)}}
-        <div class="track-box">{{{this}}}</div>
+        <div class="flexcol track-box">{{{this}}}</div>
         {{/each}}
       </div>
       <div data-item="{{bonds.id}}" class="ironsworn__bondset__settings block clickable"

--- a/system/templates/item/progress.hbs
+++ b/system/templates/item/progress.hbs
@@ -19,7 +19,7 @@
   <div class="flexrow nogrow" style="margin: 10px 0;">
     <div class="flexrow track">
       {{#each (progressCharacters data.data.current)}}
-      <div class="track-box">{{{this}}}</div>
+      <div class="flexcol track-box">{{{this}}}</div>
       {{/each}}
     </div>
   </div>


### PR DESCRIPTION
This makes the tick-mark display quite a bit nicer.

Before:

<img width="282" alt="image" src="https://user-images.githubusercontent.com/39902/125198182-b7c0f980-e215-11eb-8c8d-2ee4d0ca8897.png">

After:

<img width="265" alt="image" src="https://user-images.githubusercontent.com/39902/125198224-dc1cd600-e215-11eb-9c73-cc07638c1fa4.png">

- [ ] Generate SVGs
- [ ] Styles
- [ ] Update CHANGELOG.md
