### PR TITLE
New-Actor Dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Momentum does not apply to progress rolls ([#86](https://github.com/ben/foundry-ironsworn/pull/86))
+- New-actor dialog ([#87](https://github.com/ben/foundry-ironsworn/pull/87))
 
 ## 1.1.2
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { IronswornActor } from './module/actor/actor'
 import { CreateActorDialog } from './module/applications/createActorDialog'
 import { importFromDatasworn } from './module/datasworn'
 import { AssetItem } from './module/item/asset/assetitem'
@@ -9,6 +10,7 @@ import { VowItem } from './module/item/vow/vowitem'
 
 export interface IronswornConfig {
   itemClasses: Array<typeof BaseItem>
+  actorClass: typeof IronswornActor
   importFromDatasworn: typeof importFromDatasworn
   applications: {
     createActorDialog: CreateActorDialog | null
@@ -17,6 +19,7 @@ export interface IronswornConfig {
 
 export const IRONSWORN: IronswornConfig = {
   itemClasses: [AssetItem, BondsetItem, MoveItem, ProgressItem, VowItem],
+  actorClass: IronswornActor,
 
   applications: {
     createActorDialog: null,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { CreateActorDialog } from './module/applications/createActorDialog'
 import { importFromDatasworn } from './module/datasworn'
 import { AssetItem } from './module/item/asset/assetitem'
 import { BaseItem } from './module/item/baseitem'
@@ -9,10 +10,17 @@ import { VowItem } from './module/item/vow/vowitem'
 export interface IronswornConfig {
   itemClasses: Array<typeof BaseItem>
   importFromDatasworn: typeof importFromDatasworn
+  applications: {
+    createActorDialog: CreateActorDialog | null
+  }
 }
 
 export const IRONSWORN: IronswornConfig = {
   itemClasses: [AssetItem, BondsetItem, MoveItem, ProgressItem, VowItem],
+
+  applications: {
+    createActorDialog: null,
+  },
 
   importFromDatasworn,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { IronswornActor } from './module/actor/actor'
 import { IronswornCharacterSheet } from './module/actor/sheets/charactersheet'
 import { IronswornCompactCharacterSheet } from './module/actor/sheets/compactsheet'
 import { IronswornSharedSheet } from './module/actor/sheets/sharedsheet'
+import { CreateActorDialog } from './module/applications/createActorDialog'
 import { IronswornChatCard } from './module/chat/cards'
 import { IronswornHandlebarsHelpers } from './module/helpers/handlebars'
 import { IronswornSettings } from './module/helpers/settings'
@@ -81,6 +82,10 @@ Hooks.once('init', async () => {
   // Register Handlebars helpers
   IronswornHandlebarsHelpers.registerHelpers()
   IronswornChatCard.registerHooks()
+})
+
+Hooks.once('ready', () => {
+  CONFIG.IRONSWORN.applications.createActorDialog = new CreateActorDialog({})
 })
 
 Hooks.once('setup', () => {

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -7,8 +7,11 @@ import { CharacterMoveSheet } from './sheets/charactermovesheet'
 export class IronswornActor extends Actor {
   moveSheet?: CharacterMoveSheet
 
-  static async createDialog(_data, _options = {}) {
-    CONFIG.IRONSWORN.applications.createActorDialog?.render(true)
+  static async createDialog(data, _options = {}) {
+    if (CONFIG.IRONSWORN.applications.createActorDialog) {
+      CONFIG.IRONSWORN.applications.createActorDialog.options.folder = data?.folder
+      CONFIG.IRONSWORN.applications.createActorDialog.render(true)
+    }
     return undefined
   }
 

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -7,6 +7,11 @@ import { CharacterMoveSheet } from './sheets/charactermovesheet'
 export class IronswornActor extends Actor {
   moveSheet?: CharacterMoveSheet
 
+  static async createDialog(_data, _options = {}) {
+    CONFIG.IRONSWORN.applications.createActorDialog?.render(true)
+    return undefined
+  }
+
   /** @override */
   prepareDerivedData() {
     // Calculate momentum max/reset from debilities

--- a/src/module/applications/createActorDialog.ts
+++ b/src/module/applications/createActorDialog.ts
@@ -1,6 +1,10 @@
 import { IronswornSettings } from "../helpers/settings"
 
-export class CreateActorDialog extends FormApplication<any, any, any> {
+interface CreateActorDialogOptions extends FormApplication.Options {
+  folder: string
+}
+
+export class CreateActorDialog extends FormApplication<CreateActorDialogOptions> {
   async _updateObject() {
     // No update necessary.
   }
@@ -12,8 +16,8 @@ export class CreateActorDialog extends FormApplication<any, any, any> {
       id: 'new-actor-dialog',
       resizable: false,
       classes: ['ironsworn', 'sheet', 'new-actor', `theme-${IronswornSettings.theme}`],
-      width: 800,
-      height: 330,
+      width: 500,
+      height: 230,
     } as FormApplication.Options)
   }
 

--- a/src/module/applications/createActorDialog.ts
+++ b/src/module/applications/createActorDialog.ts
@@ -1,3 +1,4 @@
+import { IronswornActor } from "../actor/actor"
 import { IronswornSettings } from "../helpers/settings"
 
 interface CreateActorDialogOptions extends FormApplication.Options {
@@ -21,7 +22,29 @@ export class CreateActorDialog extends FormApplication<CreateActorDialogOptions>
     } as FormApplication.Options)
   }
 
-  activateListeners(html) {
+  activateListeners(html: JQuery) {
     super.activateListeners(html)
+
+    html.find('.ironsworn__character__create').on('click', ev => this._characterCreate.call(this, ev))
+    html.find('.ironsworn__shared__create').on('click', ev => this._sharedCreate.call(this, ev))
+  }
+
+  _characterCreate(ev: JQuery.ClickEvent) {
+    ev.preventDefault()
+    this._createWithFolder('Character', 'character')
+  }
+  _sharedCreate(ev: JQuery.ClickEvent) {
+    ev.preventDefault()
+    this._createWithFolder('Shared', 'shared')
+  }
+
+  async _createWithFolder(name: string, type: string) {
+    const data: any = {
+      name,
+      type,
+      folder: this.options.folder || undefined,
+    }
+    await IronswornActor.create(data, {renderSheet: true})
+    await this.close()
   }
 }

--- a/src/module/applications/createActorDialog.ts
+++ b/src/module/applications/createActorDialog.ts
@@ -1,0 +1,5 @@
+export class CreateActorDialog extends FormApplication<any, any, any> {
+  async _updateObject() {
+    // No update necessary.
+  }
+}

--- a/src/module/applications/createActorDialog.ts
+++ b/src/module/applications/createActorDialog.ts
@@ -1,5 +1,23 @@
+import { IronswornSettings } from "../helpers/settings"
+
 export class CreateActorDialog extends FormApplication<any, any, any> {
   async _updateObject() {
     // No update necessary.
+  }
+
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      title: game.i18n.localize('IRONSWORN.CreateActor'),
+      template: 'systems/foundry-ironsworn/templates/actor/create.hbs',
+      id: 'new-actor-dialog',
+      resizable: false,
+      classes: ['ironsworn', 'sheet', 'new-actor', `theme-${IronswornSettings.theme}`],
+      width: 800,
+      height: 330,
+    } as FormApplication.Options)
+  }
+
+  activateListeners(html) {
+    super.activateListeners(html)
   }
 }

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -1,5 +1,6 @@
 {
   "IRONSWORN": {
+    "CreateActor": "Create Actor",
     "Roll": "Roll",
     "Rolling": "Rolling",
     "Bonus": "Bonus",

--- a/system/templates/actor/create.hbs
+++ b/system/templates/actor/create.hbs
@@ -1,4 +1,18 @@
-<form class='{{cssClass}} flexcol' autocomplete='off'>
-
-  <h1>{{localize 'IRONSWORN.CreateActor'}}</h1>
+<form class='{{cssClass}} flexrow' autocomplete='off'>
+  <div class="flexrow boxgroup" style="margin: 30px;">
+    <div class="flexrow boxrow">
+      <div class="flexrow box clickable block ironsworn__character__create" style="align-items: center;">
+        <div class="flexcol" style="align-items: center;">
+          <img src="icons/creatures/eyes/human-single-blue.webp" width="75" height="75" alt="">
+          <h4>Character Sheet</h4>
+        </div>
+      </div>
+      <div class="flexrow box clickable block ironsworn__shared__create" style="align-items: center;">
+        <div class="flexcol" style="align-items: center;">
+          <img src="icons/environment/settlement/wagon-black.webp" width="75" height="75" alt="">
+          <h4>Shared Sheet</h4>
+        </div>
+      </div>
+    </div>
+  </div>
 </form>

--- a/system/templates/actor/create.hbs
+++ b/system/templates/actor/create.hbs
@@ -1,0 +1,4 @@
+<form class='{{cssClass}} flexcol' autocomplete='off'>
+
+  <h1>{{localize 'IRONSWORN.CreateActor'}}</h1>
+</form>


### PR DESCRIPTION
Stealing this idea from [FateX](https://github.com/anvil-vtt/FateX); instead of the not-very-usable new-actor dialog that Foundry comes with, we'll instead show a custom new-actor dialog, which is a much friendlier experience.

- [x] Update config so there's a place to launch this new dialog from
- [x] Overrides for actor creation to use the dialog
- [x] Implement the dialog, including "character" and "shared" types for now
- [x] Update CHANGELOG.md
