### PR TITLE
Site foes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix the spelling of "formidable" ([#105](https://github.com/ben/foundry-ironsworn/pull/105))
 - Include a "foes" compendium ([#106](https://github.com/ben/foundry-ironsworn/pull/106))
+- Add drag/drop support for foes into site sheet ([#107](https://github.com/ben/foundry-ironsworn/pull/107))
 
 ## 1.4.1
 

--- a/src/module/actor/sheets/charactersheet.ts
+++ b/src/module/actor/sheets/charactersheet.ts
@@ -10,7 +10,6 @@ export class IronswornCharacterSheet extends ActorSheet {
       height: 800,
       left: 50,
       template: 'systems/foundry-ironsworn/templates/actor/character.hbs',
-      dragDrop: [{ dragSelector: '.item-list .item', dropSelector: null }],
     })
   }
 

--- a/src/module/actor/sheets/sitesheet.ts
+++ b/src/module/actor/sheets/sitesheet.ts
@@ -121,6 +121,7 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
     html.find('.ironsworn__locateobjective__roll').on('click', (ev) => this._locateObjective.call(this, ev))
 
     html.find('.ironsworn__random__denizen').on('click', (ev) => this._randomDenizen.call(this, ev))
+    html.find('.ironsworn__foe__compendium').on('click', (ev) => this._foeCompendium.call(this, ev))
     html.find('.ironsworn__denizen__name').on('blur', (ev) => this._setDenizenName.call(this, ev))
   }
 
@@ -190,6 +191,11 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
       const input = this.element.find(`.ironsworn__denizen__name[data-idx=${idx}]`)
       input.addClass('highlight').trigger('focus')
     }
+  }
+
+  async _foeCompendium(_ev: JQuery.ClickEvent) {
+    const pack = game.packs?.get(`foundry-ironsworn.ironswornfoes`)
+    pack?.render(true)
   }
 
   _setDenizenName(ev: JQuery.BlurEvent) {

--- a/src/module/actor/sheets/sitesheet.ts
+++ b/src/module/actor/sheets/sitesheet.ts
@@ -156,6 +156,7 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
 
     // Denizen slot is empty; set focus and add a class
     if (!denizen?.description) {
+      await this.actor.setFlag('foundry-ironsworn', 'edit-mode', true)
       const idx = this.siteData.data.denizens.indexOf(denizen)
       const input = this.element.find(`.ironsworn__denizen__name[data-idx=${idx}]`)
       input.addClass('highlight').trigger('focus')

--- a/src/module/actor/sheets/sitesheet.ts
+++ b/src/module/actor/sheets/sitesheet.ts
@@ -39,6 +39,35 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
     })
   }
 
+  // _onDragOver(event: DragEvent) {
+  //   console.log('_onDragOver', event)
+  //   return super._onDragOver(event)
+  // }
+
+  async _onDropItem(event: DragEvent, data: ActorSheet.DropData.Item) {
+    // Fetch the item. We only want to override denizens (progress-type items)
+    const item = await Item.fromDropData(data)
+    if (!item) return false
+    if (item.type !== 'progress') {
+      return super._onDropItem(event, data)
+    }
+
+    // Find which denizen slot this is going into
+    const dropTarget = $(event.target as HTMLElement).parents('.ironsworn__denizen__drop')[0]
+    if (!dropTarget) return false
+    const idx = parseInt(dropTarget.dataset.idx || '')
+    const { denizens } = this.siteData.data
+    if (!denizens[idx]) return false
+
+    // Set the denizen description
+    const description = item.pack
+      ? `@Compendium[${item.pack}.${item.id}]{${item.name}}`
+      : item.link
+    denizens[idx].description = description
+    this.actor.update({ data: { denizens } }, { render: true })
+    return true
+  }
+
   _getHeaderButtons() {
     return [
       {

--- a/system/templates/actor/site.hbs
+++ b/system/templates/actor/site.hbs
@@ -26,8 +26,9 @@
   </div>
   {{/if}}
 
-  {{else}} {{! Prompt to drag an item in }}
+  {{else}}
 
+  {{! Prompt to drag an item in }}
   <div class="flexcol">
     <h4 style="margin: 0;">{{localize titlekey}}</h4>
     <p class="inset clickable block ironsworn__compendium__open" style="padding: 0 2em;"
@@ -145,7 +146,7 @@
     {{#each denizenMatrix}}
     <div class="flexrow boxrow">
       {{#each this}}
-      <div class="box flexrow" style="padding: 3px;">
+      <div class="box flexrow ironsworn__denizen__drop" style="padding: 3px;" data-idx="{{idx}}">
         <label class="nogrow" style="white-space: nowrap; flex-basis: 4em; line-height: 26px;">
           {{#if (eq denizen.low denizen.high)}}
           {{denizen.low}}

--- a/system/templates/actor/site.hbs
+++ b/system/templates/actor/site.hbs
@@ -33,6 +33,7 @@
     <h4 style="margin: 0;">{{localize titlekey}}</h4>
     <p class="inset clickable block ironsworn__compendium__open" style="padding: 0 2em;"
       data-compendium="{{compendiumkey}}">
+      <i class="fas fa-atlas"></i>
       {{localize 'IRONSWORN.OpenCompendium'}}
     </p>
   </div>
@@ -136,10 +137,15 @@
   </div>
 
   <h3>
+    <div style="float: right;">
+      <span class="ironsworn__random__denizen nogrow clickable block" style="padding: 5px;">
+        <i class="fa fa-dice-d6"></i>
+      </span>
+      <span class="ironsworn__foe__compendium nogrow clickable block" style="padding: 5px;">
+        <i class="fas fa-atlas"></i>
+      </span>
+    </div>
     {{localize 'IRONSWORN.Denizens'}}
-    <span class="ironsworn__random__denizen nogrow clickable block" style="padding: 5px;">
-      <i class="fa fa-dice-d6"></i>
-    </span>
   </h3>
 
   <div class="boxgroup nogrow">

--- a/system/templates/actor/site.hbs
+++ b/system/templates/actor/site.hbs
@@ -146,15 +146,21 @@
     <div class="flexrow boxrow">
       {{#each this}}
       <div class="box flexrow" style="padding: 3px;">
-        <label class="nogrow" style="white-space: nowrap; flex-basis: 4em;">
+        <label class="nogrow" style="white-space: nowrap; flex-basis: 4em; line-height: 26px;">
           {{#if (eq denizen.low denizen.high)}}
           {{denizen.low}}
           {{else}}
           {{denizen.low}}–{{denizen.high}}
           {{/if}}
         </label>
+
+        {{#if ../../actor.data.flags.foundry-ironsworn.edit-mode}}
         <input type="text" class="ironsworn__denizen__name" data-idx="{{idx}}" value="{{denizen.description}}"
           placeholder="{{denizen.descriptor}}">
+        {{else}}
+        <div style="line-height: 26px;">{{{enrichHtml denizen.description}}}</div>
+        {{/if}}
+
       </div>
       {{/each}}
     </div>


### PR DESCRIPTION
This adds support for drag-and-drop of a Progress item (like in the Foes compendium) into the site sheet.

- [x] Run denizen descriptions through `enrichHtml`
- [x] Handle drop events and convert a denizen slot to an embedded item link
- [x] ~Highlight drop targets when hovering~ I'll pick this up in a separate PR
- [x] Compendium button for denizens area
- [x] Update CHANGELOG.md
