### PR TITLE
Better xp-track component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add scene buttons for generating things for sectors ([#201](https://github.com/ben/foundry-ironsworn/pull/201))
 - …that tell you to hold your horses ([#202](https://github.com/ben/foundry-ironsworn/pull/202))
+- Starforged XP tracks: better usability ([#203](https://github.com/ben/foundry-ironsworn/pull/203))
 
 ## 1.10.9
 

--- a/src/module/vue/components/legacy-track.vue
+++ b/src/module/vue/components/legacy-track.vue
@@ -2,7 +2,13 @@
   <div class="flexcol">
     <div class="flexrow">
       <h4>{{ title }}</h4>
-      <p v-if="overflow" class="nogrow" style="padding: 1px; margin-right: 10px">{{ overflow }}</p>
+      <p
+        v-if="overflow"
+        class="nogrow"
+        style="padding: 1px; margin-right: 10px"
+      >
+        {{ overflow }}
+      </p>
       <icon-button v-if="editMode" icon="caret-left" @click="decrease" />
       <icon-button icon="caret-right" @click="increase" />
     </div>
@@ -16,16 +22,7 @@
       ></div>
     </div>
 
-    <div class="flexrow xp nogrow">
-      <xp-box
-        :actor="actor"
-        v-for="n in xpArray"
-        :key="n"
-        :value="n"
-        :current="xpSpent"
-        @click="setXp(n)"
-      />
-    </div>
+    <xp-track :max="xpBoxCount" :marked="xpSpent" @click="setXp" />
   </div>
 </template>
 

--- a/src/module/vue/components/xp-track.vue
+++ b/src/module/vue/components/xp-track.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="flexrow xp nogrow">
+    <div
+      class="clickable block xp"
+      v-for="(box, i) in computedBoxes"
+      :key="box.key"
+      :class="box.classes"
+      @mouseover="hovered = i"
+      @mouseleave="hovered = -1"
+      @click="click(i)"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    max: Number,
+    marked: Number,
+  },
+
+  data() {
+    return {
+      hovered: -1,
+    }
+  },
+
+  computed: {
+    computedBoxes() {
+      const ret = []
+      for (let i = 0; i < this.max; i++) {
+        ret.push({
+          key: `box${i}`,
+          classes: {
+            hover: this.hovered >= i,
+            selected: this.marked >= i + 1,
+          },
+        })
+      }
+      return ret
+    },
+  },
+
+  methods: {
+    click(i) {
+      if (i === 0 && this.marked === 1) {
+        i = -1
+      }
+      this.$emit('click', i + 1)
+    },
+  },
+}
+</script>


### PR DESCRIPTION
This fixes a couple of UI issues with the Starforged XP track.

- [x] Make it possible to unmark the first XP box (click it if it's the only one marked)
- [x] Better hover-preview of what will happen when you click
- [x] Update CHANGELOG.md
