### PR TITLE
Add a button to roll a random denizen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Improve the "Locate Your Objective" experience ([#90](https://github.com/ben/foundry-ironsworn/pull/90))
 - Show dice-so-nice rolls when clicking in-chat-message table-roll buttons
+- Add a random-denizen button ([#91](https://github.com/ben/foundry-ironsworn/pull/91))
 
 ## 1.3.1
 

--- a/src/module/actor/sheets/sitesheet.ts
+++ b/src/module/actor/sheets/sitesheet.ts
@@ -156,11 +156,14 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
 
     // Denizen slot is empty; set focus and add a class
     if (!denizen?.description) {
-      // TODO
+      const idx = this.siteData.data.denizens.indexOf(denizen)
+      const input = this.element.find(`.ironsworn__denizen__name[data-idx=${idx}]`)
+      input.addClass('highlight').trigger('focus')
     }
   }
 
   _setDenizenName(ev: JQuery.BlurEvent) {
+    $(ev.currentTarget).removeClass('highlight')
     const val = $(ev.currentTarget).val()?.toString() || ''
     const idx = parseInt(ev.target.dataset.idx)
     const { denizens } = this.siteData.data

--- a/src/module/actor/sheets/sitesheet.ts
+++ b/src/module/actor/sheets/sitesheet.ts
@@ -1,7 +1,7 @@
-import { createIronswornChatRoll } from '../../chat/chatrollhelpers'
+import { createIronswornChatRoll, createIronswornDenizenChat } from '../../chat/chatrollhelpers'
 import { RANK_INCREMENTS } from '../../constants'
 import { moveDataByName } from '../../helpers/data'
-import { maybeShowDice, RollDialog, rollSiteFeature } from '../../helpers/roll'
+import { RollDialog, rollSiteFeature } from '../../helpers/roll'
 import { IronswornSettings } from '../../helpers/settings'
 import { IronswornItem } from '../../item/item'
 import { IronswornActor } from '../actor'
@@ -149,10 +149,15 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
 
   async _randomDenizen(_ev: JQuery.ClickEvent) {
     const roll = await new Roll('1d100').evaluate({ async: true })
-    maybeShowDice(roll)
     const result = roll.total as number
     const denizen = this.siteData.data.denizens.find((x) => x.low <= result && x.high >= result)
-    console.log(denizen)
+    if (!denizen) throw new Error(`Rolled a ${result} but got no denizen???`)
+    await createIronswornDenizenChat({ roll, denizen, site: this.actor })
+
+    // Denizen slot is empty; set focus and add a class
+    if (!denizen?.description) {
+      // TODO
+    }
   }
 
   _setDenizenName(ev: JQuery.BlurEvent) {

--- a/src/module/actor/sheets/sitesheet.ts
+++ b/src/module/actor/sheets/sitesheet.ts
@@ -1,7 +1,7 @@
 import { createIronswornChatRoll } from '../../chat/chatrollhelpers'
 import { RANK_INCREMENTS } from '../../constants'
 import { moveDataByName } from '../../helpers/data'
-import { RollDialog, rollSiteFeature } from '../../helpers/roll'
+import { maybeShowDice, RollDialog, rollSiteFeature } from '../../helpers/roll'
 import { IronswornSettings } from '../../helpers/settings'
 import { IronswornItem } from '../../item/item'
 import { IronswornActor } from '../actor'
@@ -91,6 +91,7 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
     html.find('.ironsworn__move__roll').on('click', (ev) => this._moveRoll.call(this, ev))
     html.find('.ironsworn__locateobjective__roll').on('click', (ev) => this._locateObjective.call(this, ev))
 
+    html.find('.ironsworn__random__denizen').on('click', (ev) => this._randomDenizen.call(this, ev))
     html.find('.ironsworn__denizen__name').on('blur', (ev) => this._setDenizenName.call(this, ev))
   }
 
@@ -144,6 +145,14 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
       domain: this.domain,
       theme: this.theme,
     })
+  }
+
+  async _randomDenizen(_ev: JQuery.ClickEvent) {
+    const roll = await new Roll('1d100').evaluate({ async: true })
+    maybeShowDice(roll)
+    const result = roll.total as number
+    const denizen = this.siteData.data.denizens.find((x) => x.low <= result && x.high >= result)
+    console.log(denizen)
   }
 
   _setDenizenName(ev: JQuery.BlurEvent) {

--- a/src/module/chat/chatrollhelpers.ts
+++ b/src/module/chat/chatrollhelpers.ts
@@ -1,4 +1,5 @@
 import { IronswornActor } from '../actor/actor'
+import { DenizenSlot } from '../actor/actortypes'
 import { EnhancedDataswornMove } from '../helpers/data'
 import { IronswornSettings } from '../helpers/settings'
 import { capitalize } from '../helpers/util'
@@ -195,7 +196,7 @@ export async function createIronswornChatRoll(params: RollMessageParams) {
   return cls.create(messageData as any, {})
 }
 
-export async function createIronswornMoveChat(opts: {move?: EnhancedDataswornMove, site?: IronswornActor}) {
+export async function createIronswornMoveChat(opts: { move?: EnhancedDataswornMove; site?: IronswornActor }) {
   const bonusContent = MoveContentCallbacks[opts.move?.Name || '']?.call(this, opts)
   const content = await renderTemplate('systems/foundry-ironsworn/templates/chat/move.hbs', { ...opts, bonusContent })
   ChatMessage.create({
@@ -213,6 +214,22 @@ interface FeatureChatInput {
 
 export async function createIronswornFeatureChat(params: FeatureChatInput) {
   const content = await renderTemplate('systems/foundry-ironsworn/templates/chat/delve-feature.hbs', params)
+  ChatMessage.create({
+    speaker: ChatMessage.getSpeaker(),
+    content,
+    type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+    roll: params.roll,
+  } as any)
+}
+
+interface DenizenChatInput {
+  roll: Roll
+  site: IronswornActor
+  denizen: DenizenSlot
+}
+
+export async function createIronswornDenizenChat(params: DenizenChatInput) {
+  const content = await renderTemplate('systems/foundry-ironsworn/templates/chat/denizen.hbs', params)
   ChatMessage.create({
     speaker: ChatMessage.getSpeaker(),
     content,

--- a/src/styles/themes/ironsworn.less
+++ b/src/styles/themes/ironsworn.less
@@ -9,6 +9,11 @@
     color: @medium-color;
   }
 
+  input.highlight:focus {
+    background-color: black;
+    color: white;
+  }
+
   .window-content {
     background: @background-color;
   }

--- a/src/styles/themes/starforged.less
+++ b/src/styles/themes/starforged.less
@@ -18,6 +18,12 @@ input::placeholder {
   color: @medium-color;
 }
 
+input.highlight:focus {
+  box-shadow: 0 0 5px orange;
+  background-color: @medium-color;
+  color: @text-light-color;
+}
+
 ::-webkit-scrollbar-thumb {
   background: @dark-color;
   border-color: @medium-color;

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -73,6 +73,7 @@
     "Edit": "Edit",
     "Domain": "Domain",
     "Theme": "Theme",
+    "Denizen": "Denizen",
     "Denizens": "Denizens",
     "OpenCompendium": "Open Compendium",
     "DeleteItem": "Delete Item",

--- a/system/templates/actor/site.hbs
+++ b/system/templates/actor/site.hbs
@@ -118,7 +118,8 @@
           {{localize 'IRONSWORN.MoveContents.Find an Opportunity.title'}}
         </h4>
       </div>
-      <div class="box flexrow clickable block ironsworn__locateobjective__roll" style="justify-content: center; padding: 5px;">
+      <div class="box flexrow clickable block ironsworn__locateobjective__roll"
+        style="justify-content: center; padding: 5px;">
         <h4 class="nogrow" style="margin: 0; white-space: nowrap;">
           {{localize 'IRONSWORN.MoveContents.Locate Your Objective.title'}}
         </h4>
@@ -133,7 +134,12 @@
 
   </div>
 
-  <h3>{{localize 'IRONSWORN.Denizens'}}</h3>
+  <h3>
+    {{localize 'IRONSWORN.Denizens'}}
+    <span class="ironsworn__random__denizen nogrow clickable block" style="padding: 5px;">
+      <i class="fa fa-dice-d6"></i>
+    </span>
+  </h3>
 
   <div class="boxgroup nogrow">
     {{#each denizenMatrix}}

--- a/system/templates/chat/denizen.hbs
+++ b/system/templates/chat/denizen.hbs
@@ -1,0 +1,14 @@
+<div class="dice-roll theme-ironsworn flexcol">
+  <div class="ironsworn-roll">
+
+    <p class="flexrow" style="align-items: center;">
+      <span>{{localize 'IRONSWORN.Denizen'}}: {{site.name}}</span>
+      <span class="roll die d10" style="flex: 0 0 25px;">{{roll.total}}</span>
+    </p>
+
+    <h4 class="dice-formula">
+      {{denizen.low}}–{{denizen.high}}: {{denizen.description}}
+    </h4>
+
+  </div>
+</div>


### PR DESCRIPTION
Provide an easy way to roll a denizen. This should highlight and set focus if that denizen slot is empty.

- [x] Add and wire up the button
- [x] Roll the denizen chart
- [x] Send the result to chat
- [x] Set focus and highlight if it's an empty slot
- [x] Update CHANGELOG.md
