### PR TITLE
SF: Progresses tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Implement the progresses tab, and update the way progress items work ([#182](https://github.com/ben/foundry-ironsworn/pull/182))
+
 ## 1.10.2
 
 - Fix change logging and tweak a style ([#181](https://github.com/ben/foundry-ironsworn/pull/181))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## In progress
 
-- Implement the progresses tab, and update the way progress items work ([#182](https://github.com/ben/foundry-ironsworn/pull/182))
+- Implement the progresses tab ([#182](https://github.com/ben/foundry-ironsworn/pull/182))
 
 ## 1.10.2
 

--- a/src/module/vue/components/sf-tabs/sf-progresses.vue
+++ b/src/module/vue/components/sf-tabs/sf-progresses.vue
@@ -1,3 +1,55 @@
 <template>
-  <h3>Progresses</h3>
+  <div
+    class="flexcol sheet-area ironsworn__drop__target"
+    data-drop-type="progress"
+  >
+    <transition-group name="slide" tag="div" class="nogrow">
+      <progress-box
+        v-for="item in progressItems"
+        :key="item._id"
+        :item="item"
+        :actor="actor"
+      />
+    </transition-group>
+
+    <progress-controls :actor="actor" />
+  </div>
 </template>
+
+<style lang="less" scoped>
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.4s ease;
+  overflow: hidden;
+  max-height: 83px;
+  opacity: 1;
+}
+.slide-enter,
+.slide-leave-to {
+  max-height: 0;
+  opacity: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-top: 0;
+  border-bottom: 0;
+}
+</style>
+
+<script>
+export default {
+  props: {
+    actor: Object,
+  },
+
+  computed: {
+    progressItems() {
+      return [
+        ...this.actor.items.filter((x) => x.type === 'vow'),
+        ...this.actor.items.filter((x) => x.type === 'progress'),
+      ]
+    },
+  },
+}
+</script>


### PR DESCRIPTION
Here's how these are represented in Starforged:

<img width="317" alt="image" src="https://user-images.githubusercontent.com/39902/153232392-28ccf70d-63f1-4e47-8fb8-bafdfb9a3c85.png">

This PR just roughs them in using the old controls. We'll implement clocks and whatnot in a separate one.

- [x] Update CHANGELOG.md
- [x] Implement the "Progresses" tab on the Starforged sheet
