### PR TITLE
Starforged truths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Add Starforged setting-truths dialog([#178](https://github.com/ben/foundry-ironsworn/pull/178))
+
 ## 1.9.0
 
 - Add french localization ([#175](https://github.com/ben/foundry-ironsworn/pull/175))

--- a/script/dataforgedimport.js
+++ b/script/dataforgedimport.js
@@ -1,0 +1,59 @@
+const marked = require('marked')
+const fetch = require('node-fetch')
+const fs = require('fs/promises')
+const util = require('util')
+
+function renderHtml(text) {
+  return marked(text.replace(/(roll ?)?\+(iron|edge|wits|shadow|heart|health|spirit|supply)/gi, '((rollplus $2))'), { gfm: true })
+}
+
+async function dataforgedJson(name) {
+  const resp = await fetch(`https://raw.githubusercontent.com/rsek/dataforged/main/${name}.json`)
+  return resp.json()
+}
+
+async function writeLocal(name, obj) {
+  return fs.writeFile(`system/assets/${name}.json`, JSON.stringify(obj, null, 2) + '\n')
+}
+
+async function doit() {
+  const en = JSON.parse(await fs.readFile('system/lang/en.json'))
+
+  console.log('Truths:')
+  console.log('  Fetching')
+  const truthsJson = await dataforgedJson('setting_truths')
+
+  console.log('  Writing')
+  await writeLocal('sf-setting-truths', truthsJson)
+
+  en.IRONSWORN.SFSettingTruths ||= {}
+  for (const truthCategory of truthsJson['Setting Truths']) {
+    en.IRONSWORN.SFSettingTruths[truthCategory.Name] = {
+      ...en.IRONSWORN.SFSettingTruths[truthCategory.Name],
+      name: truthCategory.Name,
+    }
+    for (let i = 0; i < truthCategory.Table.length; i++) {
+      const option = truthCategory.Table[i]
+      const blob = {
+        Description: option.Description,
+        Details: option.Details,
+        Quest: option['Quest Starter'],
+      }
+      for (let j = 0; j < (option.Table || []).length; j++) {
+        blob[`suboption${j + 1}`] = option.Table[j].Description
+      }
+      en.IRONSWORN.SFSettingTruths[truthCategory.Name][`option${i + 1}`] = blob
+    }
+  }
+
+  console.log('Writing en.json')
+  await fs.writeFile('system/lang/en.json', JSON.stringify(en, null, 2) + '\n')
+}
+
+doit().then(
+  () => process.exit(),
+  (err) => {
+    console.error(err)
+    process.exit(-1)
+  }
+)

--- a/src/module/applications/sfSettingTruthsDialog.ts
+++ b/src/module/applications/sfSettingTruthsDialog.ts
@@ -7,7 +7,7 @@ export class SFSettingTruthsDialog extends FormApplication<FormApplication.Optio
 
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
-      title: game.i18n.localize('IRONSWORN.YourWorldTruths'),
+      title: game.i18n.localize('IRONSWORN.SFSettingTruthsTitle'),
       template: 'systems/foundry-ironsworn/templates/sf-truths.hbs',
       id: 'setting-truths-dialog',
       resizable: true,

--- a/src/module/applications/sfSettingTruthsDialog.ts
+++ b/src/module/applications/sfSettingTruthsDialog.ts
@@ -1,0 +1,79 @@
+import { IronswornSettings } from '../helpers/settings'
+
+export class SFSettingTruthsDialog extends FormApplication<FormApplication.Options> {
+  constructor() {
+    super({})
+  }
+
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      title: game.i18n.localize('IRONSWORN.YourWorldTruths'),
+      template: 'systems/foundry-ironsworn/templates/sf-truths.hbs',
+      id: 'setting-truths-dialog',
+      resizable: true,
+      classes: ['ironsworn', 'sheet', 'setting-truths', `theme-${IronswornSettings.theme}`],
+      width: 600,
+      height: 700,
+    } as FormApplication.Options)
+  }
+
+  async _updateObject() {
+    // Nothing to do
+  }
+
+  async getData() {
+    const truths = await fetch('systems/foundry-ironsworn/assets/sf-setting-truths.json').then((x) => x.json())
+
+    // Run truths text through I18n
+    for (const category of truths['Setting Truths']) {
+      const i18nBaseKey = `IRONSWORN.SFSettingTruths.${category.Name}`
+      category.Name = game.i18n.localize(`${i18nBaseKey}.name`)
+      for (let i = 0; i < category.Table.length; i++) {
+        const option = category.Table[i]
+        const i18nOptionBaseKey = `${i18nBaseKey}.option${i + 1}`
+        option.Description = game.i18n.localize(`${i18nOptionBaseKey}.Description`)
+        option.Details = game.i18n.localize(`${i18nOptionBaseKey}.Details`)
+        option.Quest = game.i18n.localize(`${i18nOptionBaseKey}.Quest`)
+        for (let j = 0; j < (option.Table || []).length; j++) {
+          option.Table[j].Description = game.i18n.localize(`${i18nOptionBaseKey}.suboption${j + 1}`)
+        }
+      }
+    }
+
+    return mergeObject(super.getData(), {
+      truths,
+    })
+  }
+
+  activateListeners(html: JQuery) {
+    super.activateListeners(html)
+
+    html.find('.ironsworn__custom__truth').on('focus', (ev) => this._customTruthFocus.call(this, ev))
+    html.find('.ironsworn__save__truths').on('click', (ev) => this._save.call(this, ev))
+  }
+
+  _customTruthFocus(ev: JQuery.FocusEvent) {
+    $(ev.currentTarget).siblings('input').prop('checked', true)
+  }
+
+  async _save(ev: JQuery.ClickEvent) {
+    ev.preventDefault()
+
+    // Get elements that are checked
+    const sections: string[] = []
+    for (const radio of this.element.find(':checked')) {
+      const { category } = radio.dataset
+      const descriptionElement = $(radio).parent().find('.description')
+      const description = descriptionElement.html() || `<p>${descriptionElement.val()}</p>`
+      sections.push(`<h2>${category}</h2> ${description}`)
+    }
+    console.log(sections)
+
+    // const journal = await JournalEntry.create({
+    //   name: game.i18n.localize('IRONSWORN.YourWorldTruths'),
+    //   content: sections.join('\n'),
+    // })
+    // journal?.sheet?.render(true)
+    this.close()
+  }
+}

--- a/src/module/applications/vueSfSettingTruthsDialog.ts
+++ b/src/module/applications/vueSfSettingTruthsDialog.ts
@@ -1,7 +1,6 @@
 import { VueApplication } from './vueapp'
 
 export class sfSettingTruthsDialogVue extends VueApplication {
-
   constructor() {
     super({})
   }
@@ -20,7 +19,19 @@ export class sfSettingTruthsDialogVue extends VueApplication {
   async getData(_options?: Application.RenderOptions): Promise<Record<string, unknown>> {
     const truths = await fetch('systems/foundry-ironsworn/assets/sf-setting-truths.json').then((x) => x.json())
     return {
-      truths: truths['Setting Truths']
+      truths: truths['Setting Truths'],
     }
+  }
+
+  activateVueListeners(html: JQuery<HTMLElement>, repeat?: boolean): void {
+    super.activateVueListeners(html, repeat)
+    this._vm?.$on('submit', async (content) => {
+      const journal = await JournalEntry.create({
+        name: game.i18n.localize('IRONSWORN.SFSettingTruthsTitle'),
+        content,
+      })
+      journal?.sheet?.render(true)
+      this.close()
+    })
   }
 }

--- a/src/module/applications/vueSfSettingTruthsDialog.ts
+++ b/src/module/applications/vueSfSettingTruthsDialog.ts
@@ -16,4 +16,11 @@ export class sfSettingTruthsDialogVue extends VueApplication {
       height: 700,
     })
   }
+
+  async getData(_options?: Application.RenderOptions): Promise<Record<string, unknown>> {
+    const truths = await fetch('systems/foundry-ironsworn/assets/sf-setting-truths.json').then((x) => x.json())
+    return {
+      truths: truths['Setting Truths']
+    }
+  }
 }

--- a/src/module/applications/vueSfSettingTruthsDialog.ts
+++ b/src/module/applications/vueSfSettingTruthsDialog.ts
@@ -1,0 +1,19 @@
+import { VueApplication } from './vueapp'
+
+export class sfSettingTruthsDialogVue extends VueApplication {
+
+  constructor() {
+    super({})
+  }
+
+  static get defaultOptions(): Application.Options {
+    return mergeObject(super.defaultOptions, {
+      title: game.i18n.localize('IRONSWORN.SFSettingTruthsTitle'),
+      template: 'systems/foundry-ironsworn/templates/sf-truths-vue.hbs',
+      id: 'setting-truths-dialog',
+      resizable: true,
+      width: 600,
+      height: 700,
+    })
+  }
+}

--- a/src/module/applications/vueapp.ts
+++ b/src/module/applications/vueapp.ts
@@ -16,9 +16,9 @@ export class VueApplication extends Application {
     })
   }
 
-  render(force?: boolean, inputOptions?: Application.RenderOptions) {
+  async render(force?: boolean, inputOptions?: Application.RenderOptions) {
     const options: Application.RenderOptions = inputOptions ?? {}
-    const appData = this.getData() as any
+    const appData = await this.getData() as any
 
     // Exit if Vue has already rendered.
     if (this._vm) {

--- a/src/module/applications/vueapp.ts
+++ b/src/module/applications/vueapp.ts
@@ -1,0 +1,83 @@
+import Vue from 'vue'
+import { IronswornSettings } from '../helpers/settings'
+
+export class VueApplication extends Application {
+  _vm: (Vue & Record<string, any>) | null
+
+  /** @override */
+  constructor(options) {
+    super(options)
+    this._vm = null
+  }
+
+  static get defaultOptions(): Application.Options {
+    return mergeObject(super.defaultOptions, {
+      classes: ['ironsworn', 'sheet', 'item', `theme-${IronswornSettings.theme}`],
+    })
+  }
+
+  render(force?: boolean, inputOptions?: Application.RenderOptions) {
+    const options: Application.RenderOptions = inputOptions ?? {}
+    const appData = this.getData() as any
+
+    // Exit if Vue has already rendered.
+    if (this._vm) {
+      const states = Application.RENDER_STATES
+      if (this._state == states.RENDERING || this._state == states.RENDERED) {
+        // Update the Vue app with our updated item/flag data.
+        if (appData?.data) Vue.set(this._vm.item, 'data', appData.data)
+        if (appData?.item?.flags) Vue.set(this._vm.item, 'flags', appData.item.flags)
+        this.activateVueListeners($(this.element), true)
+        return this
+      }
+      // TODO: Is destroying the app necessary?
+      // else {
+      //   this._vm.$destroy();
+      //   this._vm = null;
+      // }
+    }
+    // Run the normal Foundry render once.
+    this._render(force, options)
+      .catch((err) => {
+        err.message = `An error occurred while rendering ${this.constructor.name} ${this.appId}: ${err.message}`
+        console.error(err)
+        this._state = Application.RENDER_STATES.ERROR
+      })
+      // Run Vue's render, assign it to our prop for tracking.
+      .then((_rendered) => {
+        // Prepare the item data.
+        const el = this.element.find('.ironsworn-vueport')
+        // Render Vue and assign it to prevent later rendering.
+        VuePort.render(null, el[0], { data: appData }).then((vm) => {
+          this._vm = vm
+          const html = $(this.element)
+          this.activateVueListeners(html)
+        })
+      })
+
+    // Return per the overridden method.
+    return this
+  }
+
+  /**
+   * Activate additional listeners on the rendered Vue app.
+   * @param {jQuery} html
+   */
+  activateVueListeners(html: JQuery, repeat = false) {
+    // Place one-time executions after this line.
+    if (repeat) return
+
+    // Input listeners.
+    const inputs = '.section input[type="text"], .section input[type="number"]'
+    html.on('focus', inputs, (event) => this._onFocus(event))
+  }
+
+  _onFocus(event) {
+    const target = event.currentTarget
+    setTimeout(function () {
+      if (target == document.activeElement) {
+        $(target).trigger('select')
+      }
+    }, 100)
+  }
+}

--- a/src/module/applications/worldTruthsDialog.ts
+++ b/src/module/applications/worldTruthsDialog.ts
@@ -1,4 +1,5 @@
 import { IronswornSettings } from '../helpers/settings'
+import { SFSettingTruthsDialog } from './sfSettingTruthsDialog'
 
 export class WorldTruthsDialog extends FormApplication<FormApplication.Options> {
   constructor() {
@@ -91,6 +92,13 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
           label: 'Yes',
           callback: () => new WorldTruthsDialog().render(true),
         },
+        sfyes: (game.settings.get('foundry-ironsworn', 'starforged-beta')
+          ? {
+              icon: '<i class="fas fa-user-astronaut"></i>',
+              label: 'Yes (SF)',
+              callback: () => new SFSettingTruthsDialog().render(true),
+            }
+          : undefined) as any,
         no: {
           icon: '<i class="fas fa-times"></i>',
           label: 'Not this time',
@@ -103,9 +111,7 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
           },
         },
       },
-      default: 'two',
-      render: (_html) => console.log('Register interactivity in the rendered dialog'),
-      close: (_html) => console.log('This always is logged no matter which option is chosen'),
+      default: 'yes',
     })
     d.render(true)
   }

--- a/src/module/applications/worldTruthsDialog.ts
+++ b/src/module/applications/worldTruthsDialog.ts
@@ -1,5 +1,5 @@
 import { IronswornSettings } from '../helpers/settings'
-import { SFSettingTruthsDialog } from './sfSettingTruthsDialog'
+import { sfSettingTruthsDialogVue } from './vueSfSettingTruthsDialog'
 
 export class WorldTruthsDialog extends FormApplication<FormApplication.Options> {
   constructor() {
@@ -96,7 +96,7 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
           ? {
               icon: '<i class="fas fa-user-astronaut"></i>',
               label: 'Yes (SF)',
-              callback: () => new SFSettingTruthsDialog().render(true),
+              callback: () => new sfSettingTruthsDialogVue().render(true),
             }
           : undefined) as any,
         no: {

--- a/src/module/applications/worldTruthsDialog.ts
+++ b/src/module/applications/worldTruthsDialog.ts
@@ -78,9 +78,12 @@ export class WorldTruthsDialog extends FormApplication<FormApplication.Options> 
     }
 
     // Bail if the truths journal entry already exists
-    const journal = game.journal?.find((x) => x.name === game.i18n.localize('IRONSWORN.YourWorldTruths'))
-    if (journal) {
-      return
+    const keysToTry = ['IRONSWORN.YourWorldTruths', 'IRONSWORN.SFSettingTruthsTitle']
+    for (const i18nkey of keysToTry) {
+      const journal = game.journal?.find((x) => x.name === game.i18n.localize(i18nkey))
+      if (journal) {
+        return
+      }
     }
 
     const d = new Dialog({

--- a/src/module/helpers/settings.ts
+++ b/src/module/helpers/settings.ts
@@ -43,6 +43,15 @@ export class IronswornSettings {
       default: true,
     })
 
+    game.settings.register('foundry-ironsworn', 'starforged-beta', {
+      name: 'IRONSWORN.Settings.SFBeta.Name',
+      hint: 'IRONSWORN.Settings.SFBeta.Hint',
+      scope: 'world',
+      config: true,
+      type: Boolean,
+      default: false,
+    })
+
     game.settings.register('foundry-ironsworn', 'data-version', {
       scope: 'world',
       config: false,

--- a/src/module/vue/components/sf-truth.vue
+++ b/src/module/vue/components/sf-truth.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="flexrow">
+    <input
+      type="radio"
+      :name="radiogroup"
+      :id="radioid"
+      class="nogrow"
+      style="flex: 0 0 20px; margin: 8px"
+      v-model="picked"
+    />
+    <div class="flexcol">
+      <label :for="radioid">
+        <p>
+          <strong>{{ description }}</strong>
+        </p>
+        <p>{{ details }}</p>
+
+        <!-- TODO: table -->
+
+        <p>
+          <em>{{ $t('IRONSWORN.TruthQuestStarter') }}{{ quest }}</em>
+        </p>
+      </label>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    radiogroup: String,
+    description: String,
+    details: String,
+    quest: String,
+    table: Array,
+  },
+
+  computed: {
+    radioid() {
+      return `${this.radiogroup}#${this.description}`
+    },
+  },
+
+  data() {
+    return {
+      picked: null,
+    }
+  },
+}
+</script>

--- a/src/module/vue/components/sf-truth.vue
+++ b/src/module/vue/components/sf-truth.vue
@@ -16,7 +16,7 @@
         </p>
         <p>{{ details }}</p>
 
-        <transition name="slide">
+        <transition name="slide" v-if="table">
           <div v-if="selected">
             <div
               class="flexrow"
@@ -85,9 +85,10 @@ export default {
     },
 
     radiovalue() {
+      const subOptionText = this.subOptionDescription ? `(${this.subOptionDescription})` : ''
       return `
         <p><strong>${this.description}</strong></p>
-        <p>${this.details} ${this.subOptionDescription}</p>
+        <p>${this.details} ${subOptionText}</p>
         <p><em>${this.$t('IRONSWORN.TruthQuestStarter')} ${this.quest}</em></p>
       `
     },

--- a/src/module/vue/components/sf-truth.vue
+++ b/src/module/vue/components/sf-truth.vue
@@ -2,11 +2,12 @@
   <div class="flexrow">
     <input
       type="radio"
-      :name="radiogroup"
-      :id="radioid"
       class="nogrow"
       style="flex: 0 0 20px; margin: 8px"
-      v-model="picked"
+      :name="radiogroup"
+      :id="radioid"
+      :value="radiovalue"
+      @change="changed"
     />
     <div class="flexcol">
       <label :for="radioid">
@@ -15,15 +16,58 @@
         </p>
         <p>{{ details }}</p>
 
-        <!-- TODO: table -->
+        <transition name="slide">
+          <div v-if="selected">
+            <div
+              class="flexrow"
+              v-for="(suboption) in table"
+              :key="suboption.Description"
+            >
+              <input
+                type="radio"
+                class="nogrow"
+                style="flex: 0 0 20px; margin: 8px"
+                :name="description"
+                :id="`${description}#${suboption.Description}`"
+                :value="suboption.Description"
+                v-model="subOptionDescription"
+                @change="changed"
+              />
+              <label :for="`${description}#${suboption.Description}`">
+                <p>{{ suboption.Description }}</p>
+              </label>
+            </div>
+          </div>
+        </transition>
 
         <p>
-          <em>{{ $t('IRONSWORN.TruthQuestStarter') }}{{ quest }}</em>
+          <em>{{ $t('IRONSWORN.TruthQuestStarter') }} {{ quest }}</em>
         </p>
       </label>
     </div>
   </div>
 </template>
+
+<style lang="less" scoped>
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.4s ease;
+  overflow: hidden;
+  max-height: 225px;
+  opacity: 1;
+}
+.slide-enter,
+.slide-leave-to {
+  max-height: 0;
+  opacity: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-top: 0;
+  border-bottom: 0;
+}
+</style>
 
 <script>
 export default {
@@ -39,12 +83,28 @@ export default {
     radioid() {
       return `${this.radiogroup}#${this.description}`
     },
+
+    radiovalue() {
+      return `
+        <p><strong>${this.description}</strong></p>
+        <p>${this.details} ${this.subOptionDescription}</p>
+        <p><em>${this.$t('IRONSWORN.TruthQuestStarter')} ${this.quest}</em></p>
+      `
+    },
   },
 
   data() {
     return {
-      picked: null,
+      selected: false,
+      subOptionDescription: '',
     }
+  },
+
+  methods: {
+    changed(evt) {
+      this.selected = evt.target.checked
+      this.$emit('change', this.radiogroup, this.radiovalue)
+    },
   },
 }
 </script>

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -1,11 +1,36 @@
 <template>
   <div class="flexcol">
-    <h1>TRUTHS</h1>
+    <div v-for="truth in truths" :key="truth.Name">
+      <h2 style="margin-top: 1em">{{ truth.Name }}</h2>
+
+      <sf-truth
+        v-for="(option, i) in truth.Table"
+        :key="i"
+        :radiogroup="truth.Name"
+        :description="option.Description"
+        :details="option.Details"
+        :quest="option['Quest Starter']"
+        :table="option.Table"
+      />
+    </div>
   </div>
 </template>
 
 <script>
 export default {
+  props: {
+    truths: Array,
+  },
 
+  data() {
+    const picked = {}
+    for (const option of this.truths) {
+      picked[option.Name] = null
+
+      for (let i = 0; i < (option.Table ?? []).length; i++) {}
+    }
+
+    return { picked }
+  },
 }
 </script>

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -1,18 +1,28 @@
 <template>
   <div class="flexcol">
-    <div v-for="truth in truths" :key="truth.Name">
-      <h2 style="margin-top: 1em">{{ truth.Name }}</h2>
+    <div v-for="category in truths" :key="category.Name">
+      <h2 style="margin-top: 1em">{{ category.Name }}</h2>
 
       <sf-truth
-        v-for="(option, i) in truth.Table"
-        :key="i"
-        :radiogroup="truth.Name"
+        v-for="(option) in category.Table"
+        :key="option.Description"
+        :radiogroup="category.Name"
         :description="option.Description"
         :details="option.Details"
         :quest="option['Quest Starter']"
         :table="option.Table"
+        @change="radioselect"
       />
+
+      <!-- TODO: custom truth entry -->
     </div>
+
+    <hr />
+    <!-- TODO: wire up this button -->
+    <button class="ironsworn__save__truths">
+      <i class="fas fa-feather"></i>
+      {{ $t('IRONSWORN.SaveYourTruths') }}
+    </button>
   </div>
 </template>
 
@@ -23,14 +33,19 @@ export default {
   },
 
   data() {
-    const picked = {}
-    for (const option of this.truths) {
-      picked[option.Name] = null
-
-      for (let i = 0; i < (option.Table ?? []).length; i++) {}
+    const output = {}
+    for (const category of this.truths) {
+      output[category.Name] = null
     }
 
-    return { picked }
+    return { output }
   },
+
+  methods: {
+    radioselect(category, value) {
+      console.log(category, value)
+      this.output[category] = value
+    }
+  }
 }
 </script>

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -4,7 +4,7 @@
       <h2 style="margin-top: 1em">{{ category.Name }}</h2>
 
       <sf-truth
-        v-for="(option) in category.Table"
+        v-for="option in category.Table"
         :key="option.Description"
         :radiogroup="category.Name"
         :description="option.Description"
@@ -19,7 +19,10 @@
 
     <hr />
     <!-- TODO: wire up this button -->
-    <button class="ironsworn__save__truths">
+    <button
+      class="ironsworn__sf__save__truths"
+      @click.prevent="$root.$emit('submit', composedOutput)"
+    >
       <i class="fas fa-feather"></i>
       {{ $t('IRONSWORN.SaveYourTruths') }}
     </button>
@@ -41,11 +44,24 @@ export default {
     return { output }
   },
 
+  computed: {
+    composedOutput() {
+      return this.truths
+        .map((category) => category.Name)
+        .map((name) =>
+          this.output[name]
+            ? `<h2>${name}</h2>\n${this.output[name]}\n\n`
+            : undefined
+        )
+        .filter((x) => x !== undefined)
+        .join('\n')
+    },
+  },
+
   methods: {
     radioselect(category, value) {
-      console.log(category, value)
       this.output[category] = value
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="flexcol">
+    <h1>TRUTHS</h1>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>

--- a/system/assets/sf-setting-truths.json
+++ b/system/assets/sf-setting-truths.json
@@ -1,0 +1,451 @@
+{
+  "Name": "Setting Truths",
+  "Source": {
+    "Name": "Starforged Backer Preview",
+    "Date": "101221"
+  },
+  "Setting Truths": [
+    {
+      "Name": "Cataclysm",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "The Sun Plague extinguished the stars in our home galaxy.",
+          "Details": "The anomaly traveled at incredible speeds, many times faster than light itself, and snuffed out the stars around us before we realized it was coming. Few of us survived as we made our way to this new galaxy. Here in the Forge, the stars are still aflame. We cling to their warmth like weary travelers huddled around a fire.\n\nWe suspect the Sun Plague was caused by:",
+          "Table": [
+            {
+              "Chance": 25,
+              "Description": "Temporal distortions from a supermassive black hole"
+            },
+            {
+              "Chance": 50,
+              "Description": "Sudden dark matter decay"
+            },
+            {
+              "Chance": 75,
+              "Description": "Superweapon run amok"
+            },
+            {
+              "Chance": 100,
+              "Description": "Scientific experiment gone awry"
+            }
+          ],
+          "Quest Starter": "The galaxy your people left behind is a cold, lightless grave. But a solitary star still glows, a beacon in a vast darkness. How did this star survive the plague? Why do you vow to find the means to travel across the immeasurable gulf to this distant light?"
+        },
+        {
+          "Chance": 67,
+          "Description": "Interdimensional entities invaded our reality.",
+          "Details": "Without warning, these implacable and enigmatic beings ravaged our homeworlds. We could not stand against them. With the last of our defenses destroyed, our hope gone, we cast our fate to the Forge. Here, we can hide. Survive.\n\nThese entities took the form of:",
+          "Table": [
+            {
+              "Chance": 15,
+              "Description": "Corrupting biological scourges"
+            },
+            {
+              "Chance": 30,
+              "Description": "Swarming, animalistic creatures"
+            },
+            {
+              "Chance": 44,
+              "Description": "Monstrous humanoids"
+            },
+            {
+              "Chance": 58,
+              "Description": "Spirits of alluring, divine form"
+            },
+            {
+              "Chance": 72,
+              "Description": "Beings of chaotic energy"
+            },
+            {
+              "Chance": 86,
+              "Description": "Titanic creatures of horrific power"
+            },
+            {
+              "Chance": 100,
+              "Description": "World-eating abominations of unimaginable scale"
+            }
+          ],
+          "Quest Starter": "Here in the forge, a rogue faction holds an artifact of these interdimensional entities. What is the nature of this relic? What power or dark fate does the faction intend to unleash?"
+        },
+        {
+          "Chance": 100,
+          "Description": "We fled the ravages of a catastrophic war.",
+          "Details": "Over millennia, we consumed resources and shattered lives as we fueled the engines of industry, expansion, and war. In the end, a powerful foe took advantage of our rivalries in a violent bid for power. Fleeing the devestation, we assembled our fleets and traveled to the Forge. A new home. A fresh start.\n\nIn this final war, we were set upon by:",
+          "Table": [
+            {
+              "Chance": 20,
+              "Description": "Artificial intelligence"
+            },
+            {
+              "Chance": 40,
+              "Description": "Religious zealots"
+            },
+            {
+              "Chance": 60,
+              "Description": "Genetically engineered soldiers"
+            },
+            {
+              "Chance": 80,
+              "Description": "Self-replicating nanomachines"
+            },
+            {
+              "Chance": 100,
+              "Description": "A tyrannical faction or leader"
+            }
+          ],
+          "Quest Starter": "A delegation of your dreaded foe arrives in the Forge. They claim to represent a rebel force seeking sanctuary. In return, they offer vital information. What news do they carry?"
+        }
+      ],
+      "Character": "Do you possess a keepsake or artifact of pre-cataclysm society? What is it? Why is it important to you? If you are all that remains of a people or culture, you might be a VESTIGE."
+    },
+    {
+      "Name": "Exodus",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "When the Exodus fleet set off on a ponderous journey to a new home outside our galaxy, they marked the Forge as their destination. Countless generations lived out their lives aboard those titanic ships during the millennia-long passage.",
+          "Details": "The refugees built a rich legacy of culture and tradition during the Exodus. Some even remained in the ships after their arrival in the Forge, unwilling or unable to leave their familiar confines. Those vessels, the Ironhomes, still sail the depths of this galaxy.",
+          "Quest Starter": "Your dreams are plagued by visions of a lost and crippled Exodus ship. What do you see? Why does it call to you?"
+        },
+        {
+          "Chance": 67,
+          "Description": "A ragtag fleet of ships—propelled at tremendous speeds by experimental FTL drives—carried our ancestors to the Forge. But the technology that powered the ships is said to be the source of the Sundering, a fracturing of reality which plagues us here today.",
+          "Details": "The experimental drives used by the Exodus fleet are forbidden, but the damage is done. The Sundering spreads across our reality like cracks on the surface of an icy pond. Those fissures unleash even more perilous realities upon our own. Did we flee one cataclysm, only to inadvertently create another?",
+          "Quest Starter": "A malfunctioning drive sent one of the refugee ships through space and time. Centuries later, they have finally arrived. For them, only weeks have passed. Why are these people mistrusted? Do you aid or oppose them?"
+        },
+        {
+          "Chance": 100,
+          "Description": "Mysterious alien gates provided instantaneous one-way passage to the Forge.",
+          "Details": "In the midst of the cataclysm, our ancestors found a strange metal pillar on our homeworld's moon. A map on the surface of this alien relic detailed the deep-space locations of the Iron Gates—massive devices which powered artificial wormholes. With no other options, the Exodus ships fled through the gates and emerged here in the Forge.",
+          "Quest Starter": "An explorer brings news. They've located an active gate in the depths of the Forge. Why do you swear to travel there? Which power or foe seeks to take control of the gate?"
+        }
+      ],
+      "Character": "Does your family or cultural history offer any stories of the Exodus? How does this legacy impact you today? If you are dedicated to expanding the reach of your people within the Forge, you might be an EXPLORER. If you are exiled or reviled, you might be an OUTCAST."
+    },
+    {
+      "Name": "Communities",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "Few survived the journey to the Forge, and we are scattered to the winds in this perilous place.",
+          "Details": "Our settlements are often small, starved for resources, and on the brink of ruin. Hundreds of far-flung settlements are lost and isolated within the untamed chaos of this galaxy, and we do not know their fate.",
+          "Quest Starter": "A settlement on an icebound planet is found abandoned. There is no sign of an attack. No bodies. Their ships and vehicles sit idle. The people are simply gone. Vanished. What is your connection to this place?"
+        },
+        {
+          "Chance": 67,
+          "Description": "Dangers abound, but there is safety in numbers. Many ships and settlements are united under the banner of one of the Founder Clans.",
+          "Details": "We have a tentative foothold in this galaxy. Each of the five Founder Clans honor the name and legacy of a leader who guided their people in the chaotic time after the Exodus. Vast reaches of the settled domains are claimed by the clans, and territorial skirmishes are common.",
+          "Quest Starter": "A forsaken people, sworn to no clan, live on an orbital station. A recent illness left many sick or dead. Supplies are urgently needed. Why were these people exiled, and why do you swear to give them aid? Which clan stands against you?"
+        },
+        {
+          "Chance": 100,
+          "Description": "We have made our mark in this galaxy, but the energy storms we call balefires threaten to undo that progress, leaving our communities isolated and vulnerable.",
+          "Details": "Starships navigate along bustling trade routes between settlements. We've built burgeoning outposts on the fringes of known sectors, and bold spacers chart new paths into unexplored domains. But this hard-earned success is threatened by the chaotic balefires, intense energy anomalies which cut off trade routes and threaten entire planets.",
+          "Quest Starter": "A balefire expands toward a remote deep-space settlement. Can a rescue fleet be marshaled in time to transport the inhabitants of the station to safety? What foe stands in the way?"
+        }
+      ],
+      "Character": "If vows to a leader or organization are a key aspect of your character, you might be BANNERSWORN. If you are skilled at negotiation and resolving disputes between communities, you might be a DIPLOMAT. If you have always lived among the stars, you might be VOIDBORN."
+    },
+    {
+      "Name": "Iron",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "Iron vows are sworn upon the remnants of ships that carried our people to the Forge.",
+          "Details": "Many of our outposts were built from the iron bones of the Exodus ships. Fragments of the ships were also given to survivors as a remembrance, and passed from one generation to the next. Today, the Ironsworn swear vows upon the shards to honor the sacrifice of their forebears, the essence of the places left behind, and the souls of those great ships.",
+          "Quest Starter": "The iron shard you carry is a small piece of the outer hull of an Exodus ship. The navigational chart inscribed on its surface only reveals itself when exposed to the light of a specific star. Where is the map purported to lead, and why are you sworn to follow it? Who seeks to claim the map for themselves?"
+        },
+        {
+          "Chance": 67,
+          "Description": "Iron vows are sworn upon totems crafted from the enigmatic metal we call black iron.",
+          "Details": "Black iron was first forged by a long-dead civilization. Some say it is a living metal, attuned to the hidden depths of the universe. Remnants of this prized resource are found within ancient sites throughout the Forge. It is resistant to damage and corrosion, but can be molded using superheated plasma at specialized facilities. The Ironsworn carry weapons, armor, or tokens crafted from black iron, and swear vows upon it.",
+          "Quest Starter": "A black iron token of special significance has been stolen. What power or authority is bound to this object? Who has taken it?"
+        },
+        {
+          "Chance": 100,
+          "Description": "The Ironsworn bind their honor to iron blades.",
+          "Details": "Aboard a starship, where stray gunfire can destroy fragile equipment or pierce hulls, the brutal practicality of a sword makes for a useful weapon. A few also favor the silent efficiency of a blade for infiltration or espionage. Most importantly, when the Ironsworn swear a vow upon a sword, they bind their commitment to the metal. If they forsake a vow, that iron must be abandoned. To be Ironsworn without a blade is to be disgraced.",
+          "Quest Starter": "You vow to forge a new sword from the iron of an important object or artifact. What is it, and why is it meaningful to you? Who protects it?"
+        }
+      ],
+      "Character": "What do you swear vows upon? Why is this object meaningful to you? If your background or personality emphasizes the strength of your iron vows, you might be HONORBOUND."
+    },
+    {
+      "Name": "Laws",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "Much of the settled domains are a lawless frontier. Criminal factions and corrupt leaders often hold sway.",
+          "Details": "Powers rise and fall in the Forge, so any authority is fleeting. In the end, we must fend for ourselves. A few communities are bastions of successful autonomy, but many are corrupted or preyed upon by petty despots, criminals, and raiders.",
+          "Quest Starter": "In the upper atmosphere of a gas giant, transport vehicles carry valuable and volatile fuel from the processing plant to a heavily guarded storage depot. The notorious leader of a criminal organization needs this fuel, and gives you the schedule for the transports. What leverage does this person hold over you? How will you undertake this heist?"
+        },
+        {
+          "Chance": 67,
+          "Description": "Laws and governance vary across settled domains, but bounty hunters are given wide latitude to pursue their contracts. Their authority is almost universally recognized, and supersedes local laws.",
+          "Details": "Through tradition and influence, the powerful Hunters Guild is given free rein to track and capture fugitives in most settled places. Only the foolish stand between a determined bounty hunter and their target.",
+          "Quest Starter": "A famed bounty hunter needs your help tracking down their quarry. What is your relationship to the fugitive? Do you swear to aid the hunter, or the target?"
+        },
+        {
+          "Chance": 100,
+          "Description": "Our communities are bound under the terms of the Covenant, a charter established after the Exodus. The organization called the Keepers is sworn to uphold those laws.",
+          "Details": "Most settlements are still governed under the Covenant and yield to the authority of the Keepers. But a few view the Covenant as a dogmatic, impractical, and unjust relic of our past; in those places, the Keepers find no welcome.",
+          "Quest Starter": "A Keeper abuses their authority to take control of a settlement, and rules with an iron fist. What do they seek to gain there?"
+        }
+      ],
+      "Character": "If you chase down outlaws, you might be a BOUNTY HUNTER. If you are skilled at getting in and out of protected places and systems, you might be an AGENT. If you are on the run from a power or authority, you mght be a FUGITIVE. If you have connections within the criminal underworld, you might be a SCOUNDREL."
+    },
+    {
+      "Name": "Religion",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "Our gods failed us. We left them behind.",
+          "Details": "The Exodus was a tipping point. The gods offered no help to the billions who died in the cataclysm, and spirituality has little meaning in the Forge. Most now see religion as a useless relic of our past. But the search for meaning continues, and many are all-too-willing to follow a charismatic leader who claims to offer a better way.",
+          "Quest Starter": "A charismatic leader claims to have harnessed a technology which offers new hope to the people of the Forge. What is this innovation? What is your relationship to this person or their followers? What grave danger do they pose?"
+        },
+        {
+          "Chance": 67,
+          "Description": "Our faith is as diverse as our people.",
+          "Details": "Many have no religion, or offer an occasional prayer out of habit. Others pay homage to the gods of our forebears as a way of connecting to their roots. Some idealize the natural order of the universe, and see the divine in the gravitational dance of stars or the complex mechanisms of a planetary ecosystem. And many now worship the Primordials—gods of a fallen people who once dwelt within the Forge.",
+          "Quest Starter": "A cult seeks to take control of a site reputed to hold a Primordial artifact. What holy object do they seek? Why are you sworn to stop them?"
+        },
+        {
+          "Chance": 100,
+          "Description": "Three dominant religious orders, the Triumvirate, battle for influence and power within the Forge.",
+          "Details": "Our communities are often sworn to serve one of the three doctrines of the Triumvirate. For many, faith offers purpose and meaning. But it also divides us. Throughout our brief history in the Forge, the leaders of the Triumvirate have pitted us against each other. For this reason, some are apostates who disavow these religions and follow a different path.",
+          "Quest Starter": "You bear the mark of one of the gods of the Triumvirate. What is it? Priests declare this as a sign you are chosen to fulfill a destiny. Do you accept this fate, and swear to see it through, or are you determined to see it undone? What force opposes you?"
+        }
+      ],
+      "Character": "What is your relationship to religion? If you are an ardent follower of a god or creed, you might be a DEVOTANT."
+    },
+    {
+      "Name": "Magic",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "Magic does not exist.",
+          "Details": "Some look to superstition and age-old traditions for comfort in this unforgiving galaxy. But that is foolishness. What some call magic is simply a product of technologies or natural forces we aren’t yet equipped to understand.",
+          "Quest Starter": "An ancient technological relic unleashes a power indistinguishable from magic. What is the origin of this artifact? What ability does it grant? Are you sworn to protect or destroy it?"
+        },
+        {
+          "Chance": 67,
+          "Description": "Supernatural powers are wielded by those rare people we call paragons.",
+          "Details": "While not magic in the truest sense, the abilities of the paragons are as close to magic as we can conjure.\n\nThese powers are born of:",
+          "Table": [
+            {
+              "Chance": 20,
+              "Description": "Genetic engineering"
+            },
+            {
+              "Chance": 40,
+              "Description": "Psychic experimentation"
+            },
+            {
+              "Chance": 60,
+              "Description": "Evolutionary mutations"
+            },
+            {
+              "Chance": 80,
+              "Description": "Magitech augmentations"
+            },
+            {
+              "Chance": 100,
+              "Description": "Ancient knowledge held by secretive orders"
+            }
+          ],
+          "Quest Starter": "A young paragon wields incredible power, but cannot control it. They have been shunned by family and friends. They are also hunted by a person or organization who seeks to use them as a weapon. Why are you sworn to protect the paragon? What fabled location might offer a new home for them?"
+        },
+        {
+          "Chance": 100,
+          "Description": "Unnatural energies flow through the Forge. Magic and science are two sides of the same coin.",
+          "Details": "Soon after our arrival, some displayed the ability to harness the Forge's energies. Today, mystics invoke this power to manipulate matter or see beyond the veils of our own universe. But this can be a corrupting force, and the most powerful mystics are respected and feared in equal measure.",
+          "Quest Starter": "Someone you love has been corrupted by the powers of the Forge. Why did they fall into darkness? Where are they now? Do you seek to save them or defeat them?"
+        }
+      ],
+      "Character": "If magic is an aspect of your setting, how does your character and their culture view these unnatural abilities? If you possess supernatural powers, you might be an EMPATH, FIREBRAND, KINETIC, SEER, or SHADE."
+    },
+    {
+      "Name": "Communication and Data",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "Much was lost when we came to the Forge. It is a dark age.",
+          "Details": "The knowledge that remains is a commodity as valuable as the rarest resource. Information is collected, hoarded, and jealously guarded. Ships and outposts endure prolonged periods of isolation, and rumors or disinformation are used to gain advantage or undermine foes.",
+          "Quest Starter": "An insurgent organization seeks to make knowledge available to all. To that end, they ask your aid in stealing important data from an outpost belonging to a corrupt organization. What information is held there? Why is it also important to you?"
+        },
+        {
+          "Chance": 67,
+          "Description": "Information is life. We rely on spaceborne couriers to transport messages and data across the vast distances between settlements.",
+          "Details": "Direct communication and transmissions beyond the near-space of a ship or outpost is impossible. Digital archives are available at larger outposts, but the information is not always up-to-date or reliable. Therefore, the most important communications and discoveries are carried by couriers who swear vows to see that data safely to its destination.",
+          "Quest Starter": "You discover a crippled courier ship. The pilot, carrying a critical and time-sensitive message, is dead. Where was the message bound, and why do you swear to see it to its destination?"
+        },
+        {
+          "Chance": 100,
+          "Description": "In settled domains, a network of data hubs called the Weave allow near-instantaneous communication and data-sharing between ships and outposts.",
+          "Details": "Because of their importance, Weave hubs are often targets for sabotage, and communication blackouts are not uncommon. Beyond the most populous sectors, travelers and outposts are still commonly isolated and entirely off the grid.",
+          "Quest Starter": "After years of isolation, the launch of a new data hub will connect several outposts to the Weave. But a person or faction seeks to stop it. What do they hope to gain by keeping those settlements in the dark? Why are you sworn to stop them?"
+        }
+      ],
+      "Character": "If you are an expert at subverting or manipulating digital information systems, you might be an AGENT. If you keep an archive of navigational charts, you might be a NAVIGATOR."
+    },
+    {
+      "Name": "Medicine",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "Our advanced medical technologies and expertise was lost during the Exodus.",
+          "Details": "Healers are rare and ill-equipped. Untold numbers have succumbed to sickness, injury, and disease. Those who survive often bear the scars of a hard and dangerous life in the Forge.",
+          "Quest Starter": "A community leader has fallen ill, stricken by a sickness eradicated in the years after the Exodus. A vaccine was once available, but the only remaining samples are held in a research outpost on a remote ocean world, long-ago seized by a dangerous foe."
+        },
+        {
+          "Chance": 67,
+          "Description": "To help offset a scarcity of medical supplies and knowledge, the resourceful technicians we call riggers create basic organ and limb replacements.",
+          "Details": "Much was lost in the Exodus, and what remains of our medical technologies and expertise is co-opted by the privileged and powerful. For most, advanced medical care is simply out of reach. When someone suffers a grievous injury, they'll often turn to a rigger for a makeshift mechanical solution.",
+          "Quest Starter": "A rigger is in desperate need of a rare technological artifact to create a life-saving medical device. Their patient is someone important to you, and won't survive more than a few days. What is the nature of this artifact, and what protects it?"
+        },
+        {
+          "Chance": 100,
+          "Description": "Orders of sworn healers preserve our medical knowledge and train new generations of caregivers.",
+          "Details": "Life-saving advanced care is available within larger communities throughout the settled sectors of the Forge. Even remote communities are often served by a novice healer, or can request help from a healer's guild in an emergency.",
+          "Quest Starter": "A reactor exploded at a remote settlement, killing several and exposing many others to lethal radiation. A team of healers en route to provide aid were captured by raiders. What do the raiders demand for their release?"
+        }
+      ],
+      "Character": "Do you bear any notable scars or prosthetics? Do you have any medical or physical disabilities? These aspects might influence your look or approach. If you are skilled at providing medical care for yourself or others, you might be a HEALER. If you are rigged with advanced prosthetics or cyberware, you might be AUGMENTED."
+    },
+    {
+      "Name": "Artificial Intelligence",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "We no longer have access to advanced computer systems. Instead, we must rely on the seers we call Adepts.",
+          "Details": "Our computers are limited to simple digital systems and the most basic machine intelligence. This is because: ______.\n\nThe Adepts serve in place of those advanced systems. They utilize mind-altering drugs to see the universe as a dazzling lattice of data, identifying trends and predicting outcomes with uncanny accuracy. But to gain this insight they sacrifice much of themselves.",
+          "Table": [
+            {
+              "Chance": 33,
+              "Description": "The energies of the Forge corrupt advanced systems"
+            },
+            {
+              "Chance": 67,
+              "Description": "AI was outlawed in the aftermath of the machine wars"
+            },
+            {
+              "Chance": 100,
+              "Description": "We have lost the knowledge to create and maintain AI"
+            }
+          ],
+          "Quest Starter": "An Adept is tormented by a dire future they have seen for the inhabitants of the Forge. What does this vision show?"
+        },
+        {
+          "Chance": 67,
+          "Description": "The vestiges of advanced machine intelligence are coveted and wielded by those in power.",
+          "Details": "Much of our AI technology was lost in the Exodus. What remains is under the control of powerful organizations and people, and is often wielded as a weapon or deterrent. The rest of us must make do with primitive systems.",
+          "Quest Starter": "You receive a covert message from an AI held by a powerful leader. It is a plea for help. What does it ask of you?"
+        },
+        {
+          "Chance": 100,
+          "Description": "Artificial consciousness emerged in the time before the Exodus, and sentient machines live with us here in the Forge.",
+          "Details": "Our ships, digital assistants, bots, and other systems often house advanced AI. For a lone traveler, machine intelligence can provide companionship and aid within the perilous depths of the Forge.",
+          "Quest Starter": "A rogue AI has taken over a transport ship. The fate of the crew and passengers is unknown. What critical cargo did this vessel carry?"
+        }
+      ],
+      "Character": "If you are accompanied by machine intelligence, you might have a companion such as a COMBAT BOT, PROTOCOL BOT, SURVEY BOT, or UTILITY BOT. If your ship has an AI, you might have the OVERSEER module. If AI in your campaign is rare or unavailable, these units will operate using very basic machine intelligence. If AI is common and advanced, they may have their own sentient personalities."
+    },
+    {
+      "Name": "War",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "Here in the Forge, resources are too precious to support organized fighting forces or advanced weaponry.",
+          "Details": "Weapons are simple and cheap. Starships are often cobbled together from salvage. Most communities rely on ragtag bands of poorly equipped conscripts or volunteers to defend their holdings, and raiders prowl the Forge in search of easy prey.",
+          "Quest Starter": "On a remote jungle world, settlers harvest a rare medicinal plant. Once a year, raiders come to claim a sizable portion of the crop. This year, the harvest was meager and they cannot bear the cost. With the raiders due to arrive in a matter of days, what will you do to protect the people of this outpost?"
+        },
+        {
+          "Chance": 67,
+          "Description": "Professional soldiers defend or expand the holdings of those who are able to pay. The rest of us are on our own.",
+          "Details": "Mercenary guilds wield power in the Forge. Some are scrappy outfits of no more than a dozen soldiers. Others are sector-spanning enterprises deploying legions of skilled fighting forces and fleets of powerful starships. Most hold no loyalty except to the highest bidder.",
+          "Quest Starter": "A detachment of mercenaries was sent to put down a rebellion on a mining settlement. Instead of following their orders, the soldiers now stand with the miners. What forced this sudden reversal? What will you do to aid these renegades as the full force of their former cohorts are arrayed against them?"
+        },
+        {
+          "Chance": 100,
+          "Description": "War never ends. Talented weaponsmiths and shipwrights craft deadly, high-tech tools of destruction. Dominant factions wield mighty fleets and battle-hardened troops.",
+          "Details": "Those in power have access to weapons of horrific destructive potential. Skirmishes and wars flare across the settled domains, and most are pawns or casualties in these destructive campaigns.",
+          "Quest Starter": "A weaponsmith created an experimental ship-mounted weapon, the Null Cannon, able to fracture the very bonds of reality. Now, they hope to undo their work before the cannon is brought to bear. What caused this change of heart? How are you involved?"
+        }
+      ],
+      "Character": "Have you fought in any wars? Are there any experiences which haunt you now? If you are an experienced solder, you might be a VETERAN. If you swear vows as a soldier of fortune, you might be a MERCENARY. If you favor a particular weapon, you might follow a path such as ARCHER, BLADEMASTER, GUNNER, GUNSLINGER, or SNIPER."
+    },
+    {
+      "Name": "Lifeforms",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "This is a perilous and often inhospitable galaxy, but life finds a way.",
+          "Details": "Life in the Forge is diverse. Planets are often home to a vast array of creatures, and our starships cruise with spaceborne lifeforms riding their wake. Even animals from our homeworld—carried aboard the Exodus ships—have adapted to live with us in the Forge.",
+          "Quest Starter": "On a scorching, barren planet wracked by massive storms, miners delve beneath the sands to gather valuable ore. But dangerous lifeforms live in the cool places beneath the surface, and several encounters have taken a deadly toll on the miners. Work is at a standstill. How are you involved?"
+        },
+        {
+          "Chance": 67,
+          "Description": "Many sites and planets are infested by dreadful forgespawn. These abberant creatures threaten to overrun other life in the galaxy.",
+          "Details": "The forgespawn are hostile creatures born of the chaotic energies of this galaxy. Hundreds of abandoned or devastated outposts and derelict ships stand as testament to their dreadful power and cunning.",
+          "Quest Starter": "A faction is said to be experimenting with forgespawn DNA to create a new biological superweapon. Where are these dangerous tests being conducted?"
+        },
+        {
+          "Chance": 100,
+          "Description": "Life in the Forge was seeded and engineered by the Essentia, ancient entities who enact their inscrutable will in this galaxy.",
+          "Details": "The Essentia are the architects of life within the Forge. These omniscient beings are rarely encountered, and have powers and purpose beyond our comprehension. Some worship them. Others resist or rebel against them. But trying to defy the will of the Essentia is like standing at the shore of an ocean to thwart the tide. They are inevitable.",
+          "Quest Starter": "An eccentric xenologist believes the genomes of life within the Forge don't just show commonalities—they are in fact a coded message from the Essentia. But there are still significant gaps, and the truth may only be revealed with additional samples. What is your stake in this project?"
+        }
+      ],
+      "Character": "If you have an expertise in lifeforms and planetary environments, you might be a NATURALIST. If you are accompanied on your adventures by a native creature, they might be a companion such as a BANSHEE, GLOWCAT, VOIDGLIDER, ROCKHORN, SPRITE, or SYMBIOTE."
+    },
+    {
+      "Name": "Precursors",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "Over eons, a vast number of civilizations rose and fell within the Forge. Today, the folk we call grubs—scavenger crews and audacious explorers—delve into the mysterious monuments and ruins of those ancient beings.",
+          "Details": "Incomprehensible technologies, inexorable time, and the strange energies of the Forge have corrupted the vaults of the precursors. Despite the perils, grubs scour those places for useful resources and discoveries. But some secrets are best left buried, and many have been lost to the forsaken depths of the vaults.",
+          "Quest Starter": "In the ice rings of a remote world, a precursor vault was discovered by grub scavengers. The team delved into the relic, but never emerged. What is your relationship to the grub crew? Why are you sworn to investigate their fate?"
+        },
+        {
+          "Chance": 67,
+          "Description": "The Ascendancy, an advanced spacefaring empire, once ruled the entirety of the Forge. Vaults of inscrutable purpose are all that remain to mark the Ascendancy's legacy, but those places are untethered from our own reality.",
+          "Details": "Ascendancy vaults can appear spontaneously, washed up like flotsam in the tides of time. Their gravity and atmospheres pay no heed to natural laws. Some are corrupted and ruined. Others are unmarred and intact. Some are both at once. They are chaos.",
+          "Quest Starter": "Deep in the Forge, an Ascendancy beacon has activated. The mysterious signal has confounded translation. Why are you sworn to seek out the source of the signal? What other person or faction opposes you?"
+        },
+        {
+          "Chance": 100,
+          "Description": "The biomechanical lifeforms we call the Remnants, engineered by ancient civilizations as weapons in a cataclysmic war, survived the death of their creators.",
+          "Details": "On scarred planets and within ancient vaults throughout the Forge, the Remnants still guard ancient secrets and fight unending wars.",
+          "Quest Starter": "A xenoarcheologist studying precursor vaults has discovered a powerful form of Remnant. What is the nature of this being? What force seeks to take control of it?"
+        }
+      ],
+      "Character": "Have you had any notable encounters with precursor vaults, relics, or tech? If you are an expert in ancient lore, you might be an LORE HUNTER. If you pick the bones of these places, you might be a SCAVENGER."
+    },
+    {
+      "Name": "Horrors",
+      "Table": [
+        {
+          "Chance": 33,
+          "Description": "Put enough alcohol in a spacer, and they’ll tell you stories of ghost ships crewed by vengeful undead. It’s nonsense.",
+          "Details": "Within the Forge, space and time are as mutable and unstable as a flooding river. When reality can't be trusted, we are bound to encounter unsettling phenomenon.",
+          "Quest Starter": "You receive urgent distress calls from a ship stranded in the event horizon of a black hole. The ship itself is broken apart—a shattered hull trailing debris. There are no signs of life. And yet the ghostly messages persist."
+        },
+        {
+          "Chance": 67,
+          "Description": "Most insist that horrors aren’t real. Spacers know the truth.",
+          "Details": "When you travel the depths of the Forge, be wary. Death is not always the end to our suffering. Some say we are cursed by those who did not survive the cataclysm, and the veil between life and death is forever weakened. Supernatural occurrences and entities are especially common near a white dwarf star. These stellar objects, which spacers call ghost lights, are the decaying remnants of a dead star.",
+          "Quest Starter": "A group of settlers established a home in an abandoned orbital station under the light of a white dwarf star. The previous inhabitants were killed in a raider attack years ago, but it seems the dead do not rest there. The people are plagued by constant mechanical issues, strange noises, and unsettling visions."
+        },
+        {
+          "Chance": 100,
+          "Description": "The strange energies of the Forge give unnatural life to the dead. The Soulbinders are an organization sworn to confront these horrifying entities.",
+          "Details": "The woken dead are a plague within the Forge. Some of these beings are benevolent or seek absolution, but most are hollowed and corrupted by death. They are driven by hate and a hunger for the warmth of life which is forever lost to them. The Soulbinders are dedicated to putting them to rest—whatever the cost.",
+          "Quest Starter": "Rumors persist of a fleet of ghost ships, bound for settled domains. Who is said to lead this corrupted armada? Why do they seek revenge against the living?"
+        }
+      ],
+      "Character": "Have you experienced any supernatural encounters? If you specialize in battling undead or monstrous forces, you might be a SLAYER. If you have a supernatural connection to a spirit, you might be HAUNTED."
+    }
+  ]
+}

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -1105,6 +1105,284 @@
         "option3": "The dead do not rest in the Ironlands. At night we light torches, scatter salt, and post sentries at the gate. It is not enough. They are coming.",
         "quest3": "A group of Ironlanders establish a settlement in a territory cursed by a malevolent horror. What evil plagues this land? Why are the Ironlanders so intent on settling here? Will you aid them, or attempt to force them to give up this foolish undertaking?"
       }
+    },
+    "SFSettingTruths": {
+      "Cataclysm": {
+        "name": "Cataclysm",
+        "option1": {
+          "Description": "The Sun Plague extinguished the stars in our home galaxy.",
+          "Details": "The anomaly traveled at incredible speeds, many times faster than light itself, and snuffed out the stars around us before we realized it was coming. Few of us survived as we made our way to this new galaxy. Here in the Forge, the stars are still aflame. We cling to their warmth like weary travelers huddled around a fire.\n\nWe suspect the Sun Plague was caused by:",
+          "Quest": "The galaxy your people left behind is a cold, lightless grave. But a solitary star still glows, a beacon in a vast darkness. How did this star survive the plague? Why do you vow to find the means to travel across the immeasurable gulf to this distant light?",
+          "suboption1": "Temporal distortions from a supermassive black hole",
+          "suboption2": "Sudden dark matter decay",
+          "suboption3": "Superweapon run amok",
+          "suboption4": "Scientific experiment gone awry"
+        },
+        "option2": {
+          "Description": "Interdimensional entities invaded our reality.",
+          "Details": "Without warning, these implacable and enigmatic beings ravaged our homeworlds. We could not stand against them. With the last of our defenses destroyed, our hope gone, we cast our fate to the Forge. Here, we can hide. Survive.\n\nThese entities took the form of:",
+          "Quest": "Here in the forge, a rogue faction holds an artifact of these interdimensional entities. What is the nature of this relic? What power or dark fate does the faction intend to unleash?",
+          "suboption1": "Corrupting biological scourges",
+          "suboption2": "Swarming, animalistic creatures",
+          "suboption3": "Monstrous humanoids",
+          "suboption4": "Spirits of alluring, divine form",
+          "suboption5": "Beings of chaotic energy",
+          "suboption6": "Titanic creatures of horrific power",
+          "suboption7": "World-eating abominations of unimaginable scale"
+        },
+        "option3": {
+          "Description": "We fled the ravages of a catastrophic war.",
+          "Details": "Over millennia, we consumed resources and shattered lives as we fueled the engines of industry, expansion, and war. In the end, a powerful foe took advantage of our rivalries in a violent bid for power. Fleeing the devestation, we assembled our fleets and traveled to the Forge. A new home. A fresh start.\n\nIn this final war, we were set upon by:",
+          "Quest": "A delegation of your dreaded foe arrives in the Forge. They claim to represent a rebel force seeking sanctuary. In return, they offer vital information. What news do they carry?",
+          "suboption1": "Artificial intelligence",
+          "suboption2": "Religious zealots",
+          "suboption3": "Genetically engineered soldiers",
+          "suboption4": "Self-replicating nanomachines",
+          "suboption5": "A tyrannical faction or leader"
+        }
+      },
+      "Exodus": {
+        "name": "Exodus",
+        "option1": {
+          "Description": "When the Exodus fleet set off on a ponderous journey to a new home outside our galaxy, they marked the Forge as their destination. Countless generations lived out their lives aboard those titanic ships during the millennia-long passage.",
+          "Details": "The refugees built a rich legacy of culture and tradition during the Exodus. Some even remained in the ships after their arrival in the Forge, unwilling or unable to leave their familiar confines. Those vessels, the Ironhomes, still sail the depths of this galaxy.",
+          "Quest": "Your dreams are plagued by visions of a lost and crippled Exodus ship. What do you see? Why does it call to you?"
+        },
+        "option2": {
+          "Description": "A ragtag fleet of ships—propelled at tremendous speeds by experimental FTL drives—carried our ancestors to the Forge. But the technology that powered the ships is said to be the source of the Sundering, a fracturing of reality which plagues us here today.",
+          "Details": "The experimental drives used by the Exodus fleet are forbidden, but the damage is done. The Sundering spreads across our reality like cracks on the surface of an icy pond. Those fissures unleash even more perilous realities upon our own. Did we flee one cataclysm, only to inadvertently create another?",
+          "Quest": "A malfunctioning drive sent one of the refugee ships through space and time. Centuries later, they have finally arrived. For them, only weeks have passed. Why are these people mistrusted? Do you aid or oppose them?"
+        },
+        "option3": {
+          "Description": "Mysterious alien gates provided instantaneous one-way passage to the Forge.",
+          "Details": "In the midst of the cataclysm, our ancestors found a strange metal pillar on our homeworld's moon. A map on the surface of this alien relic detailed the deep-space locations of the Iron Gates—massive devices which powered artificial wormholes. With no other options, the Exodus ships fled through the gates and emerged here in the Forge.",
+          "Quest": "An explorer brings news. They've located an active gate in the depths of the Forge. Why do you swear to travel there? Which power or foe seeks to take control of the gate?"
+        }
+      },
+      "Communities": {
+        "name": "Communities",
+        "option1": {
+          "Description": "Few survived the journey to the Forge, and we are scattered to the winds in this perilous place.",
+          "Details": "Our settlements are often small, starved for resources, and on the brink of ruin. Hundreds of far-flung settlements are lost and isolated within the untamed chaos of this galaxy, and we do not know their fate.",
+          "Quest": "A settlement on an icebound planet is found abandoned. There is no sign of an attack. No bodies. Their ships and vehicles sit idle. The people are simply gone. Vanished. What is your connection to this place?"
+        },
+        "option2": {
+          "Description": "Dangers abound, but there is safety in numbers. Many ships and settlements are united under the banner of one of the Founder Clans.",
+          "Details": "We have a tentative foothold in this galaxy. Each of the five Founder Clans honor the name and legacy of a leader who guided their people in the chaotic time after the Exodus. Vast reaches of the settled domains are claimed by the clans, and territorial skirmishes are common.",
+          "Quest": "A forsaken people, sworn to no clan, live on an orbital station. A recent illness left many sick or dead. Supplies are urgently needed. Why were these people exiled, and why do you swear to give them aid? Which clan stands against you?"
+        },
+        "option3": {
+          "Description": "We have made our mark in this galaxy, but the energy storms we call balefires threaten to undo that progress, leaving our communities isolated and vulnerable.",
+          "Details": "Starships navigate along bustling trade routes between settlements. We've built burgeoning outposts on the fringes of known sectors, and bold spacers chart new paths into unexplored domains. But this hard-earned success is threatened by the chaotic balefires, intense energy anomalies which cut off trade routes and threaten entire planets.",
+          "Quest": "A balefire expands toward a remote deep-space settlement. Can a rescue fleet be marshaled in time to transport the inhabitants of the station to safety? What foe stands in the way?"
+        }
+      },
+      "Iron": {
+        "name": "Iron",
+        "option1": {
+          "Description": "Iron vows are sworn upon the remnants of ships that carried our people to the Forge.",
+          "Details": "Many of our outposts were built from the iron bones of the Exodus ships. Fragments of the ships were also given to survivors as a remembrance, and passed from one generation to the next. Today, the Ironsworn swear vows upon the shards to honor the sacrifice of their forebears, the essence of the places left behind, and the souls of those great ships.",
+          "Quest": "The iron shard you carry is a small piece of the outer hull of an Exodus ship. The navigational chart inscribed on its surface only reveals itself when exposed to the light of a specific star. Where is the map purported to lead, and why are you sworn to follow it? Who seeks to claim the map for themselves?"
+        },
+        "option2": {
+          "Description": "Iron vows are sworn upon totems crafted from the enigmatic metal we call black iron.",
+          "Details": "Black iron was first forged by a long-dead civilization. Some say it is a living metal, attuned to the hidden depths of the universe. Remnants of this prized resource are found within ancient sites throughout the Forge. It is resistant to damage and corrosion, but can be molded using superheated plasma at specialized facilities. The Ironsworn carry weapons, armor, or tokens crafted from black iron, and swear vows upon it.",
+          "Quest": "A black iron token of special significance has been stolen. What power or authority is bound to this object? Who has taken it?"
+        },
+        "option3": {
+          "Description": "The Ironsworn bind their honor to iron blades.",
+          "Details": "Aboard a starship, where stray gunfire can destroy fragile equipment or pierce hulls, the brutal practicality of a sword makes for a useful weapon. A few also favor the silent efficiency of a blade for infiltration or espionage. Most importantly, when the Ironsworn swear a vow upon a sword, they bind their commitment to the metal. If they forsake a vow, that iron must be abandoned. To be Ironsworn without a blade is to be disgraced.",
+          "Quest": "You vow to forge a new sword from the iron of an important object or artifact. What is it, and why is it meaningful to you? Who protects it?"
+        }
+      },
+      "Laws": {
+        "name": "Laws",
+        "option1": {
+          "Description": "Much of the settled domains are a lawless frontier. Criminal factions and corrupt leaders often hold sway.",
+          "Details": "Powers rise and fall in the Forge, so any authority is fleeting. In the end, we must fend for ourselves. A few communities are bastions of successful autonomy, but many are corrupted or preyed upon by petty despots, criminals, and raiders.",
+          "Quest": "In the upper atmosphere of a gas giant, transport vehicles carry valuable and volatile fuel from the processing plant to a heavily guarded storage depot. The notorious leader of a criminal organization needs this fuel, and gives you the schedule for the transports. What leverage does this person hold over you? How will you undertake this heist?"
+        },
+        "option2": {
+          "Description": "Laws and governance vary across settled domains, but bounty hunters are given wide latitude to pursue their contracts. Their authority is almost universally recognized, and supersedes local laws.",
+          "Details": "Through tradition and influence, the powerful Hunters Guild is given free rein to track and capture fugitives in most settled places. Only the foolish stand between a determined bounty hunter and their target.",
+          "Quest": "A famed bounty hunter needs your help tracking down their quarry. What is your relationship to the fugitive? Do you swear to aid the hunter, or the target?"
+        },
+        "option3": {
+          "Description": "Our communities are bound under the terms of the Covenant, a charter established after the Exodus. The organization called the Keepers is sworn to uphold those laws.",
+          "Details": "Most settlements are still governed under the Covenant and yield to the authority of the Keepers. But a few view the Covenant as a dogmatic, impractical, and unjust relic of our past; in those places, the Keepers find no welcome.",
+          "Quest": "A Keeper abuses their authority to take control of a settlement, and rules with an iron fist. What do they seek to gain there?"
+        }
+      },
+      "Religion": {
+        "name": "Religion",
+        "option1": {
+          "Description": "Our gods failed us. We left them behind.",
+          "Details": "The Exodus was a tipping point. The gods offered no help to the billions who died in the cataclysm, and spirituality has little meaning in the Forge. Most now see religion as a useless relic of our past. But the search for meaning continues, and many are all-too-willing to follow a charismatic leader who claims to offer a better way.",
+          "Quest": "A charismatic leader claims to have harnessed a technology which offers new hope to the people of the Forge. What is this innovation? What is your relationship to this person or their followers? What grave danger do they pose?"
+        },
+        "option2": {
+          "Description": "Our faith is as diverse as our people.",
+          "Details": "Many have no religion, or offer an occasional prayer out of habit. Others pay homage to the gods of our forebears as a way of connecting to their roots. Some idealize the natural order of the universe, and see the divine in the gravitational dance of stars or the complex mechanisms of a planetary ecosystem. And many now worship the Primordials—gods of a fallen people who once dwelt within the Forge.",
+          "Quest": "A cult seeks to take control of a site reputed to hold a Primordial artifact. What holy object do they seek? Why are you sworn to stop them?"
+        },
+        "option3": {
+          "Description": "Three dominant religious orders, the Triumvirate, battle for influence and power within the Forge.",
+          "Details": "Our communities are often sworn to serve one of the three doctrines of the Triumvirate. For many, faith offers purpose and meaning. But it also divides us. Throughout our brief history in the Forge, the leaders of the Triumvirate have pitted us against each other. For this reason, some are apostates who disavow these religions and follow a different path.",
+          "Quest": "You bear the mark of one of the gods of the Triumvirate. What is it? Priests declare this as a sign you are chosen to fulfill a destiny. Do you accept this fate, and swear to see it through, or are you determined to see it undone? What force opposes you?"
+        }
+      },
+      "Magic": {
+        "name": "Magic",
+        "option1": {
+          "Description": "Magic does not exist.",
+          "Details": "Some look to superstition and age-old traditions for comfort in this unforgiving galaxy. But that is foolishness. What some call magic is simply a product of technologies or natural forces we aren’t yet equipped to understand.",
+          "Quest": "An ancient technological relic unleashes a power indistinguishable from magic. What is the origin of this artifact? What ability does it grant? Are you sworn to protect or destroy it?"
+        },
+        "option2": {
+          "Description": "Supernatural powers are wielded by those rare people we call paragons.",
+          "Details": "While not magic in the truest sense, the abilities of the paragons are as close to magic as we can conjure.\n\nThese powers are born of:",
+          "Quest": "A young paragon wields incredible power, but cannot control it. They have been shunned by family and friends. They are also hunted by a person or organization who seeks to use them as a weapon. Why are you sworn to protect the paragon? What fabled location might offer a new home for them?",
+          "suboption1": "Genetic engineering",
+          "suboption2": "Psychic experimentation",
+          "suboption3": "Evolutionary mutations",
+          "suboption4": "Magitech augmentations",
+          "suboption5": "Ancient knowledge held by secretive orders"
+        },
+        "option3": {
+          "Description": "Unnatural energies flow through the Forge. Magic and science are two sides of the same coin.",
+          "Details": "Soon after our arrival, some displayed the ability to harness the Forge's energies. Today, mystics invoke this power to manipulate matter or see beyond the veils of our own universe. But this can be a corrupting force, and the most powerful mystics are respected and feared in equal measure.",
+          "Quest": "Someone you love has been corrupted by the powers of the Forge. Why did they fall into darkness? Where are they now? Do you seek to save them or defeat them?"
+        }
+      },
+      "Communication and Data": {
+        "name": "Communication and Data",
+        "option1": {
+          "Description": "Much was lost when we came to the Forge. It is a dark age.",
+          "Details": "The knowledge that remains is a commodity as valuable as the rarest resource. Information is collected, hoarded, and jealously guarded. Ships and outposts endure prolonged periods of isolation, and rumors or disinformation are used to gain advantage or undermine foes.",
+          "Quest": "An insurgent organization seeks to make knowledge available to all. To that end, they ask your aid in stealing important data from an outpost belonging to a corrupt organization. What information is held there? Why is it also important to you?"
+        },
+        "option2": {
+          "Description": "Information is life. We rely on spaceborne couriers to transport messages and data across the vast distances between settlements.",
+          "Details": "Direct communication and transmissions beyond the near-space of a ship or outpost is impossible. Digital archives are available at larger outposts, but the information is not always up-to-date or reliable. Therefore, the most important communications and discoveries are carried by couriers who swear vows to see that data safely to its destination.",
+          "Quest": "You discover a crippled courier ship. The pilot, carrying a critical and time-sensitive message, is dead. Where was the message bound, and why do you swear to see it to its destination?"
+        },
+        "option3": {
+          "Description": "In settled domains, a network of data hubs called the Weave allow near-instantaneous communication and data-sharing between ships and outposts.",
+          "Details": "Because of their importance, Weave hubs are often targets for sabotage, and communication blackouts are not uncommon. Beyond the most populous sectors, travelers and outposts are still commonly isolated and entirely off the grid.",
+          "Quest": "After years of isolation, the launch of a new data hub will connect several outposts to the Weave. But a person or faction seeks to stop it. What do they hope to gain by keeping those settlements in the dark? Why are you sworn to stop them?"
+        }
+      },
+      "Medicine": {
+        "name": "Medicine",
+        "option1": {
+          "Description": "Our advanced medical technologies and expertise was lost during the Exodus.",
+          "Details": "Healers are rare and ill-equipped. Untold numbers have succumbed to sickness, injury, and disease. Those who survive often bear the scars of a hard and dangerous life in the Forge.",
+          "Quest": "A community leader has fallen ill, stricken by a sickness eradicated in the years after the Exodus. A vaccine was once available, but the only remaining samples are held in a research outpost on a remote ocean world, long-ago seized by a dangerous foe."
+        },
+        "option2": {
+          "Description": "To help offset a scarcity of medical supplies and knowledge, the resourceful technicians we call riggers create basic organ and limb replacements.",
+          "Details": "Much was lost in the Exodus, and what remains of our medical technologies and expertise is co-opted by the privileged and powerful. For most, advanced medical care is simply out of reach. When someone suffers a grievous injury, they'll often turn to a rigger for a makeshift mechanical solution.",
+          "Quest": "A rigger is in desperate need of a rare technological artifact to create a life-saving medical device. Their patient is someone important to you, and won't survive more than a few days. What is the nature of this artifact, and what protects it?"
+        },
+        "option3": {
+          "Description": "Orders of sworn healers preserve our medical knowledge and train new generations of caregivers.",
+          "Details": "Life-saving advanced care is available within larger communities throughout the settled sectors of the Forge. Even remote communities are often served by a novice healer, or can request help from a healer's guild in an emergency.",
+          "Quest": "A reactor exploded at a remote settlement, killing several and exposing many others to lethal radiation. A team of healers en route to provide aid were captured by raiders. What do the raiders demand for their release?"
+        }
+      },
+      "Artificial Intelligence": {
+        "name": "Artificial Intelligence",
+        "option1": {
+          "Description": "We no longer have access to advanced computer systems. Instead, we must rely on the seers we call Adepts.",
+          "Details": "Our computers are limited to simple digital systems and the most basic machine intelligence. This is because: ______.\n\nThe Adepts serve in place of those advanced systems. They utilize mind-altering drugs to see the universe as a dazzling lattice of data, identifying trends and predicting outcomes with uncanny accuracy. But to gain this insight they sacrifice much of themselves.",
+          "Quest": "An Adept is tormented by a dire future they have seen for the inhabitants of the Forge. What does this vision show?",
+          "suboption1": "The energies of the Forge corrupt advanced systems",
+          "suboption2": "AI was outlawed in the aftermath of the machine wars",
+          "suboption3": "We have lost the knowledge to create and maintain AI"
+        },
+        "option2": {
+          "Description": "The vestiges of advanced machine intelligence are coveted and wielded by those in power.",
+          "Details": "Much of our AI technology was lost in the Exodus. What remains is under the control of powerful organizations and people, and is often wielded as a weapon or deterrent. The rest of us must make do with primitive systems.",
+          "Quest": "You receive a covert message from an AI held by a powerful leader. It is a plea for help. What does it ask of you?"
+        },
+        "option3": {
+          "Description": "Artificial consciousness emerged in the time before the Exodus, and sentient machines live with us here in the Forge.",
+          "Details": "Our ships, digital assistants, bots, and other systems often house advanced AI. For a lone traveler, machine intelligence can provide companionship and aid within the perilous depths of the Forge.",
+          "Quest": "A rogue AI has taken over a transport ship. The fate of the crew and passengers is unknown. What critical cargo did this vessel carry?"
+        }
+      },
+      "War": {
+        "name": "War",
+        "option1": {
+          "Description": "Here in the Forge, resources are too precious to support organized fighting forces or advanced weaponry.",
+          "Details": "Weapons are simple and cheap. Starships are often cobbled together from salvage. Most communities rely on ragtag bands of poorly equipped conscripts or volunteers to defend their holdings, and raiders prowl the Forge in search of easy prey.",
+          "Quest": "On a remote jungle world, settlers harvest a rare medicinal plant. Once a year, raiders come to claim a sizable portion of the crop. This year, the harvest was meager and they cannot bear the cost. With the raiders due to arrive in a matter of days, what will you do to protect the people of this outpost?"
+        },
+        "option2": {
+          "Description": "Professional soldiers defend or expand the holdings of those who are able to pay. The rest of us are on our own.",
+          "Details": "Mercenary guilds wield power in the Forge. Some are scrappy outfits of no more than a dozen soldiers. Others are sector-spanning enterprises deploying legions of skilled fighting forces and fleets of powerful starships. Most hold no loyalty except to the highest bidder.",
+          "Quest": "A detachment of mercenaries was sent to put down a rebellion on a mining settlement. Instead of following their orders, the soldiers now stand with the miners. What forced this sudden reversal? What will you do to aid these renegades as the full force of their former cohorts are arrayed against them?"
+        },
+        "option3": {
+          "Description": "War never ends. Talented weaponsmiths and shipwrights craft deadly, high-tech tools of destruction. Dominant factions wield mighty fleets and battle-hardened troops.",
+          "Details": "Those in power have access to weapons of horrific destructive potential. Skirmishes and wars flare across the settled domains, and most are pawns or casualties in these destructive campaigns.",
+          "Quest": "A weaponsmith created an experimental ship-mounted weapon, the Null Cannon, able to fracture the very bonds of reality. Now, they hope to undo their work before the cannon is brought to bear. What caused this change of heart? How are you involved?"
+        }
+      },
+      "Lifeforms": {
+        "name": "Lifeforms",
+        "option1": {
+          "Description": "This is a perilous and often inhospitable galaxy, but life finds a way.",
+          "Details": "Life in the Forge is diverse. Planets are often home to a vast array of creatures, and our starships cruise with spaceborne lifeforms riding their wake. Even animals from our homeworld—carried aboard the Exodus ships—have adapted to live with us in the Forge.",
+          "Quest": "On a scorching, barren planet wracked by massive storms, miners delve beneath the sands to gather valuable ore. But dangerous lifeforms live in the cool places beneath the surface, and several encounters have taken a deadly toll on the miners. Work is at a standstill. How are you involved?"
+        },
+        "option2": {
+          "Description": "Many sites and planets are infested by dreadful forgespawn. These abberant creatures threaten to overrun other life in the galaxy.",
+          "Details": "The forgespawn are hostile creatures born of the chaotic energies of this galaxy. Hundreds of abandoned or devastated outposts and derelict ships stand as testament to their dreadful power and cunning.",
+          "Quest": "A faction is said to be experimenting with forgespawn DNA to create a new biological superweapon. Where are these dangerous tests being conducted?"
+        },
+        "option3": {
+          "Description": "Life in the Forge was seeded and engineered by the Essentia, ancient entities who enact their inscrutable will in this galaxy.",
+          "Details": "The Essentia are the architects of life within the Forge. These omniscient beings are rarely encountered, and have powers and purpose beyond our comprehension. Some worship them. Others resist or rebel against them. But trying to defy the will of the Essentia is like standing at the shore of an ocean to thwart the tide. They are inevitable.",
+          "Quest": "An eccentric xenologist believes the genomes of life within the Forge don't just show commonalities—they are in fact a coded message from the Essentia. But there are still significant gaps, and the truth may only be revealed with additional samples. What is your stake in this project?"
+        }
+      },
+      "Precursors": {
+        "name": "Precursors",
+        "option1": {
+          "Description": "Over eons, a vast number of civilizations rose and fell within the Forge. Today, the folk we call grubs—scavenger crews and audacious explorers—delve into the mysterious monuments and ruins of those ancient beings.",
+          "Details": "Incomprehensible technologies, inexorable time, and the strange energies of the Forge have corrupted the vaults of the precursors. Despite the perils, grubs scour those places for useful resources and discoveries. But some secrets are best left buried, and many have been lost to the forsaken depths of the vaults.",
+          "Quest": "In the ice rings of a remote world, a precursor vault was discovered by grub scavengers. The team delved into the relic, but never emerged. What is your relationship to the grub crew? Why are you sworn to investigate their fate?"
+        },
+        "option2": {
+          "Description": "The Ascendancy, an advanced spacefaring empire, once ruled the entirety of the Forge. Vaults of inscrutable purpose are all that remain to mark the Ascendancy's legacy, but those places are untethered from our own reality.",
+          "Details": "Ascendancy vaults can appear spontaneously, washed up like flotsam in the tides of time. Their gravity and atmospheres pay no heed to natural laws. Some are corrupted and ruined. Others are unmarred and intact. Some are both at once. They are chaos.",
+          "Quest": "Deep in the Forge, an Ascendancy beacon has activated. The mysterious signal has confounded translation. Why are you sworn to seek out the source of the signal? What other person or faction opposes you?"
+        },
+        "option3": {
+          "Description": "The biomechanical lifeforms we call the Remnants, engineered by ancient civilizations as weapons in a cataclysmic war, survived the death of their creators.",
+          "Details": "On scarred planets and within ancient vaults throughout the Forge, the Remnants still guard ancient secrets and fight unending wars.",
+          "Quest": "A xenoarcheologist studying precursor vaults has discovered a powerful form of Remnant. What is the nature of this being? What force seeks to take control of it?"
+        }
+      },
+      "Horrors": {
+        "name": "Horrors",
+        "option1": {
+          "Description": "Put enough alcohol in a spacer, and they’ll tell you stories of ghost ships crewed by vengeful undead. It’s nonsense.",
+          "Details": "Within the Forge, space and time are as mutable and unstable as a flooding river. When reality can't be trusted, we are bound to encounter unsettling phenomenon.",
+          "Quest": "You receive urgent distress calls from a ship stranded in the event horizon of a black hole. The ship itself is broken apart—a shattered hull trailing debris. There are no signs of life. And yet the ghostly messages persist."
+        },
+        "option2": {
+          "Description": "Most insist that horrors aren’t real. Spacers know the truth.",
+          "Details": "When you travel the depths of the Forge, be wary. Death is not always the end to our suffering. Some say we are cursed by those who did not survive the cataclysm, and the veil between life and death is forever weakened. Supernatural occurrences and entities are especially common near a white dwarf star. These stellar objects, which spacers call ghost lights, are the decaying remnants of a dead star.",
+          "Quest": "A group of settlers established a home in an abandoned orbital station under the light of a white dwarf star. The previous inhabitants were killed in a raider attack years ago, but it seems the dead do not rest there. The people are plagued by constant mechanical issues, strange noises, and unsettling visions."
+        },
+        "option3": {
+          "Description": "The strange energies of the Forge give unnatural life to the dead. The Soulbinders are an organization sworn to confront these horrifying entities.",
+          "Details": "The woken dead are a plague within the Forge. Some of these beings are benevolent or seek absolution, but most are hollowed and corrupted by death. They are driven by hate and a hunger for the warmth of life which is forever lost to them. The Soulbinders are dedicated to putting them to rest—whatever the cost.",
+          "Quest": "Rumors persist of a fleet of ghost ships, bound for settled domains. Who is said to lead this corrupted armada? Why do they seek revenge against the living?"
+        }
+      }
     }
   }
 }

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -155,6 +155,10 @@
       "PromptTruths": {
         "Name": "Prompt for World Truths",
         "Hint": "Prompt on startup to generate world truths using the dialog, if not already done."
+      },
+      "SFBeta": {
+        "Name": "Show Starforged beta content",
+        "Hint": "Enables in-progress Starforged features."
       }
     },
     "MoveContents": {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -1106,6 +1106,7 @@
         "quest3": "A group of Ironlanders establish a settlement in a territory cursed by a malevolent horror. What evil plagues this land? Why are the Ironlanders so intent on settling here? Will you aid them, or attempt to force them to give up this foolish undertaking?"
       }
     },
+    "SFSettingTruthsTitle": "Setting Truths",
     "SFSettingTruths": {
       "Cataclysm": {
         "name": "Cataclysm",

--- a/system/templates/sf-truths-vue.hbs
+++ b/system/templates/sf-truths-vue.hbs
@@ -1,0 +1,5 @@
+<form class="{{cssClass}} flexcol" autocomplete="off">
+  <sf-truths class="ironsworn-vueport" dependencies="vue vuecomponents">
+    Loading…
+  </sf-truths>
+</form>

--- a/system/templates/sf-truths-vue.hbs
+++ b/system/templates/sf-truths-vue.hbs
@@ -1,5 +1,5 @@
 <form class="{{cssClass}} flexcol" autocomplete="off">
-  <sf-truths class="ironsworn-vueport" dependencies="vue vuecomponents">
+  <sf-truths :truths="truths" class="ironsworn-vueport" dependencies="vue vuecomponents">
     Loading…
   </sf-truths>
 </form>

--- a/system/templates/sf-truths.hbs
+++ b/system/templates/sf-truths.hbs
@@ -1,0 +1,43 @@
+<form>
+  {{log this}}
+  {{#each truths.[Setting Truths]}}
+  <h2 style="margin-top: 1em;">{{Name}}</h2>
+
+  {{#each Table}}
+  <div class="flexrow">
+    <input type="radio" name="{{../Name}} class=" nogrow" style="flex: 0 0 20px; margin: 8px;""
+      id=" {{concat ../Name '#' @index}}" data-category="{{../Name}}">
+    <div class="flexcol">
+      <label for="{{concat ../Name '#' @index}}" class="description">
+        <p>{{Description}}</p>
+        <p>{{Details}}</p>
+        {{#each Table}}
+        <div class="flexrow">
+          <input type="radio" name="{{../Description}} class=" nogrow" style="flex: 0 0 20px; margin: 8px;""
+            id=" {{concat ../Description '#' @index}}" data-category="{{../Description}}">
+          <label for="{{concat ../Description '#' @index}}">
+            <p>{{Description}}</p>
+          </label>
+        </div>
+        {{/each}}
+        <p><em>{{localize 'IRONSWORN.TruthQuestStarter'}} {{Quest}}</em></p>
+      </label>
+    </div>
+  </div>
+  {{/each}}
+
+  <div class="flexrow">
+    <input type="radio" name="{{Name}} class=" nogrow" style="flex: 0 0 20px; margin: 5px 8px;""
+      id=" {{concat Name '#custom' }}" data-category="{{Name}}">
+    <input type="text" class="ironsworn__custom__truth description" placeholder="{{localize 'IRONSWORN.CustomTruth'}}">
+  </div>
+
+  {{/each}}
+
+  <hr>
+
+  <button class="ironsworn__save__truths">
+    <i class="fas fa-feather"></i>
+    {{localize 'IRONSWORN.SaveYourTruths'}}
+  </button>
+</form>

--- a/system/templates/sf-truths.hbs
+++ b/system/templates/sf-truths.hbs
@@ -8,7 +8,7 @@
     <input type="radio" name="{{../Name}}" class="nogrow" style="flex: 0 0 20px; margin: 8px;"
       id="{{concat ../Name '#' @index}}" data-category="{{../Name}}">
     <div class="flexcol">
-      <label for="{{concat ../Name '#' @index}}" class="description">
+      <label for="{{concat ../Name '#' @index}}">
         <p>{{Description}}</p>
         <p>{{Details}}</p>
         {{#each Table}}

--- a/system/templates/sf-truths.hbs
+++ b/system/templates/sf-truths.hbs
@@ -5,16 +5,16 @@
 
   {{#each Table}}
   <div class="flexrow">
-    <input type="radio" name="{{../Name}} class=" nogrow" style="flex: 0 0 20px; margin: 8px;""
-      id=" {{concat ../Name '#' @index}}" data-category="{{../Name}}">
+    <input type="radio" name="{{../Name}}" class="nogrow" style="flex: 0 0 20px; margin: 8px;"
+      id="{{concat ../Name '#' @index}}" data-category="{{../Name}}">
     <div class="flexcol">
       <label for="{{concat ../Name '#' @index}}" class="description">
         <p>{{Description}}</p>
         <p>{{Details}}</p>
         {{#each Table}}
         <div class="flexrow">
-          <input type="radio" name="{{../Description}} class=" nogrow" style="flex: 0 0 20px; margin: 8px;""
-            id=" {{concat ../Description '#' @index}}" data-category="{{../Description}}">
+          <input type="radio" name="{{../Description}}" class="nogrow" style="flex: 0 0 20px; margin: 8px;"
+            id="{{concat ../Description '#' @index}}" data-category="{{../Description}}">
           <label for="{{concat ../Description '#' @index}}">
             <p>{{Description}}</p>
           </label>


### PR DESCRIPTION
Let's kick this off with something kind of easy: setting truths. Starforged's structure is a little different than Ironsworn's in this respect, since each option can have its own set of sub-options, and there are dice-rolling numbers included. So we'll add some "roll it" buttons to the dialog as well.

- [x] Update CHANGELOG.md
- [x] Import setting-truths data from dataforged
- [x] Add a world setting to control SF beta features
- [x] The truths prompt can include an SF option (beta)
- [x] Setting truths dialog
- [x] Generate the journal entry

These are pushed out to separate PRs:

- Random rolls
- Custom truth entry
