### PR TITLE
🐛 Minor sheet fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## In progress
 
+- Fixed input set to type=textarea:
+  This one broke cursor interaction in Firefox.
+
+- Fixed sheet not scaling correctly in Firefox
+
 ## 1.3.5
 
 - Add a search box to the character move sheet ([#92](https://github.com/ben/foundry-ironsworn/pull/92))
 
 ## 1.3.4
+
 ## 1.3.3
 
 - Adding [manifest+](https://foundryvtt.wiki/en/development/manifest-plus) fields to `system.json`
@@ -65,7 +71,9 @@
 - Use the "Fulfill Your Vow" move when trying to complete a vow ([#70](https://github.com/ben/foundry-ironsworn/pull/70))
 
 ## 0.5.3
+
 ## 0.5.2
+
 ## 0.5.1
 
 - Fixing auto-update logic

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -136,6 +136,7 @@
     padding: 0 5px;
     writing-mode: vertical-lr;
     border: none;
+    width: 2rem;
   }
 
   .stack {
@@ -422,7 +423,7 @@ hr {
 }
 
 .ironsworn.sheet.actor {
-  min-width: 560px;
+  min-width: 630px;
 }
 
 .ironsworn.sheet.item {

--- a/system/templates/item/asset.hbs
+++ b/system/templates/item/asset.hbs
@@ -45,7 +45,7 @@
       <input type="checkbox" class="ironsworn__ability__enable" data-idx="{{@index}}" {{checked enabled}}
         style="flex-grow: 0;" />
       {{#if ../item.data.flags.foundry-ironsworn.edit-mode}}
-      <input class="attribute-value" type="textarea" name="data.abilities.{{@index}}.description"
+      <input class="attribute-value" type="text" name="data.abilities.{{@index}}.description"
         value="{{description}}" />
       {{else}}
       <div>{{{enrichHtml description}}}</div>


### PR DESCRIPTION
- Fixed input set to type=textarea:
This one broke cursor interaction in Firefox.

- Fixed sheet not scaling correctly in Firefox



- [x] Update CHANGELOG.md
