### PR TITLE
Fall back to move name if i18n fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Use dataforged `$id` properties to find moves in the compendium ([#208](https://github.com/ben/foundry-ironsworn/pull/208))
+- i18n fallback for chat cards when rolling moves ([#209](https://github.com/ben/foundry-ironsworn/pull/209))
 
 ## 1.10.13
 

--- a/src/module/chat/chatrollhelpers.ts
+++ b/src/module/chat/chatrollhelpers.ts
@@ -79,6 +79,10 @@ function calculateHitTypeText(type: HIT_TYPE, match: boolean) {
 function calculateCardTitle(params: RollMessageParams) {
   if (params.move) {
     let title = game.i18n.localize(`IRONSWORN.MoveContents.${params.move.Name}.title`)
+    if (title.startsWith('IRONSWORN.')) {
+      title = params.move.Name
+    }
+
     if (params.stat) {
       title += ` (${game.i18n.localize('IRONSWORN.' + capitalize(params.stat))})`
     } else if (params.subtitle) {


### PR DESCRIPTION
Allowing Babele i18n to succeed when rolling moves.

- [x] Fix the logic
- [x] Update CHANGELOG.md
