### PR TITLE
[SF] Movesheet oracles tab

### DIFF
--- a/src/module/vue/components/sf-movesheetoracles.vue
+++ b/src/module/vue/components/sf-movesheetoracles.vue
@@ -1,0 +1,39 @@
+<template>
+  <h1>foo</h1>
+</template>
+
+<script>
+function setDeep(obj, key, val) {
+  const parts = key.split('/').map((x) => x.trim())
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i]
+    obj[part] ||= {}
+    obj = obj[part]
+  }
+  obj[parts[parts.length - 1]] = val
+}
+
+export default {
+  props: {
+    actor: Object,
+  },
+
+  data() {
+    return {
+      oracles: null,
+    }
+  },
+
+  async created() {
+    const pack = game.packs.get('foundry-ironsworn.starforgedoracles')
+    if (!pack) return
+
+    const oracles = {}
+    for (const table of pack.index.values()) {
+      setDeep(oracles, table.name, table._id)
+    }
+    console.log(oracles)
+    this.oracles = oracles
+  },
+}
+</script>

--- a/src/module/vue/components/sf-movesheetoracles.vue
+++ b/src/module/vue/components/sf-movesheetoracles.vue
@@ -19,21 +19,23 @@ export default {
   },
 
   data() {
-    return {
-      oracles: null,
-    }
-  },
-
-  async created() {
-    const pack = game.packs.get('foundry-ironsworn.starforgedoracles')
-    if (!pack) return
-
     const oracles = {}
-    for (const table of pack.index.values()) {
-      setDeep(oracles, table.name, table._id)
+    const pack = this.getPack()
+    if (pack) {
+      for (const table of pack.index.values()) {
+        setDeep(oracles, table.name, table._id)
+      }
     }
-    console.log(oracles)
-    this.oracles = oracles
+
+    return {
+      oracles,
+    }
   },
+
+  methods: {
+    getPack() {
+      return game.packs.get('foundry-ironsworn.starforgedoracles')
+    }
+  }
 }
 </script>


### PR DESCRIPTION
Implements the oracles tab for the Starforged move sheet.

- [ ] Implement a tree of oracles in the move sheet
    - [ ] Expandos for directories
    - [ ] Rolling on leafs
- [ ] Update CHANGELOG.md
