### PR TITLE
Site sheet: highlight drag targets for compendium items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## In progress
 
+- Highlight drag targets on site sheet ([#108](https://github.com/ben/foundry-ironsworn/pull/108))
+
 ## 1.4.3
+
+- Add drag/drop support for foes into site sheet ([#107](https://github.com/ben/foundry-ironsworn/pull/107))
 
 ## 1.4.2
 
 - Fix the spelling of "formidable" ([#105](https://github.com/ben/foundry-ironsworn/pull/105))
 - Include a "foes" compendium ([#106](https://github.com/ben/foundry-ironsworn/pull/106))
-- Add drag/drop support for foes into site sheet ([#107](https://github.com/ben/foundry-ironsworn/pull/107))
 
 ## 1.4.1
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { IronswornSiteSheet } from './module/actor/sheets/sitesheet'
 import { CreateActorDialog } from './module/applications/createActorDialog'
 import { WorldTruthsDialog } from './module/applications/worldTruthsDialog'
 import { IronswornChatCard } from './module/chat/cards'
+import { activateDragDropListeners } from './module/features/dragdrop'
 import { IronswornHandlebarsHelpers } from './module/helpers/handlebars'
 import { runDataMigrations } from './module/helpers/migrations'
 import { IronswornSettings } from './module/helpers/settings'
@@ -107,6 +108,8 @@ Hooks.once('init', async () => {
 
 Hooks.once('ready', async () => {
   await runDataMigrations()
+
+  activateDragDropListeners()
 
   CONFIG.IRONSWORN.applications.createActorDialog = new CreateActorDialog({})
   WorldTruthsDialog.maybeShow()

--- a/src/module/actor/sheets/sitesheet.ts
+++ b/src/module/actor/sheets/sitesheet.ts
@@ -106,6 +106,7 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
     }
 
     html.on('dragenter', (ev) => this._maybeShowDragTargets.call(this, ev))
+    html.on('dragleave', (ev) => this._hideDragTargets.call(this, ev))
 
     html.find('.ironsworn__progress__rank').on('click', (ev) => this._setRank.call(this, ev))
     html.find('.ironsworn__progress__mark').on('click', (ev) => this._markProgress.call(this, ev))
@@ -132,10 +133,12 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
 
   _showDragTargets(type: string) {
     console.log(type)
+    $(this.element).find(`.drop-target[data-drop-type="${type}"]`).addClass('drag-highlight')
   }
 
-  _hideDragTargets() {
-    console.log(this)
+  _hideDragTargets(ev?: JQuery.DragLeaveEvent) {
+    console.log(this, ev)
+    $(this.element).find('.drop-target').removeClass('drag-highlight')
   }
 
   _setRank(ev: JQuery.ClickEvent) {

--- a/src/module/actor/sheets/sitesheet.ts
+++ b/src/module/actor/sheets/sitesheet.ts
@@ -39,10 +39,6 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
     })
   }
 
-  // _onDragOver(event: DragEvent) {
-  //   console.log('_onDragOver', event)
-  //   return super._onDragOver(event)
-  // }
 
   async _onDropItem(event: DragEvent, data: ActorSheet.DropData.Item) {
     // Fetch the item. We only want to override denizens (progress-type items)
@@ -60,9 +56,7 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
     if (!denizens[idx]) return false
 
     // Set the denizen description
-    const description = item.pack
-      ? `@Compendium[${item.pack}.${item.id}]{${item.name}}`
-      : item.link
+    const description = item.pack ? `@Compendium[${item.pack}.${item.id}]{${item.name}}` : item.link
     denizens[idx].description = description
     this.actor.update({ data: { denizens } }, { render: true })
     return true
@@ -110,6 +104,8 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
       itemClass.activateActorSheetListeners(html, this)
     }
 
+    html.on('dragenter', ev => this._maybeShowDragTargets.call(this, ev))
+
     html.find('.ironsworn__progress__rank').on('click', (ev) => this._setRank.call(this, ev))
     html.find('.ironsworn__progress__mark').on('click', (ev) => this._markProgress.call(this, ev))
     html.find('.ironsworn__progress__clear').on('click', (ev) => this._clearProgress.call(this, ev))
@@ -123,6 +119,10 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
     html.find('.ironsworn__random__denizen').on('click', (ev) => this._randomDenizen.call(this, ev))
     html.find('.ironsworn__foe__compendium').on('click', (ev) => this._foeCompendium.call(this, ev))
     html.find('.ironsworn__denizen__name').on('blur', (ev) => this._setDenizenName.call(this, ev))
+  }
+
+  _maybeShowDragTargets(_ev: JQuery.DragEnterEvent) {
+    console.log(lastDraggedItemType);
   }
 
   _setRank(ev: JQuery.ClickEvent) {
@@ -207,3 +207,14 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
     this.actor.update({ data: { denizens } }, { render: false })
   }
 }
+
+let lastDraggedItemType: string | undefined
+Hooks.on('renderCompendium', (_app, html, data) => {
+  html.find('.directory-item').on('dragstart', (ev: JQuery.DragStartEvent) => {
+    const { documentId } = ev.target.dataset
+    const packId = $(ev.target).parents('.compendium').data('pack')
+    const pack = game.packs.get(packId)
+    const indexEntry = pack?.index.get(documentId)
+    lastDraggedItemType = indexEntry?.type
+  })
+})

--- a/src/module/actor/sheets/sitesheet.ts
+++ b/src/module/actor/sheets/sitesheet.ts
@@ -39,8 +39,9 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
     })
   }
 
-
   async _onDropItem(event: DragEvent, data: ActorSheet.DropData.Item) {
+    this._hideDragTargets()
+
     // Fetch the item. We only want to override denizens (progress-type items)
     const item = await Item.fromDropData(data)
     if (!item) return false
@@ -104,7 +105,7 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
       itemClass.activateActorSheetListeners(html, this)
     }
 
-    html.on('dragenter', ev => this._maybeShowDragTargets.call(this, ev))
+    html.on('dragenter', (ev) => this._maybeShowDragTargets.call(this, ev))
 
     html.find('.ironsworn__progress__rank').on('click', (ev) => this._setRank.call(this, ev))
     html.find('.ironsworn__progress__mark').on('click', (ev) => this._markProgress.call(this, ev))
@@ -122,7 +123,19 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
   }
 
   _maybeShowDragTargets(_ev: JQuery.DragEnterEvent) {
-    console.log(lastDraggedItemType);
+    if (!lastDraggedItemType) return
+    console.log(lastDraggedItemType)
+    if (['progress', 'delve-theme', 'delve-domain'].includes(lastDraggedItemType)) {
+      this._showDragTargets(lastDraggedItemType)
+    }
+  }
+
+  _showDragTargets(type: string) {
+    console.log(type)
+  }
+
+  _hideDragTargets() {
+    console.log(this)
   }
 
   _setRank(ev: JQuery.ClickEvent) {
@@ -209,7 +222,7 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
 }
 
 let lastDraggedItemType: string | undefined
-Hooks.on('renderCompendium', (_app, html, data) => {
+Hooks.on('renderCompendium', (_app, html) => {
   html.find('.directory-item').on('dragstart', (ev: JQuery.DragStartEvent) => {
     const { documentId } = ev.target.dataset
     const packId = $(ev.target).parents('.compendium').data('pack')

--- a/src/module/actor/sheets/sitesheet.ts
+++ b/src/module/actor/sheets/sitesheet.ts
@@ -40,8 +40,6 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
   }
 
   async _onDropItem(event: DragEvent, data: ActorSheet.DropData.Item) {
-    this._hideDragTargets()
-
     // Fetch the item. We only want to override denizens (progress-type items)
     const item = await Item.fromDropData(data)
     if (!item) return false
@@ -105,9 +103,6 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
       itemClass.activateActorSheetListeners(html, this)
     }
 
-    html.on('dragenter', (ev) => this._maybeShowDragTargets.call(this, ev))
-    html.on('dragleave', (ev) => this._hideDragTargets.call(this, ev))
-
     html.find('.ironsworn__progress__rank').on('click', (ev) => this._setRank.call(this, ev))
     html.find('.ironsworn__progress__mark').on('click', (ev) => this._markProgress.call(this, ev))
     html.find('.ironsworn__progress__clear').on('click', (ev) => this._clearProgress.call(this, ev))
@@ -121,24 +116,6 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
     html.find('.ironsworn__random__denizen').on('click', (ev) => this._randomDenizen.call(this, ev))
     html.find('.ironsworn__foe__compendium').on('click', (ev) => this._foeCompendium.call(this, ev))
     html.find('.ironsworn__denizen__name').on('blur', (ev) => this._setDenizenName.call(this, ev))
-  }
-
-  _maybeShowDragTargets(_ev: JQuery.DragEnterEvent) {
-    if (!lastDraggedItemType) return
-    console.log(lastDraggedItemType)
-    if (['progress', 'delve-theme', 'delve-domain'].includes(lastDraggedItemType)) {
-      this._showDragTargets(lastDraggedItemType)
-    }
-  }
-
-  _showDragTargets(type: string) {
-    console.log(type)
-    $(this.element).find(`.drop-target[data-drop-type="${type}"]`).addClass('drag-highlight')
-  }
-
-  _hideDragTargets(ev?: JQuery.DragLeaveEvent) {
-    console.log(this, ev)
-    $(this.element).find('.drop-target').removeClass('drag-highlight')
   }
 
   _setRank(ev: JQuery.ClickEvent) {
@@ -223,14 +200,3 @@ export class IronswornSiteSheet extends ActorSheet<ActorSheet.Options, Data> {
     this.actor.update({ data: { denizens } }, { render: false })
   }
 }
-
-let lastDraggedItemType: string | undefined
-Hooks.on('renderCompendium', (_app, html) => {
-  html.find('.directory-item').on('dragstart', (ev: JQuery.DragStartEvent) => {
-    const { documentId } = ev.target.dataset
-    const packId = $(ev.target).parents('.compendium').data('pack')
-    const pack = game.packs.get(packId)
-    const indexEntry = pack?.index.get(documentId)
-    lastDraggedItemType = indexEntry?.type
-  })
-})

--- a/src/module/features/dragdrop.ts
+++ b/src/module/features/dragdrop.ts
@@ -1,0 +1,22 @@
+function getIndexEntry(el: HTMLElement): Pick<any, "type"> | undefined {
+  const { documentId } = el.dataset
+  const packId = $(el).parents('.compendium').data('pack')
+  const pack = game.packs.get(packId)
+  return pack?.index.get(documentId || '')
+}
+
+export function activateDragDropListeners() {
+  Hooks.on('renderCompendium', (_app, html) => {
+    html
+      .find('.directory-item')
+      .on('dragstart', (ev: JQuery.DragStartEvent) => {
+        // Add a class to the potential targets
+        const indexEntry = getIndexEntry(ev.target)
+        $(document).find(`.ironsworn__drop__target[data-drop-type="${indexEntry?.type}"]`).addClass('drag-highlight')
+      })
+      .on('dragend', (ev: JQuery.DragEndEvent) => {
+        const indexEntry = getIndexEntry(ev.target)
+        $(document).find(`.ironsworn__drop__target[data-drop-type="${indexEntry?.type}"]`).removeClass('drag-highlight')
+      })
+  })
+}

--- a/src/styles/themes/ironsworn.less
+++ b/src/styles/themes/ironsworn.less
@@ -149,7 +149,7 @@
   }
 
   .drag-highlight {
-    background: red;
+    background: @medium-color;
   }
 
   .stats {

--- a/src/styles/themes/ironsworn.less
+++ b/src/styles/themes/ironsworn.less
@@ -148,6 +148,10 @@
     }
   }
 
+  .drag-highlight {
+    background: red;
+  }
+
   .stats {
     .stat {
       border-color: black;

--- a/src/styles/themes/starforged.less
+++ b/src/styles/themes/starforged.less
@@ -123,6 +123,10 @@ input.highlight:focus {
     }
   }
 
+  .drag-highlight {
+    background: @medium-color;
+  }
+
   .stats {
     .stat {
       border-color: @text-medium-color;

--- a/system/templates/actor/site.hbs
+++ b/system/templates/actor/site.hbs
@@ -14,11 +14,7 @@
   </div>
 
   {{#if actor.data.flags.foundry-ironsworn.edit-mode}}
-  <div
-    class="flexrow drag-target"
-    data-drag-item-type="{{itemtype}}"
-    style="position: absolute; right: 5px; top: 5px;"
-  >
+  <div class="flexrow" style="position: absolute; right: 5px; top: 5px;">
     <div class="clickable block nogrow ironsworn__{{item.type}}__settings" title="{{localize 'IRONSWORN.Edit'}}"
       data-item="{{item.id}}" style="padding: 5px;">
       <i class="fas fa-edit"></i>
@@ -33,11 +29,7 @@
   {{else}}
 
   {{! Prompt to drag an item in }}
-  <div
-    class="flexcol drag-target"
-    data-drag-item-type="{{itemtype}}"
-    style="position: absolute;"
-  >
+  <div class="flexcol">
     <h4 style="margin: 0;">{{localize titlekey}}</h4>
     <p class="inset clickable block ironsworn__compendium__open" style="padding: 0 2em;"
       data-compendium="{{compendiumkey}}">
@@ -51,8 +43,7 @@
 
 {{/inline}}
 
-<form class="{{cssClass}} flexcol" autocomplete="off">
-
+<form class="{{cssClass}} flexcol" autocomplete="off" style="position: relative;">
   <header class="sheet-header">
     <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="50" width="50" />
     <h1 class="charname"><input name="name" type="text" value="{{actor.name}}"
@@ -84,10 +75,10 @@
 
   <div class="boxgroup flexcol nogrow" style="margin-bottom: 1em;">
     <div class="flexrow boxrow nogrow">
-      <div class="flexcol box">
+      <div class="flexcol box drop-target" data-drop-type="delve-theme">
         {{>subcard titlekey='IRONSWORN.Theme' item=theme itemtype='delve-theme' compendiumkey='ironsworndelvethemes'}}
       </div>
-      <div class="flexcol box">
+      <div class="flexcol box drop-target" data-drop-type="delve-domain">
         {{>subcard titlekey='IRONSWORN.Domain' item=domain itemtype='delve-domain' compendiumkey='ironsworndelvedomains'}}
       </div>
     </div>
@@ -160,7 +151,12 @@
     {{#each denizenMatrix}}
     <div class="flexrow boxrow">
       {{#each this}}
-      <div class="box flexrow ironsworn__denizen__drop" style="padding: 3px;" data-idx="{{idx}}">
+      <div
+        class="box flexrow ironsworn__denizen__drop drop-target"
+        data-drop-type="progress"
+        style="padding: 3px;"
+        data-idx="{{idx}}"
+      >
         <label class="nogrow" style="white-space: nowrap; flex-basis: 4em; line-height: 26px;">
           {{#if (eq denizen.low denizen.high)}}
           {{denizen.low}}

--- a/system/templates/actor/site.hbs
+++ b/system/templates/actor/site.hbs
@@ -75,10 +75,10 @@
 
   <div class="boxgroup flexcol nogrow" style="margin-bottom: 1em;">
     <div class="flexrow boxrow nogrow">
-      <div class="flexcol box drop-target" data-drop-type="delve-theme">
+      <div class="flexcol box ironsworn__drop__target" data-drop-type="delve-theme">
         {{>subcard titlekey='IRONSWORN.Theme' item=theme itemtype='delve-theme' compendiumkey='ironsworndelvethemes'}}
       </div>
-      <div class="flexcol box drop-target" data-drop-type="delve-domain">
+      <div class="flexcol box ironsworn__drop__target" data-drop-type="delve-domain">
         {{>subcard titlekey='IRONSWORN.Domain' item=domain itemtype='delve-domain' compendiumkey='ironsworndelvedomains'}}
       </div>
     </div>
@@ -152,7 +152,7 @@
     <div class="flexrow boxrow">
       {{#each this}}
       <div
-        class="box flexrow ironsworn__denizen__drop drop-target"
+        class="box flexrow ironsworn__denizen__drop ironsworn__drop__target"
         data-drop-type="progress"
         style="padding: 3px;"
         data-idx="{{idx}}"

--- a/system/templates/actor/site.hbs
+++ b/system/templates/actor/site.hbs
@@ -14,7 +14,11 @@
   </div>
 
   {{#if actor.data.flags.foundry-ironsworn.edit-mode}}
-  <div class="flexrow" style="position: absolute; right: 5px; top: 5px;">
+  <div
+    class="flexrow drag-target"
+    data-drag-item-type="{{itemtype}}"
+    style="position: absolute; right: 5px; top: 5px;"
+  >
     <div class="clickable block nogrow ironsworn__{{item.type}}__settings" title="{{localize 'IRONSWORN.Edit'}}"
       data-item="{{item.id}}" style="padding: 5px;">
       <i class="fas fa-edit"></i>
@@ -29,7 +33,11 @@
   {{else}}
 
   {{! Prompt to drag an item in }}
-  <div class="flexcol">
+  <div
+    class="flexcol drag-target"
+    data-drag-item-type="{{itemtype}}"
+    style="position: absolute;"
+  >
     <h4 style="margin: 0;">{{localize titlekey}}</h4>
     <p class="inset clickable block ironsworn__compendium__open" style="padding: 0 2em;"
       data-compendium="{{compendiumkey}}">
@@ -77,10 +85,10 @@
   <div class="boxgroup flexcol nogrow" style="margin-bottom: 1em;">
     <div class="flexrow boxrow nogrow">
       <div class="flexcol box">
-        {{>subcard titlekey='IRONSWORN.Theme' item=theme compendiumkey='ironsworndelvethemes'}}
+        {{>subcard titlekey='IRONSWORN.Theme' item=theme itemtype='delve-theme' compendiumkey='ironsworndelvethemes'}}
       </div>
       <div class="flexcol box">
-        {{>subcard titlekey='IRONSWORN.Domain' item=domain compendiumkey='ironsworndelvedomains'}}
+        {{>subcard titlekey='IRONSWORN.Domain' item=domain itemtype='delve-domain' compendiumkey='ironsworndelvedomains'}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
It's not super discoverable that you can drag foes into denizen slots. This adds some UI niceness that can help with that - highlighting valid drop targets when you drag in a theme/domain/progress.

- [x] Hook to record inbound item type
- [x] Functions to  show/hide the targets
- [x] Markup for drop-target elements
- [x] Update CHANGELOG.md
