### PR TITLE
Stars for progress items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Implement the progresses tab ([#182](https://github.com/ben/foundry-ironsworn/pull/182))
 - Convert "vow" objects to "progress" objects ([#183](https://github.com/ben/foundry-ironsworn/pull/183))
+- Starrable progress items show on the legacies tab ([#184](https://github.com/ben/foundry-ironsworn/pull/184))
 
 ## 1.10.2
 

--- a/src/module/item/itemtypes.ts
+++ b/src/module/item/itemtypes.ts
@@ -51,6 +51,7 @@ export interface AssetDataProperties {
 
 interface ProgressDataSourceData extends ProgressBase {
   subtype: String
+  starred: Boolean
 }
 interface ProgressDataPropertiesData extends ProgressDataSourceData {}
 

--- a/src/module/vue/components/icon-button.vue
+++ b/src/module/vue/components/icon-button.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flexrow clickable block nogrow" @click="click">
-    <i :class="$concat('fas fa-', icon)"></i>
+    <i :class="classes"></i>
   </div>
 </template>
 
@@ -8,6 +8,17 @@
 export default {
   props: {
     icon: { type: String, required: true },
+    solid: { type: Boolean, default: true },
+  },
+
+  computed: {
+    classes() {
+      return {
+        fas: this.solid,
+        far: !this.solid,
+        [`fa-${this.icon}`]: true,
+      }
+    }
   },
 
   methods: {

--- a/src/module/vue/components/icon-button.vue
+++ b/src/module/vue/components/icon-button.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flexrow clickable block nogrow" @click="click">
+  <div class="flexrow clickable block nogrow" @click="click" :title="tooltip">
     <i :class="classes"></i>
   </div>
 </template>
@@ -9,6 +9,7 @@ export default {
   props: {
     icon: { type: String, required: true },
     solid: { type: Boolean, default: true },
+    tooltip: String
   },
 
   computed: {
@@ -18,7 +19,7 @@ export default {
         far: !this.solid,
         [`fa-${this.icon}`]: true,
       }
-    }
+    },
   },
 
   methods: {

--- a/src/module/vue/components/progress/progress-box.vue
+++ b/src/module/vue/components/progress/progress-box.vue
@@ -22,6 +22,7 @@
             <icon-button
               icon="star"
               :solid="item.data.starred"
+              :tooltip="$t('IRONSWORN.StarProgress')"
               @click="toggleStar"
               v-if="showStar"
             />

--- a/src/module/vue/components/progress/progress-box.vue
+++ b/src/module/vue/components/progress/progress-box.vue
@@ -17,7 +17,15 @@
             <icon-button icon="play" @click="advance" />
             <icon-button icon="dice-d6" @click="fulfill" />
           </div>
-          <h4>{{ item.name }}</h4>
+          <h4 class="flexrow">
+            <span>{{ item.name }}</span>
+            <icon-button
+              icon="star"
+              :solid="item.data.starred"
+              @click="toggleStar"
+              v-if="showStar"
+            />
+          </h4>
         </div>
       </div>
       <div class="flexrow">
@@ -45,6 +53,7 @@ export default {
   props: {
     actor: { type: Object, required: true },
     item: { type: Object, required: true },
+    showStar: Boolean,
   },
 
   computed: {
@@ -82,6 +91,9 @@ export default {
     },
     advance() {
       this.foundryItem.markProgress()
+    },
+    toggleStar() {
+      this.$item.update({ data: { starred: !this.item.data.starred } })
     },
     fulfill() {
       this.foundryItem.fulfill()

--- a/src/module/vue/components/sf-tabs/sf-legacies.vue
+++ b/src/module/vue/components/sf-tabs/sf-legacies.vue
@@ -1,8 +1,27 @@
 <template>
   <div>
-    <legacy-track propKey="quests" :title="$t('IRONSWORN.Quests')" :actor="actor" />
-    <legacy-track propKey="bonds" :title="$t('IRONSWORN.Bonds')" :actor="actor" />
-    <legacy-track propKey="discoveries" :title="$t('IRONSWORN.Discoveries')" :actor="actor" />
+    <legacy-track
+      propKey="quests"
+      :title="$t('IRONSWORN.Quests')"
+      :actor="actor"
+    />
+    <legacy-track
+      propKey="bonds"
+      :title="$t('IRONSWORN.Bonds')"
+      :actor="actor"
+    />
+    <legacy-track
+      propKey="discoveries"
+      :title="$t('IRONSWORN.Discoveries')"
+      :actor="actor"
+    />
+
+    <progress-box
+      v-for="item in starredProgresses"
+      :key="item._id"
+      :item="item"
+      :actor="actor"
+    />
   </div>
 </template>
 
@@ -11,6 +30,14 @@ import LegacyTrack from '../legacy-track.vue'
 export default {
   props: {
     actor: Object,
+  },
+
+  computed: {
+    starredProgresses() {
+      return this.actor.items
+        .filter((x) => x.type === 'progress')
+        .filter((x) => x.data.starred)
+    },
   },
 }
 </script>

--- a/src/module/vue/components/sf-tabs/sf-progresses.vue
+++ b/src/module/vue/components/sf-tabs/sf-progresses.vue
@@ -9,6 +9,7 @@
         :key="item._id"
         :item="item"
         :actor="actor"
+        :showStar="true"
       />
     </transition-group>
 

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -18,6 +18,7 @@
     "ClearProgress": "Clear Progress",
     "FulfillVow": "Fulfill Vow",
     "ProgressRoll": "Progress Roll",
+    "StarProgress": "When active, this item will also show up on the 'Legacies' tab.",
     "Mark": "Mark",
     "Fulfill": "Fulfill",
     "Clear": "Clear",

--- a/system/template.json
+++ b/system/template.json
@@ -145,7 +145,8 @@
       "templates": [
         "progress"
       ],
-      "subtype": "progress"
+      "subtype": "progress",
+      "starred": false
     },
     "vow": {
       "templates": [


### PR DESCRIPTION
This allows you to "star" a progress item, which will have it show on the legacies tab.

- [x] Update CHANGELOG.md
- [x] Extend templates and types with a `starred` field
- [x] Progress-box component can show stars, which toggle the starred state
    - [x] …with a nice tooltip
- [x] Show starred progresses on the legacies tab

Here's what that looks like:
![CleanShot 2022-02-11 at 16 57 32](https://user-images.githubusercontent.com/39902/153689583-fbb0eb17-7488-4411-a2dc-bc7540a3fb50.jpg)

