### PR TITLE
Better visibility for negative-momentum-canceled action dice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Make tick marks a bit less square ([#138](https://github.com/ben/foundry-ironsworn/pull/138))
 - Add a v2 site sheet based on vue ([#133](https://github.com/ben/foundry-ironsworn/pull/133))
 - Fix a bug in the v2 character sheet ([#139](https://github.com/ben/foundry-ironsworn/pull/139))
+- Make canceled action dice more visible ([#140](https://github.com/ben/foundry-ironsworn/pull/140))
 
 ## 1.6.2
 

--- a/src/module/helpers/handlebars.ts
+++ b/src/module/helpers/handlebars.ts
@@ -2,10 +2,24 @@ import { range } from 'lodash'
 import { RANKS } from '../constants'
 import { capitalize } from './util'
 
-function classesForRoll(r) {
+interface RollClassesOptions {
+  canceled: boolean
+}
+function classesForRoll(r, opts?: Partial<RollClassesOptions>) {
+  const theOpts = {
+    ...{ canceled: false },
+    ...opts
+  }
   const d = r.dice[0]
   const maxRoll = d?.faces || 10
-  return [d?.constructor.name.toLowerCase(), d && 'd' + d.faces, (d?.total || r.result) <= 1 ? 'min' : null, (d?.total || r.result) == maxRoll ? 'max' : null].filter((x) => x).join(' ')
+  return [
+    d?.constructor.name.toLowerCase(),
+    d && 'd' + d.faces,
+    (d?.total || r.result) <= 1 ? 'min' : null,
+    (d?.total || r.result) == maxRoll ? 'max' : null,
+    theOpts.canceled ? 'canceled' : null,
+  ].filter((x) => x)
+  .join(' ')
 }
 
 const actionRoll = (roll) => roll.terms[0].rolls.find((r) => r.dice.length === 0 || r.dice[0].faces === 6)
@@ -35,7 +49,7 @@ export class IronswornHandlebarsHelpers {
       const r = actionRoll(this.roll)
       const terms = [...r.terms]
       const d = terms.shift()
-      const classes = classesForRoll(r)
+      const classes = classesForRoll(r, { canceled: this.negativeMomentumCancel })
       const termStrings = terms.map((t) => t.operator || t.number)
       return `<strong><span class="roll ${classes}">${d?.total || 0}</span>${termStrings.join('')}</strong>`
     })

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -510,4 +510,8 @@ hr {
     color: #18520b;
     filter: sepia(0.5) hue-rotate(60deg);
   }
+
+  .roll.canceled {
+    filter: drop-shadow(0px 0px 5px orange);
+  }
 }


### PR DESCRIPTION
Fixes #136. Before:

<img width="288" alt="image" src="https://user-images.githubusercontent.com/39902/136665703-88a8a7ff-8bde-45bc-b00e-10a5262adfd6.png">

After:

<img width="290" alt="image" src="https://user-images.githubusercontent.com/39902/136665698-ad2876e4-0c3c-4721-bed4-0009965d4b1c.png">


- [x] Update CHANGELOG.md
