### PR TITLE
Add scene controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Add scene buttons for generating things for sectors ([#201](https://github.com/ben/foundry-ironsworn/pull/201))
+
 ## 1.10.9
 
 - Progress items have clocks ([#200](https://github.com/ben/foundry-ironsworn/pull/200))

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { IronswornChatCard } from './module/chat/cards'
 import { activateChangelogListeners } from './module/features/changelog'
 import { maybePromptForDependencies } from './module/features/dependencies'
 import { activateDragDropListeners } from './module/features/dragdrop'
+import { activateSceneButtonListeners } from './module/features/sceneButtons'
 import { IronswornHandlebarsHelpers } from './module/helpers/handlebars'
 import { runDataMigrations } from './module/helpers/migrations'
 import { IronswornSettings } from './module/helpers/settings'
@@ -148,6 +149,7 @@ Hooks.once('init', async () => {
   // Register Handlebars helpers
   IronswornHandlebarsHelpers.registerHelpers()
   IronswornChatCard.registerHooks()
+  activateSceneButtonListeners()
 })
 
 Hooks.once('ready', async () => {

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -19,6 +19,7 @@ export function activateSceneButtonListeners() {
       visible: true,
       activeTool: 'select',
       tools: [
+        { name: 'star', icon: 'fas fa-globe', title: 'Create Sector' },
         { name: 'star', icon: 'fas fa-star', title: 'Create Star' },
         { name: 'planet', icon: 'fas fa-globe-europe', title: 'Create Planet' },
         { name: 'settlement', icon: 'fas fa-city', title: 'Create Settlement' },

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -1,0 +1,36 @@
+import { IronswornSettings } from '../helpers/settings'
+
+export function activateSceneButtonListeners() {
+  if (!IronswornSettings.starforgedBeta) return
+
+  CONFIG.Canvas.layers['ironsworn'] = { layerClass: IronswornCanvasLayer, group: 'primary' }
+
+  Hooks.on('getSceneControlButtons', (controls) => {
+    console.log({ controls })
+    if (!game.user?.isGM) {
+      return controls
+    }
+
+    const sfControl: SceneControl = {
+      name: 'Starforged',
+      title: 'Starforged Tools',
+      icon: 'fas fa-rocket',
+      layer: 'ironsworn',
+      visible: true,
+      activeTool: 'select',
+      tools: [{ name: 'select', icon: 'fas fa-expand', title: 'Select' }],
+    }
+
+    controls.push(sfControl)
+    return controls
+  })
+}
+
+class IronswornCanvasLayer extends CanvasLayer {
+  static get layerOptions() {
+    return foundry.utils.mergeObject(super.layerOptions, {
+      zIndex: 180,
+      name: 'ironsworn',
+    })
+  }
+}

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -13,16 +13,16 @@ export function activateSceneButtonListeners() {
 
     const sfControl: SceneControl = {
       name: 'Starforged',
-      title: 'Starforged Tools', // TODO: i18n
+      title: game.i18n.localize('IRONSWORN.StarforgedTools'),
       icon: 'fas fa-space-shuttle',
       layer: 'ironsworn',
       visible: true,
       activeTool: 'select',
       tools: [
-        { name: 'star', icon: 'fas fa-globe', title: 'Create Sector' },
-        { name: 'star', icon: 'fas fa-star', title: 'Create Star' },
-        { name: 'planet', icon: 'fas fa-globe-europe', title: 'Create Planet' },
-        { name: 'settlement', icon: 'fas fa-city', title: 'Create Settlement' },
+        { name: 'star', icon: 'fas fa-globe', title: game.i18n.localize('IRONSWORN.NewSector') },
+        { name: 'star', icon: 'fas fa-star', title: game.i18n.localize('IRONSWORN.NewStar') },
+        { name: 'planet', icon: 'fas fa-globe-europe', title: game.i18n.localize('IRONSWORN.NewPlanet') },
+        { name: 'settlement', icon: 'fas fa-city', title: game.i18n.localize('IRONSWORN.NewSettlement') },
       ],
     }
 

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -13,12 +13,16 @@ export function activateSceneButtonListeners() {
 
     const sfControl: SceneControl = {
       name: 'Starforged',
-      title: 'Starforged Tools',
-      icon: 'fas fa-rocket',
+      title: 'Starforged Tools', // TODO: i18n
+      icon: 'fas fa-space-shuttle',
       layer: 'ironsworn',
       visible: true,
       activeTool: 'select',
-      tools: [{ name: 'select', icon: 'fas fa-expand', title: 'Select' }],
+      tools: [
+        { name: 'star', icon: 'fas fa-star', title: 'Create Star' },
+        { name: 'planet', icon: 'fas fa-globe-europe', title: 'Create Planet' },
+        { name: 'settlement', icon: 'fas fa-city', title: 'Create Settlement' },
+      ],
     }
 
     controls.push(sfControl)

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -125,6 +125,11 @@
     "Third": "third",
     "Fourth": "fourth",
     "Fifth": "fifth",
+    "StarforgedTools": "Starforged Tools",
+    "NewSector": "New Sector",
+    "NewStar": "New Star",
+    "NewPlanet": "New Planet",
+    "NewSettlement": "New Settlement",
     "ChangeLog": {
       "Renamed": "Renamed to {name}",
       "renamed": "renamed to {name}",


### PR DESCRIPTION
Just placeholders for now, but the skeleton is ready for more generation tools as per the process in Chapter 2 "Build a Starting Sector."

- [x] Add non-functional buttons for sector-, star-, planet-, and settlement generation.
- [x] i18n
- [x] Update CHANGELOG.md
