### PR TITLE
Adjust buttons on progress-box

### DIFF
--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -10,10 +10,10 @@ export class IronswornItem extends Item {
   /**
    * Progress methods
    */
-  markProgress() {
+  markProgress(numMarks = 1) {
     if (this.data.type !== 'vow' && this.data.type !== 'progress') return
 
-    const increment = RANK_INCREMENTS[this.data.data.rank]
+    const increment = RANK_INCREMENTS[this.data.data.rank] * numMarks
     const newValue = Math.min(this.data.data.current + increment, 40)
     return this.update({ 'data.current': newValue })
   }

--- a/src/module/vue/components/progress/progress-box.vue
+++ b/src/module/vue/components/progress/progress-box.vue
@@ -14,7 +14,8 @@
             <rank-hexes :current="item.data.rank" @click="rankClick" />
             <icon-button v-if="editMode" icon="trash" @click="destroy" />
             <icon-button icon="edit" @click="edit" />
-            <icon-button icon="play" @click="advance" />
+            <icon-button v-if="editMode" icon="caret-left" @click="retreat" />
+            <icon-button icon="caret-right" @click="advance" />
             <icon-button icon="dice-d6" @click="fulfill" />
           </div>
           <h4 class="flexrow">
@@ -91,7 +92,10 @@ export default {
       this.foundryItem.update({ data: { rank } })
     },
     advance() {
-      this.foundryItem.markProgress()
+      this.foundryItem.markProgress(1)
+    },
+    retreat() {
+      this.foundryItem.markProgress(-1)
     },
     toggleStar() {
       this.$item.update({ data: { starred: !this.item.data.starred } })


### PR DESCRIPTION
Before:

![CleanShot 2022-02-13 at 08 30 48](https://user-images.githubusercontent.com/39902/153762860-ba4f4d64-8e40-471d-b3f0-d28edc4b7369.jpg)
![CleanShot 2022-02-13 at 08 30 58](https://user-images.githubusercontent.com/39902/153762862-b3344de6-6bad-421b-917f-12f52ddca345.jpg)

After:

![CleanShot 2022-02-13 at 08 31 30](https://user-images.githubusercontent.com/39902/153762880-a0b1bf21-e88b-45cf-ab39-d69f8f4f2b3f.jpg)
![CleanShot 2022-02-13 at 08 31 35](https://user-images.githubusercontent.com/39902/153762882-a5a5bc9c-cdcf-4ed2-ab55-a85f94dd11c9.jpg)

- [ ] Update icons to be less heavy
- [ ] Add a "reduce" button while in edit mode
- [ ] Update CHANGELOG.md
