### PR TITLE
Fix some bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Streamline and downsize some text in the character sheet ([#109](https://github.com/ben/foundry-ironsworn/pull/109))
+- Fix a few bugs ([#116](https://github.com/ben/foundry-ironsworn/pull/116))
 
 ## 1.4.4
 

--- a/script/dataswornImport.js
+++ b/script/dataswornImport.js
@@ -21,6 +21,11 @@ function processMove(move) {
   let [_, description, strong, weak, miss] = move.Text.match(resultRegex) || []
   let extradescription, extrastrong, extraweak, extramiss
 
+  // Fixup for Companion Endure Harm, it includes a stat that's hard to implement
+  if (move.Name === 'Companion Endure Harm') {
+    move.Stats = move.Stats.filter(x => x !== 'companion health')
+  }
+
   // Fixup for Delve the Depths; the table is in the wrong place
   if (move.Name === 'Delve the Depths') {
     const tableRegex = /(Edge\s+\|\s+Shadow[\s\S]+)/

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -27,7 +27,7 @@ export class IronswornChatCard {
     html.find('.burn-momentum').on('click', (ev) => this._burnMomentum.call(this, ev))
     html.find('.ironsworn__delvedepths__roll').on('click', (ev) => this._delveDepths.call(this, ev))
     html.find('.ironsworn__revealdanger__roll').on('click', (ev) => this._revealDanger.call(this, ev))
-    html.find('.ironsworn__sojourn__extra__roll').on('click', ev => this._sojournExtra.call(this, ev))
+    html.find('.ironsworn__sojourn__extra__roll').on('click', (ev) => this._sojournExtra.call(this, ev))
   }
 
   async _burnMomentum(ev: JQuery.ClickEvent) {
@@ -39,11 +39,18 @@ export class IronswornChatCard {
     theActor?.burnMomentum()
 
     let bonusContent: string | undefined
-    let result: string | undefined
+    let result: string
     if (move) {
       const theMove = await moveDataByName(move)
       result = theMove && theMove[capitalize(hittype.toLowerCase())]
       bonusContent = MoveContentCallbacks[move]?.call(this, { hitType: hittype as HIT_TYPE, stat })
+    } else {
+      // I wish this were easier
+      const i18nKey =
+        hittype === HIT_TYPE.STRONG ? 'StrongHit' :
+        hittype === HIT_TYPE.WEAK ? 'WeakHit' :
+        'Miss'
+      result = `<strong>${game.i18n.localize('IRONSWORN.' + i18nKey)}</strong>`
     }
 
     const parent = $(ev.currentTarget).parents('.message-content')
@@ -51,7 +58,7 @@ export class IronswornChatCard {
     parent.find('.roll-result button').prop('disabled', true)
     parent.find('.momentum-burn').html(`
       <h3>${game.i18n.localize('IRONSWORN.MomentumBurnt')}</h3>
-      ${result}
+      ${result || ''}
       ${bonusContent || ''}
     `)
 
@@ -128,7 +135,7 @@ export class IronswornChatCard {
     delete move.ExtraDescription
 
     const actor = defaultActor()
-    RollDialog.show({move, actor})
+    RollDialog.show({ move, actor })
   }
 
   async replaceSelectorWith(el: HTMLElement, selector: string, newContent: string) {

--- a/src/module/helpers/handlebars.ts
+++ b/src/module/helpers/handlebars.ts
@@ -37,7 +37,7 @@ export class IronswornHandlebarsHelpers {
       const d = terms.shift()
       const classes = classesForRoll(r)
       const termStrings = terms.map((t) => t.operator || t.number)
-      return `<strong><span class="roll ${classes}">${d?.total || d}</span>${termStrings.join('')}</strong>`
+      return `<strong><span class="roll ${classes}">${d?.total || 0}</span>${termStrings.join('')}</strong>`
     })
 
     Handlebars.registerHelper('challengeDice', function () {

--- a/system/assets/moves.json
+++ b/system/assets/moves.json
@@ -389,8 +389,7 @@
             "Page": "94"
           },
           "Stats": [
-            "heart",
-            "companion health"
+            "heart"
           ],
           "Description": "<p>When <strong>your companion faces physical damage</strong>, they suffer -health equal to the amount of harm inflicted. If your companion’s health is 0, exchange any leftover -health for -momentum. Then, roll +heart or +your companion’s health, whichever is higher.</p>\n",
           "Strong": "<p>On a <strong>strong hit</strong>, your companion rallies. Give them +1 health.</p>\n",


### PR DESCRIPTION
This fixes a few issues reported by players:

- [x] #113 was caused by Javascript treating `0` as falsy and me not providing the right fallback value
- [x] #114 is because "companion health" isn't a stat the system recognizes, and can't find to roll against
- [x] #115 was incomplete rolling logic when there was no move involved
- [x] Update CHANGELOG.md

For #114, I'm just removing that stat from the list now, but in the future it'd be good to find all the "companion" assets and list their health stats in the move box and roll dialog.