### PR TITLE
Legacy tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## In progress
 
+- Starforged: legacy tracks ([#180](https://github.com/ben/foundry-ironsworn/pull/180))
+
 ## 1.10.0
 
-- Add Starforged setting-truths dialog([#178](https://github.com/ben/foundry-ironsworn/pull/178))
+- Add Starforged setting-truths dialog ([#178](https://github.com/ben/foundry-ironsworn/pull/178))
 - Add Starforged character sheet ([#179](https://github.com/ben/foundry-ironsworn/pull/179))
 
 ## 1.9.0

--- a/src/module/actor/actortypes.ts
+++ b/src/module/actor/actortypes.ts
@@ -20,6 +20,14 @@ interface CharacterDataSourceData {
     unprepared: boolean
     wounded: boolean
   }
+  legacies: {
+    quests: number
+    questsXpSpent: number
+    bonds: number
+    bondsXpSpent: number
+    discoveries: number
+    discoveriesXpSpent: number
+  }
   xp: number
 }
 

--- a/src/module/features/changelog.ts
+++ b/src/module/features/changelog.ts
@@ -60,6 +60,8 @@ type ActorTypeHandler = (IronswornActor, any) => string | undefined
 const ACTOR_TYPE_HANDLERS: { [key: string]: ActorTypeHandler } = {
   character: (actor: IronswornActor, data) => {
     const characterData = actor.data as CharacterDataProperties
+
+    // Ironsworn XP
     if (data.data?.xp !== undefined) {
       const oldXp = characterData.data.xp
       const newXp = data.data.xp as number
@@ -67,6 +69,19 @@ const ACTOR_TYPE_HANDLERS: { [key: string]: ActorTypeHandler } = {
         return game.i18n.format('IRONSWORN.ChangeLog.MarkedXP', { amt: newXp - oldXp })
       } else {
         return game.i18n.format('IRONSWORN.ChangeLog.UnmarkedXP', { amt: oldXp - newXp })
+      }
+    }
+
+    // Starforged legacy XP
+    for (const kind of ['quests', 'bonds', 'discoveries']) {
+      const oldXp = characterData.data.legacies[`${kind}XpSpent`]
+      const newXp = data.data.legacies[`${kind}XpSpent`] as number
+      if (newXp !== undefined) {
+        if (newXp > oldXp) {
+          return game.i18n.format('IRONSWORN.ChangeLog.MarkedXP', { amt: newXp - oldXp })
+        } else {
+          return game.i18n.format('IRONSWORN.ChangeLog.UnmarkedXP', { amt: oldXp - newXp })
+        }
       }
     }
 
@@ -159,8 +174,8 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
         if (oldEnables[i] !== newEnables[i]) {
           const descriptors = ['First', 'Second', 'Third', 'Fourth', 'Fifth']
           const pos = game.i18n.localize(`IRONSWORN.${descriptors[i]}`)
-          if (newEnables[i]) return game.i18n.format('IRONSWORN.ChangeLog.MarkedAbility', {pos})
-          return game.i18n.format('IRONSWORN.ChangeLog.UnmarkedAbility', {pos})
+          if (newEnables[i]) return game.i18n.format('IRONSWORN.ChangeLog.MarkedAbility', { pos })
+          return game.i18n.format('IRONSWORN.ChangeLog.UnmarkedAbility', { pos })
         }
       }
     }
@@ -172,13 +187,13 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
       return game.i18n.format('IRONSWORN.ChangeLog.AdjustedStat', {
         amt: `${signPrefix}${newValue - oldValue}`,
         stat: assetData.data.track.name,
-        val: newValue
+        val: newValue,
       })
     }
 
     if (data.data?.exclusiveOptions !== undefined) {
       const selectedOption = data.data.exclusiveOptions.find((x) => x.selected)
-      return game.i18n.format('IRONSWORN.ChangeLog.MarkedOption', {name: selectedOption.name})
+      return game.i18n.format('IRONSWORN.ChangeLog.MarkedOption', { name: selectedOption.name })
     }
 
     if (data.data?.fields !== undefined) {
@@ -186,7 +201,7 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
         const newField = data.data.fields[i]
         const oldField = assetData.data.fields[i]
         if (oldField && oldField?.value !== newField.value) {
-          return game.i18n.format('IRONSWORN.ChangeLog.SetField', {name: newField.name, val: newField.value})
+          return game.i18n.format('IRONSWORN.ChangeLog.SetField', { name: newField.name, val: newField.value })
         }
       }
     }

--- a/src/module/vue/components/character-header.vue
+++ b/src/module/vue/components/character-header.vue
@@ -11,6 +11,7 @@
           v-bind:key="n"
           :value="n"
           :current="actor.data.xp"
+          @click="setXp(n)"
         />
         <xp-box :actor="actor" :value="0">×</xp-box>
       </div>
@@ -28,6 +29,12 @@ export default {
     return {
       xpArray: [1, 2, 3, 4, 5, 6, 7, 8, 9],
     }
+  },
+
+  methods: {
+    setXp(n) {
+      this.$actor.update({ data: { xp: n } })
+    },
   },
 }
 </script>

--- a/src/module/vue/components/legacy-track.vue
+++ b/src/module/vue/components/legacy-track.vue
@@ -1,20 +1,26 @@
 <template>
-  <div class="flexrow track">
-    <div
-      class="flexcol track-box"
-      v-for="(box, i) in boxes"
-      :key="`box${i}`"
-      v-html="box"
-    ></div>
+  <div class="flexcol">
+    <div class="flexrow">
+      <h4>{{ title }}</h4>
+      <icon-button v-if="editMode" icon="caret-left" @click="decrease" />
+      <icon-button icon="caret-right" @click="increase" />
+    </div>
+
+    <div class="flexrow track">
+      <div
+        class="flexcol track-box"
+        v-for="(box, i) in boxes"
+        :key="`box${i}`"
+        v-html="box"
+      ></div>
+    </div>
   </div>
 </template>
 
 <style lang="less" scoped>
-// .track .track-box {
-//   width: 40px;
-//   height: 40px;
-//   flex-grow: 0;
-// }
+h4 {
+  margin: 0.5rem 0;
+}
 </style>
 
 <script>
@@ -31,9 +37,13 @@ export default {
   props: {
     actor: Object,
     propKey: String,
+    title: String,
   },
 
   computed: {
+    editMode() {
+      return this.actor.flags['foundry-ironsworn']?.['edit-mode']
+    },
     ticks() {
       return this.actor.data.legacies[this.propKey] ?? 0
     },
@@ -51,6 +61,21 @@ export default {
         remainingTicks -= 4
       }
       return ret
+    },
+  },
+
+  methods: {
+    adjust(inc) {
+      const current = this.actor.data?.legacies[this.propKey] ?? 0
+      this.$actor.update({
+        [`data.legacies.${this.propKey}`]: current + inc,
+      })
+    },
+    increase() {
+      this.adjust(1)
+    },
+    decrease() {
+      this.adjust(-1)
     },
   },
 }

--- a/src/module/vue/components/legacy-track.vue
+++ b/src/module/vue/components/legacy-track.vue
@@ -1,8 +1,32 @@
 <template>
-  <h4>legacy track: {{ ticks }} {{ xpSpent }}</h4>
+  <div class="flexrow track">
+    <div
+      class="flexcol track-box"
+      v-for="(box, i) in boxes"
+      :key="`box${i}`"
+      v-html="box"
+    ></div>
+  </div>
 </template>
 
+<style lang="less" scoped>
+// .track .track-box {
+//   width: 40px;
+//   height: 40px;
+//   flex-grow: 0;
+// }
+</style>
+
 <script>
+function ticksSvg(ticks) {
+  let ret = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">'
+  if (ticks > 0) ret += '<line x1="23" y1="23" x2="77" y2="77" />'
+  if (ticks > 1) ret += '<line x1="77" y1="23" x2="23" y2="77" />'
+  if (ticks > 2) ret += '<line x1="15" y1="50" x2="85" y2="50" />'
+  if (ticks > 3) ret += '<line x1="50" y1="15" x2="50" y2="85" />'
+  return ret + '</svg>'
+}
+
 export default {
   props: {
     actor: Object,
@@ -11,10 +35,22 @@ export default {
 
   computed: {
     ticks() {
-      return this.actor.data.legacies[this.propKey] || 0
+      return this.actor.data.legacies[this.propKey] ?? 0
     },
     xpSpent() {
-      return this.actor.data.legacies[`${this.propKey}XpSpent`] || 0
+      return this.actor.data.legacies[`${this.propKey}XpSpent`] ?? 0
+    },
+    overflow() {
+      return Math.floor(this.ticks / 40) * 10
+    },
+    boxes() {
+      const ret = []
+      let remainingTicks = this.ticks % 40
+      for (let i = 0; i < 10; i++) {
+        ret.push(ticksSvg(remainingTicks))
+        remainingTicks -= 4
+      }
+      return ret
     },
   },
 }

--- a/src/module/vue/components/legacy-track.vue
+++ b/src/module/vue/components/legacy-track.vue
@@ -2,6 +2,7 @@
   <div class="flexcol">
     <div class="flexrow">
       <h4>{{ title }}</h4>
+      <p v-if="overflow" class="nogrow" style="padding: 1px; margin-right: 10px">{{ overflow }}</p>
       <icon-button v-if="editMode" icon="caret-left" @click="decrease" />
       <icon-button icon="caret-right" @click="increase" />
     </div>
@@ -81,7 +82,10 @@ export default {
       return this.actor.data.legacies[`${this.propKey}XpSpent`] ?? 0
     },
     overflow() {
-      return Math.floor(this.ticks / 40) * 10
+      const n = Math.floor(this.ticks / 40) * 10
+      if (n > 0) {
+        return `(+${n})`
+      }
     },
     boxes() {
       const ret = []

--- a/src/module/vue/components/legacy-track.vue
+++ b/src/module/vue/components/legacy-track.vue
@@ -14,12 +14,25 @@
         v-html="box"
       ></div>
     </div>
+
+    <div class="flexrow xp nogrow">
+      <xp-box
+        :actor="actor"
+        v-for="n in xpArray"
+        :key="n"
+        :value="n"
+        :current="xpSpent"
+      />
+    </div>
   </div>
 </template>
 
 <style lang="less" scoped>
 h4 {
   margin: 0.5rem 0;
+}
+.xp {
+  max-height: 25px;
 }
 </style>
 
@@ -46,6 +59,22 @@ export default {
     },
     ticks() {
       return this.actor.data.legacies[this.propKey] ?? 0
+    },
+    xpBoxCount() {
+      // 2 for each box up until 10, then 1 for each box afterwards
+      const fullBoxes = Math.floor(this.ticks / 4)
+      if (fullBoxes <= 10) {
+        return fullBoxes * 2
+      } else {
+        return fullBoxes + 10
+      }
+    },
+    xpArray() {
+      const ret = []
+      for (let i = 1; i <= this.xpBoxCount; i++) {
+        ret.push(i)
+      }
+      return ret
     },
     xpSpent() {
       return this.actor.data.legacies[`${this.propKey}XpSpent`] ?? 0

--- a/src/module/vue/components/legacy-track.vue
+++ b/src/module/vue/components/legacy-track.vue
@@ -22,6 +22,7 @@
         :key="n"
         :value="n"
         :current="xpSpent"
+        @click="setXp(n)"
       />
     </div>
   </div>
@@ -32,7 +33,7 @@ h4 {
   margin: 0.5rem 0;
 }
 .xp {
-  max-height: 25px;
+  max-height: 40px;
 }
 </style>
 
@@ -105,6 +106,12 @@ export default {
     },
     decrease() {
       this.adjust(-1)
+    },
+
+    setXp(n) {
+      this.$actor.update({
+        data: { legacies: { [`${this.propKey}XpSpent`]: n } },
+      })
     },
   },
 }

--- a/src/module/vue/components/legacy-track.vue
+++ b/src/module/vue/components/legacy-track.vue
@@ -1,0 +1,21 @@
+<template>
+  <h4>legacy track: {{ ticks }} {{ xpSpent }}</h4>
+</template>
+
+<script>
+export default {
+  props: {
+    actor: Object,
+    propKey: String,
+  },
+
+  computed: {
+    ticks() {
+      return this.actor.data.legacies[this.propKey] || 0
+    },
+    xpSpent() {
+      return this.actor.data.legacies[`${this.propKey}XpSpent`] || 0
+    },
+  },
+}
+</script>

--- a/src/module/vue/components/sf-tabs/sf-bonds.vue
+++ b/src/module/vue/components/sf-tabs/sf-bonds.vue
@@ -1,0 +1,3 @@
+<template>
+  <h3>Bonds</h3>
+</template>

--- a/src/module/vue/components/sf-tabs/sf-clocks.vue
+++ b/src/module/vue/components/sf-tabs/sf-clocks.vue
@@ -1,0 +1,3 @@
+<template>
+  <h3>Clocks</h3>
+</template>

--- a/src/module/vue/components/sf-tabs/sf-legacies.vue
+++ b/src/module/vue/components/sf-tabs/sf-legacies.vue
@@ -1,0 +1,3 @@
+<template>
+  <h3>Legacies</h3>
+</template>

--- a/src/module/vue/components/sf-tabs/sf-legacies.vue
+++ b/src/module/vue/components/sf-tabs/sf-legacies.vue
@@ -1,9 +1,14 @@
 <template>
   <div>
-    <h3>Legacies</h3>
-
+    <h4>{{$t('IRONSWORN.Quests')}}</h4>
     <legacy-track :actor="actor" propKey="quests" />
+
+    <hr>
+    <h4>{{$t('IRONSWORN.Bonds')}}</h4>
     <legacy-track :actor="actor" propKey="bonds" />
+
+    <hr>
+    <h4>{{$t('IRONSWORN.Discoveries')}}</h4>
     <legacy-track :actor="actor" propKey="discoveries" />
   </div>
 </template>

--- a/src/module/vue/components/sf-tabs/sf-legacies.vue
+++ b/src/module/vue/components/sf-tabs/sf-legacies.vue
@@ -1,3 +1,18 @@
 <template>
-  <h3>Legacies</h3>
+  <div>
+    <h3>Legacies</h3>
+
+    <legacy-track :actor="actor" propKey="quests" />
+    <legacy-track :actor="actor" propKey="bonds" />
+    <legacy-track :actor="actor" propKey="discoveries" />
+  </div>
 </template>
+
+<script>
+import LegacyTrack from '../legacy-track.vue'
+export default {
+  props: {
+    actor: Object,
+  },
+}
+</script>

--- a/src/module/vue/components/sf-tabs/sf-legacies.vue
+++ b/src/module/vue/components/sf-tabs/sf-legacies.vue
@@ -1,15 +1,8 @@
 <template>
   <div>
-    <h4>{{$t('IRONSWORN.Quests')}}</h4>
-    <legacy-track :actor="actor" propKey="quests" />
-
-    <hr>
-    <h4>{{$t('IRONSWORN.Bonds')}}</h4>
-    <legacy-track :actor="actor" propKey="bonds" />
-
-    <hr>
-    <h4>{{$t('IRONSWORN.Discoveries')}}</h4>
-    <legacy-track :actor="actor" propKey="discoveries" />
+    <legacy-track propKey="quests" :title="$t('IRONSWORN.Quests')" :actor="actor" />
+    <legacy-track propKey="bonds" :title="$t('IRONSWORN.Bonds')" :actor="actor" />
+    <legacy-track propKey="discoveries" :title="$t('IRONSWORN.Discoveries')" :actor="actor" />
   </div>
 </template>
 

--- a/src/module/vue/components/sf-tabs/sf-progresses.vue
+++ b/src/module/vue/components/sf-tabs/sf-progresses.vue
@@ -1,0 +1,3 @@
+<template>
+  <h3>Progresses</h3>
+</template>

--- a/src/module/vue/components/sf-tabs/sf-scenes.vue
+++ b/src/module/vue/components/sf-tabs/sf-scenes.vue
@@ -1,0 +1,3 @@
+<template>
+  <h3>Scenes</h3>
+</template>

--- a/src/module/vue/components/xp-box.vue
+++ b/src/module/vue/components/xp-box.vue
@@ -1,9 +1,5 @@
 <template>
-  <div
-    @click="click"
-    :class="classes"
-    data-resource="xp"
-  >
+  <div @click="$emit('click')" :class="classes" data-resource="xp">
     <slot />
   </div>
 </template>
@@ -27,12 +23,6 @@ export default {
     },
     selected() {
       return this.value <= this.current
-    },
-  },
-  methods: {
-    click(event) {
-      const actor = game.actors?.get(this.actor._id)
-      actor?.update({ data: { xp: this.value } })
     },
   },
 }

--- a/src/module/vue/sf-charactersheet.vue
+++ b/src/module/vue/sf-charactersheet.vue
@@ -55,7 +55,7 @@
           </div>
         </div>
         <keep-alive>
-          <component :is="currentTab.component" />
+          <component :is="currentTab.component" :actor="actor" />
         </keep-alive>
       </div>
 

--- a/src/module/vue/sf-charactersheet.vue
+++ b/src/module/vue/sf-charactersheet.vue
@@ -55,7 +55,11 @@
           </div>
         </div>
         <keep-alive>
-          <component :is="currentTab.component" :actor="actor" />
+          <component
+            :is="currentTab.component"
+            :actor="actor"
+            style="margin: 0.5rem"
+          />
         </keep-alive>
       </div>
 

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -77,21 +77,21 @@
         margin: 0;
       }
     }
+  }
+
+  .xp {
+    flex-grow: 0;
+    flex-direction: row;
+    flex-basis: 140px;
+    align-items: center;
 
     .xp {
-      flex-grow: 0;
-      flex-direction: row;
-      flex-basis: 140px;
-      align-items: center;
-
-      .xp {
-        height: 15px;
-        flex-basis: 15px;
-        border: 1px solid;
-        margin: 3px;
-        line-height: 13px;
-        text-align: center;
-      }
+      height: 15px;
+      flex-basis: 15px;
+      border: 1px solid;
+      margin: 3px;
+      line-height: 13px;
+      text-align: center;
     }
   }
 

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -43,6 +43,8 @@
     "Legacies": "Legacies",
     "Clocks": "Clocks",
     "Scenes": "Scenes",
+    "Quests": "Quests",
+    "Discoveries": "Discoveries",
     "Debilities": "Debilities",
     "Conditions": "Conditions",
     "Banes": "Banes",

--- a/system/template.json
+++ b/system/template.json
@@ -21,8 +21,11 @@
       "momentum": 2,
       "legacies": {
         "quests": 0,
+        "questsXpSpent": 0,
         "bonds": 0,
-        "discoveries": 0
+        "bondsXpSpent": 0,
+        "discoveries": 0,
+        "discoveriesXpSpent": 0
       },
       "debility": {
         "corrupted": false,


### PR DESCRIPTION
Adding support for legacy tracks on the "Legacies" tab. On the paper sheet they look like this:

![CleanShot 2022-02-06 at 07 48 51](https://user-images.githubusercontent.com/39902/152689006-a5ab63ed-6fb4-456d-8c64-dc3c2248cca8.jpg)

- These move with Legacy Rewards (i.e. Make a Discovery earns you two ticks)
- When you fill a box, you get two XP to spend
- If you fill the entire track, you can keep going, but you only earn one XP per box filled

### TODO

- [x] Update CHANGELOG.md
- [x] Placeholder tabs
- [x] Legacy track component
  - [x] 10 big boxes
  - [x] XP boxes
  - [x] Progress controls
  - [x] Overflow
- [x] Wire legacy tracks in tab
- [x] Add xp to chat tracking
