### PR TITLE
Quick search for moves and oracles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Use dataforged `$id` properties to find moves in the compendium ([#208](https://github.com/ben/foundry-ironsworn/pull/208))
 - i18n fallback for chat cards when rolling moves ([#209](https://github.com/ben/foundry-ironsworn/pull/209))
+- Search box for SF moves and oracles ([#210](https://github.com/ben/foundry-ironsworn/pull/210))
 
 ## 1.10.13
 

--- a/src/module/vue/components/oracletree-node.vue
+++ b/src/module/vue/components/oracletree-node.vue
@@ -2,8 +2,8 @@
   <div class="flexcol">
     <h4 class="clickable text" @click="click">
       <i class="fa fa-dice-d6" v-if="oracle.tableId" />
-      <span v-else-if="expanded">V</span>
-      <span v-else>&gt;</span>
+      <span v-else-if="expanded"><i class="fa fa-caret-down" /></span>
+      <span v-else><i class="fa fa-caret-right" /></span>
       {{ oracle.title }}
     </h4>
 

--- a/src/module/vue/components/sf-movesheetmoves.vue
+++ b/src/module/vue/components/sf-movesheetmoves.vue
@@ -1,6 +1,28 @@
 <template>
   <div class="flexcol">
-    <div class="nogrow" v-for="ck of categoryKeys" :key="ck">
+    <div class="flexrow nogrow">
+      <input
+        type="text"
+        :placeholder="$t('IRONSWORN.Search')"
+        v-model="searchQuery"
+      />
+      <i
+        class="fa fa-times-circle nogrow clickable text"
+        @click="clearSearch"
+        style="padding: 6px"
+      />
+    </div>
+
+    <div class="nogrow" v-if="searchQuery">
+      <sf-moverow
+        v-for="move of searchResults"
+        :key="move.$id"
+        :actor="actor"
+        :move="move"
+      />
+    </div>
+
+    <div class="nogrow" v-else v-for="ck of categoryKeys" :key="ck">
       <h2>
         {{ ck }}
       </h2>
@@ -29,6 +51,7 @@ export default {
 
   data() {
     return {
+      searchQuery: '',
       moves: {},
       categoryKeys: [
         'Session Moves',
@@ -63,9 +86,30 @@ export default {
     this.moves = moves
   },
 
+  computed: {
+    sortedMoves() {
+      const ret = []
+      for (const category of Object.keys(this.moves || {})) {
+        ret.push(...this.moves[category].moves)
+      }
+      return ret
+    },
+
+    searchResults() {
+      if (!this.searchQuery) return null
+
+      const re = new RegExp(this.searchQuery, 'i')
+      return this.sortedMoves.filter((x) => re.test(x.foundryItem.name))
+    },
+  },
+
   methods: {
     movesForKey(ck) {
       return this.moves[ck]?.moves
+    },
+
+    clearSearch() {
+      this.searchQuery = ''
     },
   },
 }

--- a/src/module/vue/components/sf-movesheetoracles.vue
+++ b/src/module/vue/components/sf-movesheetoracles.vue
@@ -1,10 +1,32 @@
 <template>
   <div class="flexcol">
-    <oracletree-node
-      v-for="oracle in oracles"
-      :key="oracle.key"
-      :oracle="oracle"
-    />
+    <div class="flexrow nogrow">
+      <input
+        type="text"
+        :placeholder="$t('IRONSWORN.Search')"
+        v-model="searchQuery"
+      />
+      <i
+        class="fa fa-times-circle nogrow clickable text"
+        @click="clearSearch"
+        style="padding: 6px"
+      />
+    </div>
+
+    <div v-if="searchResults">
+      <oracletree-node
+        v-for="oracle in searchResults"
+        :key="oracle.key"
+        :oracle="oracle"
+      />
+    </div>
+    <div v-else>
+      <oracletree-node
+        v-for="oracle in oracles"
+        :key="oracle.key"
+        :oracle="oracle"
+      />
+    </div>
   </div>
 </template>
 
@@ -46,12 +68,18 @@ export default {
 
   data() {
     let oracles = []
+    const sortedOracles = []
     const pack = this.getPack()
     if (pack) {
       // Construct an index
       const index = {}
       for (const table of pack.index.values()) {
         setDeep(index, table.name, table._id)
+        sortedOracles.push({
+          title: table.name,
+          key: table._id,
+          tableId: table._id,
+        })
       }
 
       // Explode into objects
@@ -60,13 +88,28 @@ export default {
 
     return {
       oracles,
+      sortedOracles,
+      searchQuery: '',
     }
+  },
+
+  computed: {
+    searchResults() {
+      if (!this.searchQuery) return null
+
+      const re = new RegExp(this.searchQuery, 'i')
+      return this.sortedOracles.filter((x) => re.test(x.title))
+    },
   },
 
   methods: {
     getPack() {
       return game.packs.get('foundry-ironsworn.starforgedoracles')
     },
+
+    clearSearch() {
+      this.searchQuery = ''
+    }
   },
 }
 </script>


### PR DESCRIPTION
Adds a search box for both tabs on the SF movesheet.

- [x] Implement for moves
- [x] Implement for oracles
- [x] Update CHANGELOG.md
