### PR TITLE
Add search box to move sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Add a search box to the character move sheet ([#92](https://github.com/ben/foundry-ironsworn/pull/92))
+
 ## 1.3.4
 ## 1.3.3
 

--- a/src/module/actor/sheets/charactermovesheet.ts
+++ b/src/module/actor/sheets/charactermovesheet.ts
@@ -54,6 +54,8 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
 
   activateListeners(html: JQuery) {
     html.find('.ironsworn__move__search').on('keyup', (ev) => this._moveSearch.call(this, ev))
+    html.find('.ironsworn__move__search__clear').on('click', (ev) => this._moveSearchClear.call(this, ev))
+
     html.find('.ironsworn__move__expand').on('click', (e) => this._handleBuiltInMoveExpand.call(this, e))
     html.find('.ironsworn__builtin__move__roll').on('click', (e) => this._handleBuiltInMoveRoll.call(this, e))
     html.find('.ironsworn__custom__move__roll').on('click', (e) => this._handleCustomMoveRoll.call(this, e))
@@ -113,6 +115,11 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
       this.element.find('ol.moves li').filter(negate(doesMatch)).hide()
       this.element.find('ol.moves li').filter(doesMatch).show()
     }
+  }
+
+  _moveSearchClear(e: JQuery.ClickEvent) {
+    this.element.find('.ironsworn__move__search').val('')
+    this.element.find('ol.moves li').show()
   }
 
   _handleBuiltInMoveExpand(e: JQuery.ClickEvent) {

--- a/src/module/actor/sheets/charactermovesheet.ts
+++ b/src/module/actor/sheets/charactermovesheet.ts
@@ -108,8 +108,10 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
   _moveSearch(e: JQuery.KeyUpEvent) {
     const query = $(e.currentTarget).val()
     if (!query || query === '') {
+      this.element.find('ol.moves>h2').show()
       this.element.find('ol.moves li').show()
     } else {
+      this.element.find('ol.moves>h2').hide()
       const re = new RegExp($(e.currentTarget).val() as string, 'i')
       const doesMatch = (_i, el: HTMLElement): boolean => re.test($(el).find('h4').text())
       this.element.find('ol.moves li').filter(negate(doesMatch)).hide()
@@ -119,6 +121,7 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
 
   _moveSearchClear(e: JQuery.ClickEvent) {
     this.element.find('.ironsworn__move__search').val('')
+    this.element.find('ol.moves>h2').show()
     this.element.find('ol.moves li').show()
   }
 

--- a/src/module/actor/sheets/charactermovesheet.ts
+++ b/src/module/actor/sheets/charactermovesheet.ts
@@ -1,3 +1,4 @@
+import { negate } from 'lodash'
 import { cachedMoves, moveDataByName } from '../../helpers/data'
 import { attachInlineRollListeners, RollDialog } from '../../helpers/roll'
 import { IronswornSettings } from '../../helpers/settings'
@@ -52,6 +53,7 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
   }
 
   activateListeners(html: JQuery) {
+    html.find('.ironsworn__move__search').on('keyup', (ev) => this._moveSearch.call(this, ev))
     html.find('.ironsworn__move__expand').on('click', (e) => this._handleBuiltInMoveExpand.call(this, e))
     html.find('.ironsworn__builtin__move__roll').on('click', (e) => this._handleBuiltInMoveRoll.call(this, e))
     html.find('.ironsworn__custom__move__roll').on('click', (e) => this._handleCustomMoveRoll.call(this, e))
@@ -99,6 +101,18 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
     data.moves = this.actor.items.filter((x) => x.type === 'move')
 
     return data
+  }
+
+  _moveSearch(e: JQuery.KeyUpEvent) {
+    const query = $(e.currentTarget).val()
+    if (!query || query === '') {
+      this.element.find('ol.moves li').show()
+    } else {
+      const re = new RegExp($(e.currentTarget).val() as string, 'i')
+      const doesMatch = (_i, el: HTMLElement): boolean => re.test($(el).find('h4').text())
+      this.element.find('ol.moves li').filter(negate(doesMatch)).hide()
+      this.element.find('ol.moves li').filter(doesMatch).show()
+    }
   }
 
   _handleBuiltInMoveExpand(e: JQuery.ClickEvent) {

--- a/src/module/actor/sheets/charactermovesheet.ts
+++ b/src/module/actor/sheets/charactermovesheet.ts
@@ -119,7 +119,7 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
     }
   }
 
-  _moveSearchClear(e: JQuery.ClickEvent) {
+  _moveSearchClear(_e: JQuery.ClickEvent) {
     this.element.find('.ironsworn__move__search').val('')
     this.element.find('ol.moves>h2').show()
     this.element.find('ol.moves li').show()

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -44,6 +44,7 @@
     "Moves": "Moves",
     "CustomMoves": "Custom Moves",
     "Oracles": "Oracles",
+    "Search":"Search",
     "Plot": "Plot",
     "Location": "Location",
     "Character": "Character",

--- a/system/templates/actor/moves.hbs
+++ b/system/templates/actor/moves.hbs
@@ -13,8 +13,8 @@
         <div class="nogrow clickable block"><i class="fa fa-times-circle" style="padding: 5px;"></i></div>
       </div>
 
-      <div class='flexcol item-list'>
-        <ol>
+      <div class="flexcol item-list">
+        <ol class="moves">
 
           {{!-- Built-in moves --}}
           {{#each builtInMoves}}

--- a/system/templates/actor/moves.hbs
+++ b/system/templates/actor/moves.hbs
@@ -10,7 +10,9 @@
 
       <div class="flexrow nogrow" style="align-items: center;">
         <input type="text" class="ironsworn__move__search" placeholder="{{localize 'IRONSWORN.Search'}}">
-        <div class="nogrow clickable block"><i class="fa fa-times-circle" style="padding: 5px;"></i></div>
+        <div class="nogrow clickable block ironsworn__move__search__clear">
+          <i class="fa fa-times-circle" style="padding: 6px;"></i>
+        </div>
       </div>
 
       <div class="flexcol item-list">

--- a/system/templates/actor/moves.hbs
+++ b/system/templates/actor/moves.hbs
@@ -6,7 +6,13 @@
   </nav>
 
   <div class="ironsworn__tabs__content sheet-body flexcol">
-    <section class="tab" data-tab="moves">
+    <section class="tab flexcol" data-tab="moves">
+
+      <div class="flexrow nogrow" style="align-items: center;">
+        <input type="text" class="ironsworn__move__search" placeholder="{{localize 'IRONSWORN.Search'}}">
+        <div class="nogrow clickable block"><i class="fa fa-times-circle" style="padding: 5px;"></i></div>
+      </div>
+
       <div class='flexcol item-list'>
         <ol>
 


### PR DESCRIPTION
Fixes #71. Adds a search box to the move sheet, which narrows down the entries in the list to only matches with the search query.

- [x] Add a search box with case-insensitive regex matching
- [x] Update CHANGELOG.md
