### PR TITLE
Roll dialog: actor select if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Actor select in move dialog if needed ([#142](https://github.com/ben/foundry-ironsworn/pull/142))
+
 ## 1.6.4
 
 - Make the Vue site sheet the default ([#141](https://github.com/ben/foundry-ironsworn/pull/141))

--- a/src/module/helpers/roll.ts
+++ b/src/module/helpers/roll.ts
@@ -42,10 +42,15 @@ export class RollDialog extends Dialog {
     const template = 'systems/foundry-ironsworn/templates/roll-dialog.hbs'
     const renderOpts = { ...opts } as any
     if (!opts.actor) {
-      renderOpts.allCharacters = sortBy(
+      const allCharacters = sortBy(
         game.actors?.filter((x) => x.type === 'character'),
         'name'
       )
+      if (allCharacters.length === 1) {
+        renderOpts.actor = allCharacters[0]
+      } else {
+        renderOpts.allCharacters = allCharacters
+      }
     }
     const content = await renderTemplate(template, renderOpts)
 

--- a/src/module/helpers/roll.ts
+++ b/src/module/helpers/roll.ts
@@ -50,6 +50,7 @@ export class RollDialog extends Dialog {
         renderOpts.actor = allCharacters[0]
       } else {
         renderOpts.allCharacters = allCharacters
+        renderOpts.mruCharacter = opts.site?.getFlag('foundry-ironsworn', 'mru-character')
       }
     }
     const content = await renderTemplate(template, renderOpts)
@@ -57,7 +58,11 @@ export class RollDialog extends Dialog {
     const callbackForStat = (stat: string) => (x) => {
       const form = x[0].querySelector('form')
       const bonus = form.bonus.value ? parseInt(form.bonus.value, 10) : undefined
-      const actor = opts.actor ?? game.actors?.get(form.char.value)
+      let actor = opts.actor
+      if (form.char?.value) {
+        actor = game.actors?.get(form.char.value)
+        opts.site?.setFlag('foundry-ironsworn', 'mru-character', actor?.id)
+      }
       this.rollAndCreateChatMessage({
         ...opts,
         actor,

--- a/src/module/vue/components/site/site-movebox.vue
+++ b/src/module/vue/components/site/site-movebox.vue
@@ -26,8 +26,7 @@ export default {
   methods: {
     async click() {
       const move = await CONFIG.IRONSWORN.moveDataByName(this.move)
-      const actor = CONFIG.IRONSWORN.defaultActor()
-      CONFIG.IRONSWORN.RollDialog.show({ move, actor, site: this.actor })
+      CONFIG.IRONSWORN.RollDialog.show({ move, site: this.ironswornActor })
     },
   },
 }

--- a/src/module/vue/site-sheet.vue
+++ b/src/module/vue/site-sheet.vue
@@ -185,14 +185,12 @@ export default {
       const move = await CONFIG.IRONSWORN.moveDataByName(
         'Locate Your Objective'
       )
-      const actor = CONFIG.IRONSWORN.defaultActor()
       const progress = Math.floor(this.actor.data.current / 4)
       const roll = new Roll(`{${progress}, d10, d10}`)
       CONFIG.IRONSWORN.createIronswornChatRoll({
         isProgress: true,
         move,
         roll,
-        actor,
         subtitle: this.actor.name || undefined,
       })
     },

--- a/system/templates/roll-dialog.hbs
+++ b/system/templates/roll-dialog.hbs
@@ -8,4 +8,15 @@
     <label>{{localize 'IRONSWORN.Bonus'}}</label>
     <input type="number" step="1" name="bonus" />
   </div>
+
+  {{#unless actor}}
+  <div class="form-group">
+    <label for="char">{{localize 'IRONSWORN.Character'}}</label>
+    <select name="char">
+      {{#each allCharacters}}
+      <option value="{{id}}">{{name}}</option>
+      {{/each}}
+    </select>
+  </div>
+  {{/unless}}
 </form>

--- a/system/templates/roll-dialog.hbs
+++ b/system/templates/roll-dialog.hbs
@@ -1,7 +1,7 @@
 <form>
   {{#if move}}
-    <div>{{{enrichHtml move.Description}}}</div>
-    <hr>
+  <div>{{{enrichHtml move.Description}}}</div>
+  <hr>
   {{/if}}
 
   <div class="form-group">
@@ -14,7 +14,9 @@
     <label for="char">{{localize 'IRONSWORN.Character'}}</label>
     <select name="char">
       {{#each allCharacters}}
-      <option value="{{id}}">{{name}}</option>
+      <option value="{{id}}" {{#if (eq ../mruCharacter id)}}selected{{/if}}>
+        {{name}}
+      </option>
       {{/each}}
     </select>
   </div>


### PR DESCRIPTION
The `defaultActor` helper does a confusing thing invisibly sometimes, so let's get rid of it if we can. This adds an extra drop-down to the move dialog, which lets the player choose a character if there is more than one choice to make.

- [x] Add widget to the dialog
- [x] Remember the choice in a flag on the site
- [x] Update CHANGELOG.md
