### PR TITLE
World workbook sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Add a "Your Truths" worksheet ([#97](https://github.com/ben/foundry-ironsworn/pull/97))
+
 ## 1.3.7
 
 - Fix the parsing and logic for the Sojourn move ([#96](https://github.com/ben/foundry-ironsworn/pull/96))

--- a/script/dataswornImport.js
+++ b/script/dataswornImport.js
@@ -50,7 +50,7 @@ function processMove(move) {
 }
 
 async function doit() {
-  // Assets
+  //////////////////////////////////////////////////
   console.log('Assets:')
   console.log('  Fetching')
   const assetsJson = await dataswornJson('ironsworn_assets')
@@ -101,7 +101,7 @@ async function doit() {
   console.log('  Writing')
   await writeLocal('assets', assets)
 
-  // Moves
+  //////////////////////////////////////////////////
   console.log('Moves:')
   console.log('  Fetching')
   const movesJson = await dataswornJson('ironsworn_moves')
@@ -181,7 +181,7 @@ async function doit() {
     en.IRONSWORN.MoveContents[move.Name] = obj
   }
 
-  // Delve: themes
+  //////////////////////////////////////////////////
   console.log('Delve themes:')
   console.log('  Fetching')
   const delveThemesJson = await dataswornJson('ironsworn_delve_themes')
@@ -209,6 +209,7 @@ async function doit() {
     }
   }
 
+  //////////////////////////////////////////////////
   console.log('Delve domains:')
   console.log('  Fetching')
   const delveDomainsJson = await dataswornJson('ironsworn_delve_domains')
@@ -233,6 +234,27 @@ async function doit() {
     for (let i = 0; i < domain.Dangers.length; i++) {
       const danger = domain.Dangers[i]
       en.IRONSWORN.DomainContents[domain.Name][`danger${i + 1}`] = danger.Description
+    }
+  }
+
+  //////////////////////////////////////////////////
+  console.log('Truths:')
+  console.log('  Fetching')
+  const truthsJson = await dataswornJson('ironsworn_world_truths')
+
+  console.log('  Writing')
+  await writeLocal('world-truths', truthsJson)
+
+  en.IRONSWORN.WorldTruths ||= {}
+  for (const truthCategory of truthsJson.Categories) {
+    en.IRONSWORN.WorldTruths[truthCategory.Name] = {
+      ...en.IRONSWORN.WorldTruths[truthCategory.name],
+      name: truthCategory.Name
+    }
+    for(let i=0; i<truthCategory.Options.length; i++) {
+      const option = truthCategory.Options[i]
+      en.IRONSWORN.WorldTruths[truthCategory.Name][`option${i+1}`] = option.Truth
+      en.IRONSWORN.WorldTruths[truthCategory.Name][`quest${i+1}`] = option.Quest
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { IronswornCompactCharacterSheet } from './module/actor/sheets/compactshe
 import { IronswornSharedSheet } from './module/actor/sheets/sharedsheet'
 import { IronswornSiteSheet } from './module/actor/sheets/sitesheet'
 import { CreateActorDialog } from './module/applications/createActorDialog'
+import { WorldTruthsDialog } from './module/applications/worldTruthsDialog'
 import { IronswornChatCard } from './module/chat/cards'
 import { IronswornHandlebarsHelpers } from './module/helpers/handlebars'
 import { IronswornSettings } from './module/helpers/settings'
@@ -105,6 +106,7 @@ Hooks.once('init', async () => {
 
 Hooks.once('ready', () => {
   CONFIG.IRONSWORN.applications.createActorDialog = new CreateActorDialog({})
+  WorldTruthsDialog.maybeShow()
 })
 
 Hooks.once('setup', () => {

--- a/src/module/applications/worldTruthsDialog.ts
+++ b/src/module/applications/worldTruthsDialog.ts
@@ -12,8 +12,8 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
       id: 'world-truths-dialog',
       resizable: true,
       classes: ['ironsworn', 'sheet', 'world-truths', `theme-${IronswornSettings.theme}`],
-      width: 500,
-      height: 500,
+      width: 600,
+      height: 700,
     } as FormApplication.Options)
   }
 
@@ -28,6 +28,16 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
     return mergeObject(super.getData(), {
       truths
     })
+  }
+
+  activateListeners(html: JQuery) {
+    super.activateListeners(html)
+
+    html.find('.ironsworn__custom__truth').on('focus', ev => this._customTruthFocus.call(this, ev))
+  }
+
+  _customTruthFocus(ev: JQuery.FocusEvent) {
+    $(ev.currentTarget).siblings('input').prop('checked', true)
   }
 
   static async maybeShow() {

--- a/src/module/applications/worldTruthsDialog.ts
+++ b/src/module/applications/worldTruthsDialog.ts
@@ -71,8 +71,14 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
   }
 
   static async maybeShow() {
-    // Show this dialog if appropriate
+    // Bail if we're configured to not even try
     if (!game.settings.get('foundry-ironsworn', 'prompt-world-truths')) {
+      return
+    }
+
+    // Bail if the truths journal entry already exists
+    const journal = game.journal?.find((x) => x.name === game.i18n.localize('IRONSWORN.YourWorldTruths'))
+    if (journal) {
       return
     }
 

--- a/src/module/applications/worldTruthsDialog.ts
+++ b/src/module/applications/worldTruthsDialog.ts
@@ -1,4 +1,4 @@
-import { IronswornSettings } from "../helpers/settings"
+import { IronswornSettings } from '../helpers/settings'
 
 export class WorldTruthsDialog extends FormApplication<FormApplication.Options> {
   constructor() {
@@ -21,8 +21,33 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
     // Nothing to do
   }
 
-  static maybeShow() {
+  static async maybeShow() {
     // Show this dialog if appropriate
-    new WorldTruthsDialog().render(true)
+    // TODO: return if dont-bug-me setting is set
+
+    const d = new Dialog({
+      title: game.i18n.localize('IRONSWORN.YourWorldTruths'),
+      content: '<p>Would you like to generate your world truths?</p>',
+      buttons: {
+        yes: {
+          icon: '<i class="fas fa-check"></i>',
+          label: 'Yes',
+          callback: () => new WorldTruthsDialog().render(true),
+        },
+        no: {
+          icon: '<i class="fas fa-times"></i>',
+          label: 'Not this time',
+        },
+        goaway: {
+          icon: '<i class="fas fa-times"></i>',
+          label: 'Never',
+          callback: () => {},
+        },
+      },
+      default: 'two',
+      render: (_html) => console.log('Register interactivity in the rendered dialog'),
+      close: (_html) => console.log('This always is logged no matter which option is chosen'),
+    })
+    d.render(true)
   }
 }

--- a/src/module/applications/worldTruthsDialog.ts
+++ b/src/module/applications/worldTruthsDialog.ts
@@ -1,0 +1,28 @@
+import { IronswornSettings } from "../helpers/settings"
+
+export class WorldTruthsDialog extends FormApplication<FormApplication.Options> {
+  constructor() {
+    super({})
+  }
+
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      title: game.i18n.localize('IRONSWORN.YourWorldTruths'),
+      template: 'systems/foundry-ironsworn/templates/truths.hbs',
+      id: 'world-truths-dialog',
+      resizable: true,
+      classes: ['ironsworn', 'sheet', 'world-truths', `theme-${IronswornSettings.theme}`],
+      width: 500,
+      height: 500,
+    } as FormApplication.Options)
+  }
+
+  async _updateObject() {
+    // Nothing to do
+  }
+
+  static maybeShow() {
+    // Show this dialog if appropriate
+    new WorldTruthsDialog().render(true)
+  }
+}

--- a/src/module/applications/worldTruthsDialog.ts
+++ b/src/module/applications/worldTruthsDialog.ts
@@ -21,6 +21,15 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
     // Nothing to do
   }
 
+  async getData() {
+    const truths = await fetch('/systems/foundry-ironsworn/assets/world-truths.json').then((x) => x.json())
+    // TODO: run truths text through I18n
+
+    return mergeObject(super.getData(), {
+      truths
+    })
+  }
+
   static async maybeShow() {
     // Show this dialog if appropriate
     if (!game.settings.get('foundry-ironsworn', 'prompt-world-truths')) {

--- a/src/module/applications/worldTruthsDialog.ts
+++ b/src/module/applications/worldTruthsDialog.ts
@@ -23,7 +23,16 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
 
   async getData() {
     const truths = await fetch('/systems/foundry-ironsworn/assets/world-truths.json').then((x) => x.json())
-    // TODO: run truths text through I18n
+
+    // Run truths text through I18n
+    for (const category of truths.Categories) {
+      for (let i = 0; i < category.Options.length; i++) {
+        const option = category.Options[i]
+        option.Truth = game.i18n.localize(`IRONSWORN.WorldTruths.${category.Name}.option${i + 1}`)
+        option.Quest = game.i18n.localize(`IRONSWORN.WorldTruths.${category.Name}.quest${i + 1}`)
+      }
+      category.Name = game.i18n.localize(`IRONSWORN.WorldTruths.${category.Name}.name`)
+    }
 
     return mergeObject(super.getData(), {
       truths,
@@ -54,8 +63,8 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
     }
 
     const journal = await JournalEntry.create({
-      name: "Your World", // TODO: i18n
-      content: sections.join('\n')
+      name: game.i18n.localize('IRONSWORN.YourWorldTruths'),
+      content: sections.join('\n'),
     })
     journal?.sheet?.render(true)
     this.close()

--- a/src/module/applications/worldTruthsDialog.ts
+++ b/src/module/applications/worldTruthsDialog.ts
@@ -34,10 +34,16 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
     super.activateListeners(html)
 
     html.find('.ironsworn__custom__truth').on('focus', ev => this._customTruthFocus.call(this, ev))
+    html.find('.ironsworn__save__truths').on('click', ev => this._save.call(this, ev))
+
   }
 
   _customTruthFocus(ev: JQuery.FocusEvent) {
     $(ev.currentTarget).siblings('input').prop('checked', true)
+  }
+
+  _save(ev: JQuery.ClickEvent) {
+    ev.preventDefault()
   }
 
   static async maybeShow() {

--- a/src/module/applications/worldTruthsDialog.ts
+++ b/src/module/applications/worldTruthsDialog.ts
@@ -23,7 +23,9 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
 
   static async maybeShow() {
     // Show this dialog if appropriate
-    // TODO: return if dont-bug-me setting is set
+    if (!game.settings.get('foundry-ironsworn', 'prompt-world-truths')) {
+      return
+    }
 
     const d = new Dialog({
       title: game.i18n.localize('IRONSWORN.YourWorldTruths'),
@@ -41,7 +43,9 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
         goaway: {
           icon: '<i class="fas fa-times"></i>',
           label: 'Never',
-          callback: () => {},
+          callback: () => {
+            game.settings.set('foundry-ironsworn', 'prompt-world-truths', false)
+          },
         },
       },
       default: 'two',

--- a/src/module/applications/worldTruthsDialog.ts
+++ b/src/module/applications/worldTruthsDialog.ts
@@ -26,24 +26,39 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
     // TODO: run truths text through I18n
 
     return mergeObject(super.getData(), {
-      truths
+      truths,
     })
   }
 
   activateListeners(html: JQuery) {
     super.activateListeners(html)
 
-    html.find('.ironsworn__custom__truth').on('focus', ev => this._customTruthFocus.call(this, ev))
-    html.find('.ironsworn__save__truths').on('click', ev => this._save.call(this, ev))
-
+    html.find('.ironsworn__custom__truth').on('focus', (ev) => this._customTruthFocus.call(this, ev))
+    html.find('.ironsworn__save__truths').on('click', (ev) => this._save.call(this, ev))
   }
 
   _customTruthFocus(ev: JQuery.FocusEvent) {
     $(ev.currentTarget).siblings('input').prop('checked', true)
   }
 
-  _save(ev: JQuery.ClickEvent) {
+  async _save(ev: JQuery.ClickEvent) {
     ev.preventDefault()
+
+    // Get elements that are checked
+    const sections: string[] = []
+    for (const radio of this.element.find(':checked')) {
+      const { category } = radio.dataset
+      const descriptionElement = $(radio).parent().find('.description')
+      const description = descriptionElement.html() || `<p>${descriptionElement.val()}</p>`
+      sections.push(`<h2>${category}</h2> ${description}`)
+    }
+
+    const journal = await JournalEntry.create({
+      name: "Your World", // TODO: i18n
+      content: sections.join('\n')
+    })
+    journal?.sheet?.render(true)
+    this.close()
   }
 
   static async maybeShow() {

--- a/src/module/helpers/settings.ts
+++ b/src/module/helpers/settings.ts
@@ -24,6 +24,15 @@ export class IronswornSettings {
       type: Boolean,
       default: true,
     })
+
+    game.settings.register('foundry-ironsworn', 'prompt-world-truths', {
+      name: 'IRONSWORN.Settings.PromptTruths.Name',
+      hint: 'IRONSWORN.Settings.PromptTruths.Hint',
+      scope: 'world',
+      config: true,
+      type: Boolean,
+      default: true,
+    })
   }
 
   static get theme(): string {

--- a/system/assets/world-truths.json
+++ b/system/assets/world-truths.json
@@ -1,0 +1,239 @@
+{
+  "Title": "Ironsworn World Truths",
+  "Source": {
+    "Name": "Ironsworn Rulebook"
+  },
+  "Categories": [
+    {
+      "Name": "The Old World",
+      "Source": {
+        "Name": "Ironsworn Rulebook",
+        "Page": "123"
+      },
+      "Options": [
+        {
+          "Truth": "The savage clans called the Skulde invaded the kingdoms of the Old World. Our armies fell. Most were killed or taken into slavery. Those who escaped set sail aboard anything that would float. After an arduous months-long voyage, the survivors made landfall upon the Ironlands.",
+          "Quest": "You are a descendant of the Skulde. Because of your heritage, your family has long borne the distrust of your fellow Ironlanders. Now, a small force of Skulde have landed on our shores. Are they the harbinger of an invasion? Where do your loyalties lie?"
+        },
+        {
+          "Truth": "The sickness moved like a horrible wave across the Old World, killing all in its path. Thousands fled aboard ships. However, the plague could not be outrun. On many ships, the disease was contained through ruthless measures—tossing overboard any who exhibited the slightest symptom. Other ships were forever lost. In the end, those who survived found the Ironlands and made it their new home. Some say we will forever be cursed by those we left behind.",
+          "Quest": "A settlement is stricken by disease. Though this sickness bears some similarities to the Old World plague, it doesn’t kill its victims. Instead, it changes them. How does this disease manifest? Why do you swear to seek out a cure?"
+        },
+        {
+          "Truth": "The Old World could no longer sustain us. We were too large in number. We had felled the forests. Our crops withered in the barren ground. The cities and villages overflowed with desperate, hungry people. Petty kings battled for scraps. We cast our fate to the sea and found the Ironlands. A new world. A fresh start.",
+          "Quest": "Decades ago, the exodus ended. Since then, no ships have sailed here from the Old World. Until now. Word comes of a single ship, newly arrived across the vast ocean, grounded on the rocks of the Barrier Islands. When you hear the name of this ship, you swear to uncover the fate of its passengers. Why is it so important to you?"
+        }
+      ]
+    },
+    {
+      "Name": "Iron",
+      "Source": {
+        "Name": "Ironsworn Rulebook",
+        "Page": "124"
+      },
+      "Options": [
+        {
+          "Truth": "The imposing hills and mountains of the Ironlands are rich in iron ore. Most prized of all is the star-forged black iron.",
+          "Quest": "The caravan, bound for the distant southlands, left the mining settlement last season but never arrived at its destination. It carried a bounty of black iron. Why is finding this lost caravan so important to you?"
+        },
+        {
+          "Truth": "The weather is bleak. Rain and wind sweep in from the ocean. The winters are long and bitter. One of the first settlers complained, \"Only those made of iron dare live in this foul place\" – and thus our land was named.",
+          "Quest": "The harvest fell short. The unrelenting snows left the village isolated. The food is running out. What will you do to see these people through this harsh season?"
+        },
+        {
+          "Truth": "Inscrutable metal pillars are found throughout the land. They are iron gray, and smooth as river stone. No one knows their purpose. Some say they are as old as the world. Some, such as the Iron Priests, worship them and swear vows upon them. Most make the warding sign and hurry along their way when they happen across one. The pillars do not tarnish, and even the sharpest blade cannot mark them.",
+          "Quest": "Your dreams are haunted by visions of a pillar which stands in an unfamiliar landscape. What do you see? Why are you sworn to seek it out?"
+        }
+      ]
+    },
+    {
+      "Name": "Legacies",
+      "Source": {
+        "Name": "Ironsworn Rulebook",
+        "Page": "124"
+      },
+      "Options": [
+        {
+          "Truth": "We are the first humans to walk these lands.",
+          "Quest": "In the writings of one of the first settlers, there is a description of a glade in the heart of the Deep Wilds. The spirits of this place are said to grant a miraculous blessing. What boon does it bestow?"
+        },
+        {
+          "Truth": "Other humans sailed here from the Old World untold years ago, but all that is left of them is a savage, feral people we call the broken. Is their fate to become our own?",
+          "Quest": "You find a child—one of the broken. It is wounded, and hunted by others of its kind. Do you protect it, even at the risk of inviting the wrath of the broken tribes?"
+        },
+        {
+          "Truth": "Before the Ironlanders, before even the firstborn, another people lived here. Their ancient ruins are found throughout the Ironlands.",
+          "Quest": "Miners uncovered an underground ruin. Thereafter, the people of the settlement are haunted by strange dreams. The ruins call to them, they say. Several have disappeared in that dark, ancient place – including someone important to you."
+        }
+      ]
+    },
+    {
+      "Name": "Communities",
+      "Source": {
+        "Name": "Ironsworn Rulebook",
+        "Page": "125"
+      },
+      "Options": [
+        {
+          "Truth": "We are few in number in this accursed land. Most rarely have contact with anyone outside our own small steading or village, and strangers are viewed with deep suspicion.",
+          "Quest": "In the dead of winter, a desperate man arrives at a snowbound steading. He is wounded, hungry, and nearly frozen to death. His family has been taken. By whom? Will you brave the merciless winter to save them?"
+        },
+        {
+          "Truth": "We live in communities called circles. These are settlements ranging in size from a steading with a few families to a village of several hundred. Some circles belong to nomadic folk. Some powerful circles might include a cluster of settlements. We trade (and sometimes feud) with other circles.",
+          "Quest": "A decades-long feud between two circles has flared into open conflict. What is the cause of this dispute? Do you join in the fight, or swear to put a stop to it?"
+        },
+        {
+          "Truth": "We have forged the Ironlands into a home. Villages within the Havens are connected by well-trod roads. Trade caravans travel between settlements in the Havens and those in outlying regions. Even so, much of this land is untamed.",
+          "Quest": "Caravans are forced to pay for passage along a trade road. This payment, one-quarter of the goods carried, leaves several communities without sufficient winter stores. Who is making these demands? How will you set things right?"
+        }
+      ]
+    },
+    {
+      "Name": "Leaders",
+      "Source": {
+        "Name": "Ironsworn Rulebook",
+        "Page": "125"
+      },
+      "Options": [
+        {
+          "Truth": "Leadership is as varied as the people. Some communities are governed by the head of a powerful family. Or, they have a council of elders who make decisions and settle disputes. In others, the priests hold sway. For some, it is duels in the circle that decide.",
+          "Quest": "You have vivid reoccurring dreams of an Ironlands city. It has strong stone walls, bustling markets, and a keep on a high hill. And so many people! Nowhere in the Ironlands does such a city exist. In your dreams, you are the ruler of this city. Somehow, no matter how long it takes, you must make this vision a reality."
+        },
+        {
+          "Truth": "Each of our communities has its own leader, called an overseer. Every seventh spring, the people affirm their current overseer or choose a new one. Some overseers wear the iron circlet reluctantly, while others thirst for power and gain it through schemes or threats.",
+          "Quest": "An overseer has fallen ill. She is sure to die without help, and the illness is unknown to the village healer. Poison, or perhaps even foul magic, is suspected. The families in the community are now at each other’s throats as they position their preferred candidates to take up the iron circlet. Will you discover the truth of the overseer’s illness and restore her to health?"
+        },
+        {
+          "Truth": "Numerous clan-chiefs rule over petty domains. Most are intent on becoming the one true king. Their squabbles will be our undoing.",
+          "Quest": "You secretly possess one-half of the True Crown, an Old World relic. Centuries ago, this crown was broken in two when an assassin’s axe split the head of the supreme ruler. You are descended from that lineage. Who gave you this relic? Will you find the other half of the broken crown and attempt to unite the clans under your rule? Or, do you see another use for it?"
+        }
+      ]
+    },
+    {
+      "Name": "Defense",
+      "Source": {
+        "Name": "Ironsworn Rulebook",
+        "Page": "126"
+      },
+      "Options": [
+        {
+          "Truth": "Here in the Ironlands, supplies are too precious, and the lands are too sparsely populated, to support organized fighting forces. When a community is threatened, the people stand together to protect their own.",
+          "Quest": "A settlement is unable, or unwilling, to defend itself against an imminent threat. Why? What peril do they face? What will you do to protect them?"
+        },
+        {
+          "Truth": "The wardens are our soldiers, guards, and militia. They serve their communities by standing sentry, patrolling surrounding lands, and organizing defenses in times of crisis. Most have strong ties to their community. Others, called free wardens, are wandering mercenaries who hire on to serve a community or protect caravans.",
+          "Quest": "You come upon a dying warden. She tells you of an important mission, and charges you with its completion. \"Swear to me,\" she says, reaching out with a bloodied hand to give you an object crucial to the quest. What is it?"
+        },
+        {
+          "Truth": "Our warbands are rallied to strike at our enemies or defend our holdings. Though not nearly as impressive as the armies that once marched across the Old World, these forces are as well-trained and equipped as their communities can manage. The banners of the warbands are adorned with depictions of their Old World history and Ironland victories.",
+          "Quest": "A warband was wiped out in a battle against an overwhelming enemy. What is your connection to this band? Who defeated them? Will you carry their banner on a quest for vengeance, or do you vow to see it brought home to a place of honor?"
+        }
+      ]
+    },
+    {
+      "Name": "Mysticism",
+      "Source": {
+        "Name": "Ironsworn Rulebook",
+        "Page": "127"
+      },
+      "Options": [
+        {
+          "Truth": "Some still find comfort in the old ways. They call on mystics to divine the fortune of their newborn, or ask them to perform rituals to invoke a bountiful harvest. Others act out of fear against those who they suspect of having power. However, most folk believe true magic—if it ever existed—is lost to us now.",
+          "Quest": "Someone close to you is accused of cursing a settlement, causing fields to go fallow and cattle to become sick. What is the evidence of this? Will you defend this person and uncover the true cause of the settlement’s troubles?"
+        },
+        {
+          "Truth": "Magic is rare and dangerous, but those few who wield the power are truly gifted.",
+          "Quest": "You have heard stories of someone who wields true power. They live in an isolated settlement far away. Who told you of this mystic? Are they feared or respected? Why do you swear to seek them out?"
+        },
+        {
+          "Truth": "Magic courses through this land as the rivers flow through the hills. The power is there for those who choose to harness it, and even the common folk often know a helpful ritual or two.",
+          "Quest": "Someone you love walked the paths of power, and succumbed to it. Who are they? Why did they fall into darkness? Where are they now? Do you seek to save them or defeat them?"
+        }
+      ]
+    },
+    {
+      "Name": "Religion",
+      "Source": {
+        "Name": "Ironsworn Rulebook",
+        "Page": "127"
+      },
+      "Options": [
+        {
+          "Truth": "A few Ironlanders still make signs or mumble prayers out of habit or tradition, but most believe the gods long ago abandoned us.",
+          "Quest": "A charismatic Ironlander, encouraging her followers to renounce the vestiges of Old World religions, proposes a new path for this new world. What doctrine does she teach? What does she seek to achieve? Are you sworn to aid or stop her?"
+        },
+        {
+          "Truth": "The people honor old gods and new. In this harsh land, a prayer is a simple but powerful comfort.",
+          "Quest": "An Ironlander is determined to make a pilgrimage into dangerous lands. What holy place do they seek? Why do you swear to aid them on this journey? Who seeks to stop them and why?"
+        },
+        {
+          "Truth": "Our gods are many. They make themselves known through manifestations and miracles. Some say they even secretly walk among us. The priests convey the will of the gods and hold sway over many communities.",
+          "Quest": "You bear the mark of a god. What is it? The priests declare this as a sign you are chosen to fulfill a destiny. Do you accept this fate, and swear to see it through, or are you determined to see it undone? What force opposes you?"
+        }
+      ]
+    },
+    {
+      "Name": "Firstborn",
+      "Source": {
+        "Name": "Ironsworn Rulebook",
+        "Page": "128"
+      },
+      "Options": [
+        {
+          "Truth": "The firstborn have passed into legend. Some say the remnants of the old tribes still dwell in deep forests or high mountains. Most believe they were never anything more than myth.",
+          "Quest": "Someone obsessed with the firstborn wants to find evidence of their existence. This will require an expedition into the far reaches of the Ironlands. What is your role in this mission?"
+        },
+        {
+          "Truth": "The firstborn live in isolation and are fiercely protective of their own lands.",
+          "Quest": "The elf, outcast from his kind, lives with Ironlanders. Over time, he became a part of the community. Now, he is dying. He yearns to return to his people before he passes. Does he seek absolution or justice? Why do you swear to help him? What force opposes his return?"
+        },
+        {
+          "Truth": "The firstborn hold sway in the Ironlands. The elves of the deep forests and the giants of the hills tolerate us and even trade with us—for now. Ironlanders fear the day they decide we are no longer welcome here.",
+          "Quest": "Humans and giants are on the brink of war. What has happened? Who do you side with? Can anything be done to defuse the situation?"
+        }
+      ]
+    },
+    {
+      "Name": "Beasts",
+      "Source": {
+        "Name": "Ironsworn Rulebook",
+        "Page": "128"
+      },
+      "Options": [
+        {
+          "Truth": "The beasts of old are nothing but legend. A few who travel into the deep forests and high mountains return with wild tales of monstrous creatures, but they are obviously delusional. No such things exist.",
+          "Quest": "You were witness to an attack by what you thought was an animal of monstrous proportions. No one believes you. In fact, you are accused of the murder you blame on this beast. How can you prove your innocence? Can you even trust your own memories of the event?"
+        },
+        {
+          "Truth": "Monstrous beasts stalk the wild areas of the Ironlands.",
+          "Quest": "A prominent Ironlander is consumed with the need to bring vengeance upon a specific beast. What makes this creature distinctive? How did it earn the wrath of this Ironlander? Do you aid this person in their quest, or act to prevent their blind hate from destroying more than just the beast?"
+        },
+        {
+          "Truth": "Beasts of all sorts roam the Ironlands. They dwell primarily in the reaches, but range into the settled lands to hunt. There, they often prey on cattle, but attacks on travelers, caravans, or even settlements are not uncommon.",
+          "Quest": "Professional slayers earn their keep by killing beasts. This particular slayer, famed throughout the Ironlands for her numerous kills, has gone missing on a hunt. Did she finally meet her match, or is something more nefarious at play. What is your connection to her?"
+        }
+      ]
+    },
+    {
+      "Name": "Horrors",
+      "Source": {
+        "Name": "Ironsworn Rulebook",
+        "Page": "129"
+      },
+      "Options": [
+        {
+          "Truth": "Nothing but stories to frighten children.",
+          "Quest": "The murders began last season. Local gossip suggests they are the work of a vengeful horror, but there may be more mundane forces at work. What is your connection to these killings? What will you do to stop them?"
+        },
+        {
+          "Truth": "We are wary of dark forests and deep waterways, for monsters lurk in those places. In the depths of the long-night, when all is wreathed in darkness, only fools venture beyond their homes.",
+          "Quest": "You bear the scars of an attack by a horror. What was it? Are those scars physical, emotional, or both? How do you seek to make yourself whole again?"
+        },
+        {
+          "Truth": "The dead do not rest in the Ironlands. At night we light torches, scatter salt, and post sentries at the gate. It is not enough. They are coming.",
+          "Quest": "A group of Ironlanders establish a settlement in a territory cursed by a malevolent horror. What evil plagues this land? Why are the Ironlanders so intent on settling here? Will you aid them, or attempt to force them to give up this foolish undertaking?"
+        }
+      ]
+    }
+  ]
+}

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -96,6 +96,10 @@
       "SharedSupply": {
         "Name": "Shared Supply Tracker",
         "Hint": "If on, changing any character/shared supply tracker changes all other actors' supply trackers as well."
+      },
+      "PromptTruths": {
+        "Name": "Prompt for World Truths",
+        "Hint": "Prompt on startup to generate world truths using the dialog, if not already done."
       }
     },
     "MoveContents": {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -940,6 +940,107 @@
         "danger4": "Artifact with a hidden danger",
         "danger5": "Denizen lurks in darkness"
       }
+    },
+    "WorldTruths": {
+      "The Old World": {
+        "name": "The Old World",
+        "option1": "The savage clans called the Skulde invaded the kingdoms of the Old World. Our armies fell. Most were killed or taken into slavery. Those who escaped set sail aboard anything that would float. After an arduous months-long voyage, the survivors made landfall upon the Ironlands.",
+        "quest1": "You are a descendant of the Skulde. Because of your heritage, your family has long borne the distrust of your fellow Ironlanders. Now, a small force of Skulde have landed on our shores. Are they the harbinger of an invasion? Where do your loyalties lie?",
+        "option2": "The sickness moved like a horrible wave across the Old World, killing all in its path. Thousands fled aboard ships. However, the plague could not be outrun. On many ships, the disease was contained through ruthless measures—tossing overboard any who exhibited the slightest symptom. Other ships were forever lost. In the end, those who survived found the Ironlands and made it their new home. Some say we will forever be cursed by those we left behind.",
+        "quest2": "A settlement is stricken by disease. Though this sickness bears some similarities to the Old World plague, it doesn’t kill its victims. Instead, it changes them. How does this disease manifest? Why do you swear to seek out a cure?",
+        "option3": "The Old World could no longer sustain us. We were too large in number. We had felled the forests. Our crops withered in the barren ground. The cities and villages overflowed with desperate, hungry people. Petty kings battled for scraps. We cast our fate to the sea and found the Ironlands. A new world. A fresh start.",
+        "quest3": "Decades ago, the exodus ended. Since then, no ships have sailed here from the Old World. Until now. Word comes of a single ship, newly arrived across the vast ocean, grounded on the rocks of the Barrier Islands. When you hear the name of this ship, you swear to uncover the fate of its passengers. Why is it so important to you?"
+      },
+      "Iron": {
+        "name": "Iron",
+        "option1": "The imposing hills and mountains of the Ironlands are rich in iron ore. Most prized of all is the star-forged black iron.",
+        "quest1": "The caravan, bound for the distant southlands, left the mining settlement last season but never arrived at its destination. It carried a bounty of black iron. Why is finding this lost caravan so important to you?",
+        "option2": "The weather is bleak. Rain and wind sweep in from the ocean. The winters are long and bitter. One of the first settlers complained, \"Only those made of iron dare live in this foul place\" – and thus our land was named.",
+        "quest2": "The harvest fell short. The unrelenting snows left the village isolated. The food is running out. What will you do to see these people through this harsh season?",
+        "option3": "Inscrutable metal pillars are found throughout the land. They are iron gray, and smooth as river stone. No one knows their purpose. Some say they are as old as the world. Some, such as the Iron Priests, worship them and swear vows upon them. Most make the warding sign and hurry along their way when they happen across one. The pillars do not tarnish, and even the sharpest blade cannot mark them.",
+        "quest3": "Your dreams are haunted by visions of a pillar which stands in an unfamiliar landscape. What do you see? Why are you sworn to seek it out?"
+      },
+      "Legacies": {
+        "name": "Legacies",
+        "option1": "We are the first humans to walk these lands.",
+        "quest1": "In the writings of one of the first settlers, there is a description of a glade in the heart of the Deep Wilds. The spirits of this place are said to grant a miraculous blessing. What boon does it bestow?",
+        "option2": "Other humans sailed here from the Old World untold years ago, but all that is left of them is a savage, feral people we call the broken. Is their fate to become our own?",
+        "quest2": "You find a child—one of the broken. It is wounded, and hunted by others of its kind. Do you protect it, even at the risk of inviting the wrath of the broken tribes?",
+        "option3": "Before the Ironlanders, before even the firstborn, another people lived here. Their ancient ruins are found throughout the Ironlands.",
+        "quest3": "Miners uncovered an underground ruin. Thereafter, the people of the settlement are haunted by strange dreams. The ruins call to them, they say. Several have disappeared in that dark, ancient place – including someone important to you."
+      },
+      "Communities": {
+        "name": "Communities",
+        "option1": "We are few in number in this accursed land. Most rarely have contact with anyone outside our own small steading or village, and strangers are viewed with deep suspicion.",
+        "quest1": "In the dead of winter, a desperate man arrives at a snowbound steading. He is wounded, hungry, and nearly frozen to death. His family has been taken. By whom? Will you brave the merciless winter to save them?",
+        "option2": "We live in communities called circles. These are settlements ranging in size from a steading with a few families to a village of several hundred. Some circles belong to nomadic folk. Some powerful circles might include a cluster of settlements. We trade (and sometimes feud) with other circles.",
+        "quest2": "A decades-long feud between two circles has flared into open conflict. What is the cause of this dispute? Do you join in the fight, or swear to put a stop to it?",
+        "option3": "We have forged the Ironlands into a home. Villages within the Havens are connected by well-trod roads. Trade caravans travel between settlements in the Havens and those in outlying regions. Even so, much of this land is untamed.",
+        "quest3": "Caravans are forced to pay for passage along a trade road. This payment, one-quarter of the goods carried, leaves several communities without sufficient winter stores. Who is making these demands? How will you set things right?"
+      },
+      "Leaders": {
+        "name": "Leaders",
+        "option1": "Leadership is as varied as the people. Some communities are governed by the head of a powerful family. Or, they have a council of elders who make decisions and settle disputes. In others, the priests hold sway. For some, it is duels in the circle that decide.",
+        "quest1": "You have vivid reoccurring dreams of an Ironlands city. It has strong stone walls, bustling markets, and a keep on a high hill. And so many people! Nowhere in the Ironlands does such a city exist. In your dreams, you are the ruler of this city. Somehow, no matter how long it takes, you must make this vision a reality.",
+        "option2": "Each of our communities has its own leader, called an overseer. Every seventh spring, the people affirm their current overseer or choose a new one. Some overseers wear the iron circlet reluctantly, while others thirst for power and gain it through schemes or threats.",
+        "quest2": "An overseer has fallen ill. She is sure to die without help, and the illness is unknown to the village healer. Poison, or perhaps even foul magic, is suspected. The families in the community are now at each other’s throats as they position their preferred candidates to take up the iron circlet. Will you discover the truth of the overseer’s illness and restore her to health?",
+        "option3": "Numerous clan-chiefs rule over petty domains. Most are intent on becoming the one true king. Their squabbles will be our undoing.",
+        "quest3": "You secretly possess one-half of the True Crown, an Old World relic. Centuries ago, this crown was broken in two when an assassin’s axe split the head of the supreme ruler. You are descended from that lineage. Who gave you this relic? Will you find the other half of the broken crown and attempt to unite the clans under your rule? Or, do you see another use for it?"
+      },
+      "Defense": {
+        "name": "Defense",
+        "option1": "Here in the Ironlands, supplies are too precious, and the lands are too sparsely populated, to support organized fighting forces. When a community is threatened, the people stand together to protect their own.",
+        "quest1": "A settlement is unable, or unwilling, to defend itself against an imminent threat. Why? What peril do they face? What will you do to protect them?",
+        "option2": "The wardens are our soldiers, guards, and militia. They serve their communities by standing sentry, patrolling surrounding lands, and organizing defenses in times of crisis. Most have strong ties to their community. Others, called free wardens, are wandering mercenaries who hire on to serve a community or protect caravans.",
+        "quest2": "You come upon a dying warden. She tells you of an important mission, and charges you with its completion. \"Swear to me,\" she says, reaching out with a bloodied hand to give you an object crucial to the quest. What is it?",
+        "option3": "Our warbands are rallied to strike at our enemies or defend our holdings. Though not nearly as impressive as the armies that once marched across the Old World, these forces are as well-trained and equipped as their communities can manage. The banners of the warbands are adorned with depictions of their Old World history and Ironland victories.",
+        "quest3": "A warband was wiped out in a battle against an overwhelming enemy. What is your connection to this band? Who defeated them? Will you carry their banner on a quest for vengeance, or do you vow to see it brought home to a place of honor?"
+      },
+      "Mysticism": {
+        "name": "Mysticism",
+        "option1": "Some still find comfort in the old ways. They call on mystics to divine the fortune of their newborn, or ask them to perform rituals to invoke a bountiful harvest. Others act out of fear against those who they suspect of having power. However, most folk believe true magic—if it ever existed—is lost to us now.",
+        "quest1": "Someone close to you is accused of cursing a settlement, causing fields to go fallow and cattle to become sick. What is the evidence of this? Will you defend this person and uncover the true cause of the settlement’s troubles?",
+        "option2": "Magic is rare and dangerous, but those few who wield the power are truly gifted.",
+        "quest2": "You have heard stories of someone who wields true power. They live in an isolated settlement far away. Who told you of this mystic? Are they feared or respected? Why do you swear to seek them out?",
+        "option3": "Magic courses through this land as the rivers flow through the hills. The power is there for those who choose to harness it, and even the common folk often know a helpful ritual or two.",
+        "quest3": "Someone you love walked the paths of power, and succumbed to it. Who are they? Why did they fall into darkness? Where are they now? Do you seek to save them or defeat them?"
+      },
+      "Religion": {
+        "name": "Religion",
+        "option1": "A few Ironlanders still make signs or mumble prayers out of habit or tradition, but most believe the gods long ago abandoned us.",
+        "quest1": "A charismatic Ironlander, encouraging her followers to renounce the vestiges of Old World religions, proposes a new path for this new world. What doctrine does she teach? What does she seek to achieve? Are you sworn to aid or stop her?",
+        "option2": "The people honor old gods and new. In this harsh land, a prayer is a simple but powerful comfort.",
+        "quest2": "An Ironlander is determined to make a pilgrimage into dangerous lands. What holy place do they seek? Why do you swear to aid them on this journey? Who seeks to stop them and why?",
+        "option3": "Our gods are many. They make themselves known through manifestations and miracles. Some say they even secretly walk among us. The priests convey the will of the gods and hold sway over many communities.",
+        "quest3": "You bear the mark of a god. What is it? The priests declare this as a sign you are chosen to fulfill a destiny. Do you accept this fate, and swear to see it through, or are you determined to see it undone? What force opposes you?"
+      },
+      "Firstborn": {
+        "name": "Firstborn",
+        "option1": "The firstborn have passed into legend. Some say the remnants of the old tribes still dwell in deep forests or high mountains. Most believe they were never anything more than myth.",
+        "quest1": "Someone obsessed with the firstborn wants to find evidence of their existence. This will require an expedition into the far reaches of the Ironlands. What is your role in this mission?",
+        "option2": "The firstborn live in isolation and are fiercely protective of their own lands.",
+        "quest2": "The elf, outcast from his kind, lives with Ironlanders. Over time, he became a part of the community. Now, he is dying. He yearns to return to his people before he passes. Does he seek absolution or justice? Why do you swear to help him? What force opposes his return?",
+        "option3": "The firstborn hold sway in the Ironlands. The elves of the deep forests and the giants of the hills tolerate us and even trade with us—for now. Ironlanders fear the day they decide we are no longer welcome here.",
+        "quest3": "Humans and giants are on the brink of war. What has happened? Who do you side with? Can anything be done to defuse the situation?"
+      },
+      "Beasts": {
+        "name": "Beasts",
+        "option1": "The beasts of old are nothing but legend. A few who travel into the deep forests and high mountains return with wild tales of monstrous creatures, but they are obviously delusional. No such things exist.",
+        "quest1": "You were witness to an attack by what you thought was an animal of monstrous proportions. No one believes you. In fact, you are accused of the murder you blame on this beast. How can you prove your innocence? Can you even trust your own memories of the event?",
+        "option2": "Monstrous beasts stalk the wild areas of the Ironlands.",
+        "quest2": "A prominent Ironlander is consumed with the need to bring vengeance upon a specific beast. What makes this creature distinctive? How did it earn the wrath of this Ironlander? Do you aid this person in their quest, or act to prevent their blind hate from destroying more than just the beast?",
+        "option3": "Beasts of all sorts roam the Ironlands. They dwell primarily in the reaches, but range into the settled lands to hunt. There, they often prey on cattle, but attacks on travelers, caravans, or even settlements are not uncommon.",
+        "quest3": "Professional slayers earn their keep by killing beasts. This particular slayer, famed throughout the Ironlands for her numerous kills, has gone missing on a hunt. Did she finally meet her match, or is something more nefarious at play. What is your connection to her?"
+      },
+      "Horrors": {
+        "name": "Horrors",
+        "option1": "Nothing but stories to frighten children.",
+        "quest1": "The murders began last season. Local gossip suggests they are the work of a vengeful horror, but there may be more mundane forces at work. What is your connection to these killings? What will you do to stop them?",
+        "option2": "We are wary of dark forests and deep waterways, for monsters lurk in those places. In the depths of the long-night, when all is wreathed in darkness, only fools venture beyond their homes.",
+        "quest2": "You bear the scars of an attack by a horror. What was it? Are those scars physical, emotional, or both? How do you seek to make yourself whole again?",
+        "option3": "The dead do not rest in the Ironlands. At night we light torches, scatter salt, and post sentries at the gate. It is not enough. They are coming.",
+        "quest3": "A group of Ironlanders establish a settlement in a territory cursed by a malevolent horror. What evil plagues this land? Why are the Ironlanders so intent on settling here? Will you aid them, or attempt to force them to give up this foolish undertaking?"
+      }
     }
   }
 }

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -1,6 +1,7 @@
 {
   "IRONSWORN": {
     "CreateActor": "Create Actor",
+    "YourWorldTruths": "Your World: Truths",
     "Roll": "Roll",
     "Rolling": "Rolling",
     "Bonus": "Bonus",

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -2,6 +2,9 @@
   "IRONSWORN": {
     "CreateActor": "Create Actor",
     "YourWorldTruths": "Your World: Truths",
+    "TruthQuestStarter": "Quest Starter:",
+    "SaveYourTruths": "Save Your Truths",
+    "CustomTruth": "Custom Truth",
     "Roll": "Roll",
     "Rolling": "Rolling",
     "Bonus": "Bonus",

--- a/system/templates/truths.hbs
+++ b/system/templates/truths.hbs
@@ -4,23 +4,21 @@
 
   {{#each Options}}
   <div class="flexrow">
-    <input type="radio" name="{{../Name}} class="nogrow" style="flex-basis: 20px; margin: 8px;""
+    <input type="radio" name="{{../Name}} class="nogrow" style="flex: 0 0 20px; margin: 8px;""
       id="{{concat ../Name '#' @index}}" data-category="{{../Name}}">
     <div class="flexcol">
       <label for="{{concat ../Name '#' @index}}" class="description">
         <p>{{Truth}}</p>
-        {{!-- TODO: I18n for 'Quest Starter:' --}}
-        <p><em>Quest Starter: {{Quest}}</em></p>
+        <p><em>{{localize 'IRONSWORN.TruthQuestStarter'}} {{Quest}}</em></p>
       </label>
     </div>
   </div>
   {{/each}}
 
   <div class="flexrow">
-    <input type="radio" name="{{Name}} class="nogrow" style="flex-basis: 20px; margin: 5px 8px;""
+    <input type="radio" name="{{Name}} class="nogrow" style="flex: 0 0 20px; margin: 5px 8px;""
       id="{{concat Name '#custom'}}"  data-category="{{Name}}">
-    {{!-- TODO: i18n for 'Custom Truth' --}}
-    <input type="text" class="ironsworn__custom__truth description" placeholder="Custom Truth">
+    <input type="text" class="ironsworn__custom__truth description" placeholder="{{localize 'IRONSWORN.CustomTruth'}}">
   </div>
 
   {{/each}}
@@ -29,7 +27,6 @@
 
   <button class="ironsworn__save__truths">
     <i class="fas fa-feather"></i>
-    {{!-- TODO: i18n --}}
-    Save Your Truths
+    {{localize 'IRONSWORN.SaveYourTruths'}}
   </button>
 </form>

--- a/system/templates/truths.hbs
+++ b/system/templates/truths.hbs
@@ -1,18 +1,25 @@
 <form>
   {{#each truths.Categories}}
-  <h2>{{Name}}</h2>
+  <h2 style="margin-top: 1em;">{{Name}}</h2>
 
   {{#each Options}}
-  <input type="radio" name="{{../Name}}" id="{{concat ../Name @index}}">
-  <label for="{{concat ../Name @index}}">
-    <p>{{Truth}}</p>
-    {{!-- TODO: I18n for 'Quest Starter:' --}}
-    <p><em>Quest Starter: {{Quest}}</em></p>
-  </label>
+  <div class="flexrow">
+    <input class="nogrow" style="flex-basis: 20px; margin: 8px;" type="radio" name="{{../Name}}" id="{{concat ../Name @index}}">
+    <div class="flexcol">
+      <label for="{{concat ../Name @index}}">
+        <p>{{Truth}}</p>
+        {{!-- TODO: I18n for 'Quest Starter:' --}}
+        <p><em>Quest Starter: {{Quest}}</em></p>
+      </label>
+    </div>
+  </div>
   {{/each}}
-  <input type="radio" name="{{../Name}}" id="{{concat ../Name 'custom'}}">
-  {{!-- TODO: i18n for 'Custom Truth' --}}
-  <input type="text" id="{{concat ../Name 'custom'}}" placeholder="Custom Truth">
+
+  <div class="flexrow">
+    <input class="nogrow" style="flex-basis: 20px; margin: 5px 8px;" type="radio" name="{{Name}}" id="{{concat Name 'custom'}}">
+    {{!-- TODO: i18n for 'Custom Truth' --}}
+    <input type="text" id="{{concat Name 'custom'}}" placeholder="Custom Truth">
+  </div>
 
   {{/each}}
 </form>

--- a/system/templates/truths.hbs
+++ b/system/templates/truths.hbs
@@ -1,0 +1,3 @@
+<form>
+  <h1>Truths</h1>
+</form>

--- a/system/templates/truths.hbs
+++ b/system/templates/truths.hbs
@@ -1,3 +1,18 @@
 <form>
-  <h1>Truths</h1>
+  {{#each truths.Categories}}
+  <h2>{{Name}}</h2>
+
+  {{#each Options}}
+  <input type="radio" name="{{../Name}}" id="{{concat ../Name @index}}">
+  <label for="{{concat ../Name @index}}">
+    <p>{{Truth}}</p>
+    {{!-- TODO: I18n for 'Quest Starter:' --}}
+    <p><em>Quest Starter: {{Quest}}</em></p>
+  </label>
+  {{/each}}
+  <input type="radio" name="{{../Name}}" id="{{concat ../Name 'custom'}}">
+  {{!-- TODO: i18n for 'Custom Truth' --}}
+  <input type="text" id="{{concat ../Name 'custom'}}" placeholder="Custom Truth">
+
+  {{/each}}
 </form>

--- a/system/templates/truths.hbs
+++ b/system/templates/truths.hbs
@@ -4,10 +4,10 @@
 
   {{#each Options}}
   <div class="flexrow">
-    <input class="nogrow" style="flex-basis: 20px; margin: 8px;" type="radio" name="{{../Name}}"
-      id="{{concat ../Name '#' @index}}" value="{{Truth}}">
+    <input type="radio" name="{{../Name}} class="nogrow" style="flex-basis: 20px; margin: 8px;""
+      id="{{concat ../Name '#' @index}}" data-category="{{../Name}}">
     <div class="flexcol">
-      <label for="{{concat ../Name '#' @index}}">
+      <label for="{{concat ../Name '#' @index}}" class="description">
         <p>{{Truth}}</p>
         {{!-- TODO: I18n for 'Quest Starter:' --}}
         <p><em>Quest Starter: {{Quest}}</em></p>
@@ -17,10 +17,10 @@
   {{/each}}
 
   <div class="flexrow">
-    <input class="nogrow" style="flex-basis: 20px; margin: 5px 8px;" type="radio" name="{{Name}}"
-      id="{{concat Name '#custom'}}">
+    <input type="radio" name="{{Name}} class="nogrow" style="flex-basis: 20px; margin: 5px 8px;""
+      id="{{concat Name '#custom'}}"  data-category="{{Name}}">
     {{!-- TODO: i18n for 'Custom Truth' --}}
-    <input type="text" class="ironsworn__custom__truth" placeholder="Custom Truth">
+    <input type="text" class="ironsworn__custom__truth description" placeholder="Custom Truth">
   </div>
 
   {{/each}}
@@ -30,6 +30,6 @@
   <button class="ironsworn__save__truths">
     <i class="fas fa-feather"></i>
     {{!-- TODO: i18n --}}
-    Save these choices
+    Save Your Truths
   </button>
 </form>

--- a/system/templates/truths.hbs
+++ b/system/templates/truths.hbs
@@ -18,7 +18,7 @@
   <div class="flexrow">
     <input class="nogrow" style="flex-basis: 20px; margin: 5px 8px;" type="radio" name="{{Name}}" id="{{concat Name 'custom'}}">
     {{!-- TODO: i18n for 'Custom Truth' --}}
-    <input type="text" id="{{concat Name 'custom'}}" placeholder="Custom Truth">
+    <input type="text" class="ironsworn__custom__truth" placeholder="Custom Truth">
   </div>
 
   {{/each}}

--- a/system/templates/truths.hbs
+++ b/system/templates/truths.hbs
@@ -4,9 +4,10 @@
 
   {{#each Options}}
   <div class="flexrow">
-    <input class="nogrow" style="flex-basis: 20px; margin: 8px;" type="radio" name="{{../Name}}" id="{{concat ../Name @index}}">
+    <input class="nogrow" style="flex-basis: 20px; margin: 8px;" type="radio" name="{{../Name}}"
+      id="{{concat ../Name '#' @index}}" value="{{Truth}}">
     <div class="flexcol">
-      <label for="{{concat ../Name @index}}">
+      <label for="{{concat ../Name '#' @index}}">
         <p>{{Truth}}</p>
         {{!-- TODO: I18n for 'Quest Starter:' --}}
         <p><em>Quest Starter: {{Quest}}</em></p>
@@ -16,10 +17,19 @@
   {{/each}}
 
   <div class="flexrow">
-    <input class="nogrow" style="flex-basis: 20px; margin: 5px 8px;" type="radio" name="{{Name}}" id="{{concat Name 'custom'}}">
+    <input class="nogrow" style="flex-basis: 20px; margin: 5px 8px;" type="radio" name="{{Name}}"
+      id="{{concat Name '#custom'}}">
     {{!-- TODO: i18n for 'Custom Truth' --}}
     <input type="text" class="ironsworn__custom__truth" placeholder="Custom Truth">
   </div>
 
   {{/each}}
+
+  <hr>
+
+  <button class="ironsworn__save__truths">
+    <i class="fas fa-feather"></i>
+    {{!-- TODO: i18n --}}
+    Save these choices
+  </button>
 </form>


### PR DESCRIPTION
This adds a sheet that walks the player through the "Your Truths" section of the rulebook, which will generate a journal entry when completed. It'll be offered as an option when opening up a world unless the journal entry already exists, or the user clicks the "don't show me this again" button.

Fixes #83.

- [x] Import truths data (running ahead of https://github.com/rsek/datasworn/pull/13 a bit)
- [x] Create the FormApplication
  - [x] Fill in the options
  - [x] Allow custom text entry
  - [x] Generate journal entry when complete
- [x] Prompt to open on world startup
  - [x] "don't show me this again" button, backed by a world setting
- [x] Update CHANGELOG.md
