### PR TITLE
Don't allow users to create site objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Remove "site" from the list of items a player can create ([#85](https://github.com/ben/foundry-ironsworn/pull/85))
+
 ## 1.1.1
 
 - Negative momentum cancels action die ([#81](https://github.com/ben/foundry-ironsworn/pull/81))

--- a/system/template.json
+++ b/system/template.json
@@ -38,7 +38,6 @@
       "progress",
       "vow",
       "bondset",
-      "site",
       "move"
     ],
     "templates": {


### PR DESCRIPTION
Firstly because they're probably going to be actors (so they can be placed on the map), and secondly because there's no sheet, so trying to create one throws an error. Fixes #84.

- [x] Remove the thing
- [x] Update CHANGELOG.md
