### PR TITLE
SF: move references link to move sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Inline move links highlight moves in movesheet ([#218](https://github.com/ben/foundry-ironsworn/pull/218))
+
 ## 1.10.17
 
 - Fix a bug with the Delve move roller (thanks, @UmbralAlderman! [#216](https://github.com/ben/foundry-ironsworn/pull/216))

--- a/src/module/actor/sheets/charactermovesheet.ts
+++ b/src/module/actor/sheets/charactermovesheet.ts
@@ -208,6 +208,7 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
 
   async highlightMove(move: IronswornItem) {
     console.log({ move })
+    move.sheet?.render(true)
   }
 }
 

--- a/src/module/actor/sheets/charactermovesheet.ts
+++ b/src/module/actor/sheets/charactermovesheet.ts
@@ -202,7 +202,12 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
         }
       }
     }
-    ;(table as any)?.draw()
+    ; (table as any)?.draw()
+  }
+
+
+  async highlightMove(move: IronswornItem) {
+    console.log({ move })
   }
 }
 

--- a/src/module/actor/sheets/sf-charactermovesheet.ts
+++ b/src/module/actor/sheets/sf-charactermovesheet.ts
@@ -31,6 +31,6 @@ export class SFCharacterMoveSheet extends VueApplication {
   }
 
   async highlightMove(move: IronswornItem) {
-    console.log({move})
+    this._vm?.$refs.child?.['highlightMove']?.(move)
   }
 }

--- a/src/module/actor/sheets/sf-charactermovesheet.ts
+++ b/src/module/actor/sheets/sf-charactermovesheet.ts
@@ -1,5 +1,6 @@
 import { VueApplication } from '../../applications/vueapp'
 import { IronswornSettings } from '../../helpers/settings'
+import { IronswornItem } from '../../item/item'
 import { IronswornActor } from '../actor'
 
 export class SFCharacterMoveSheet extends VueApplication {
@@ -23,10 +24,13 @@ export class SFCharacterMoveSheet extends VueApplication {
   }
 
   async getData() {
-    console.log(this)
     const data: any = super.getData()
     data.actor = this.actor.toObject(false)
     data.data = this.actor.data
     return data
+  }
+
+  async highlightMove(move: IronswornItem) {
+    console.log({move})
   }
 }

--- a/src/module/vue/components/asset/asset.vue
+++ b/src/module/vue/components/asset/asset.vue
@@ -17,6 +17,7 @@
           element="p"
           :actor="actor"
           v-if="asset.data.description"
+          @moveclick="moveclick"
         >
           <div v-html="$enrichHtml(asset.data.description)"></div>
         </with-rolllisteners>
@@ -27,6 +28,7 @@
             :key="'ability' + i"
             element="li"
             :actor="actor"
+            @moveclick="moveclick"
           >
             <div v-html="$enrichHtml(ability.description)"></div>
           </with-rolllisteners>
@@ -138,6 +140,9 @@ export default {
       }
       this.foundryItem.update({ data: { exclusiveOptions: options } })
     },
+    moveclick(item) {
+      this.$actor?.moveSheet?.highlightMove(item)
+    }
   },
 }
 </script>

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="item-row">
+  <div class="item-row" :class="{ highlighted: move.highlighted }">
     <h4 style="margin: 0" class="flexrow" :title="tooltip">
       <i class="fa fa-dice-d6 clickable text nogrow" @click="rollMove" />
       <span @click="expanded = !expanded">{{ move.Name }}</span>
@@ -35,6 +35,10 @@ h4 {
 }
 i.fa-dice-d6 {
   padding-right: 0.5rem;
+}
+
+.item-row {
+  transition: all 0.4s ease;
 }
 
 .slide-enter-active,
@@ -85,6 +89,16 @@ export default {
     },
     miss() {
       return this.move.foundryItem?.data?.data?.miss
+    },
+  },
+
+  watch: {
+    'move.highlighted': async function (value) {
+      if (value) {
+        this.expanded = true
+        await new Promise((r) => setTimeout(r, 200))
+        this.$el.scrollIntoView()
+      }
     },
   },
 

--- a/src/module/vue/components/sf-movesheetmoves.vue
+++ b/src/module/vue/components/sf-movesheetmoves.vue
@@ -123,6 +123,10 @@ export default {
     clearSearch() {
       this.searchQuery = ''
     },
+
+    highlightMove(item) {
+      console.log('movestab', item)
+    }
   },
 }
 </script>

--- a/src/module/vue/components/sf-movesheetmoves.vue
+++ b/src/module/vue/components/sf-movesheetmoves.vue
@@ -92,6 +92,7 @@ export default {
       move.foundryItem = compendiumMoves.find(
         (x) => x.data.data.sourceId === move['$id']
       )
+      move.highlighted = false
       moves[move.Category] ||= { key: move.Category, moves: [] }
       moves[move.Category].moves.push(move)
     }
@@ -124,8 +125,20 @@ export default {
       this.searchQuery = ''
     },
 
-    highlightMove(item) {
-      console.log('movestab', item)
+    async highlightMove(item) {
+      this.searchQuery = ''
+      await new Promise(r => setTimeout(r, 10))
+      // TODO: this doesn't support custom moves
+      for (const k of Object.keys(this.moves)) {
+        const moveCategory = this.moves[k]
+        for (const move of moveCategory.moves) {
+          if (move.$id === item.data.data.sourceId) {
+            move.highlighted = true
+            setTimeout(() => move.highlighted = false, 2000)
+            return
+          }
+        }
+      }
     }
   },
 }

--- a/src/module/vue/components/sf-movesheetmoves.vue
+++ b/src/module/vue/components/sf-movesheetmoves.vue
@@ -139,6 +139,9 @@ export default {
           }
         }
       }
+
+      // Not found; just open the sheet
+      item.sheet?.render(true)
     }
   },
 }

--- a/src/module/vue/components/with-rolllisteners.vue
+++ b/src/module/vue/components/with-rolllisteners.vue
@@ -13,6 +13,24 @@ export default {
   mounted() {
     const actor = game.actors?.get(this.actor._id)
     CONFIG.IRONSWORN.attachInlineRollListeners($(this.$el), { actor })
+
+    $(this.$el).find('.entity-link').on('click', this.click)
+  },
+
+  methods: {
+    click(ev) {
+      ev.preventDefault()
+
+      const { pack, id } = ev.currentTarget.dataset
+      const gamePack = game.packs.get(pack)
+      gamePack.getDocument(id).then(gameItem => {
+        if (gameItem.type === 'move') {
+          this.$emit('moveclick', gameItem)
+        }
+      })
+
+      return this.$listeners['moveclick'] ? false : true
+    },
   },
 }
 </script>

--- a/src/module/vue/components/with-rolllisteners.vue
+++ b/src/module/vue/components/with-rolllisteners.vue
@@ -22,8 +22,13 @@ export default {
       ev.preventDefault()
 
       const { pack, id } = ev.currentTarget.dataset
+      if (!pack) {
+        const item = game.items?.get(id)
+        return item?.sheet?.render(true)
+      }
+
       const gamePack = game.packs.get(pack)
-      gamePack.getDocument(id).then(gameItem => {
+      gamePack?.getDocument(id)?.then(gameItem => {
         if (gameItem.type === 'move') {
           this.$emit('moveclick', gameItem)
         }

--- a/src/module/vue/sf-charactermovesheet.vue
+++ b/src/module/vue/sf-charactermovesheet.vue
@@ -15,6 +15,7 @@
       <component
         :is="currentTab.component"
         :actor="actor"
+        ref="activeTab"
       />
     </keep-alive>
   </div>
@@ -47,5 +48,13 @@ export default {
       currentTab: tabs[0],
     }
   },
+
+  methods: {
+    async highlightMove(item) {
+      this.currentTab = this.tabs[0]
+      await new Promise(r => setTimeout(r, 10))
+      this.$refs.activeTab?.['highlightMove']?.(item)
+    }
+  }
 }
 </script>

--- a/src/styles/themes/ironsworn.less
+++ b/src/styles/themes/ironsworn.less
@@ -52,6 +52,11 @@
 
   .item-row {
     border-color: black;
+    background-color: white;
+
+    &.highlighted {
+      background-color: lightyellow;
+    }
   }
 
   .progresses .item {

--- a/system/templates/actor/sf-charactermoves.hbs
+++ b/system/templates/actor/sf-charactermoves.hbs
@@ -1,5 +1,5 @@
 <form class="{{cssClass}} flexcol" autocomplete="off">
-  <sf-charactermovesheet class="ironsworn-vueport" dependencies="vue vuecomponents" :actor="actor">
+  <sf-charactermovesheet class="ironsworn-vueport" dependencies="vue vuecomponents" :actor="actor" ref="child">
     Loading…
   </sf-charactermovesheet>
 </form>


### PR DESCRIPTION
Enhancing the usability of the cross-linking in the SF moves and assets.

- [x] Intercept move-item clicks
- [x] Pipe the event to the move-sheet "moves" tab
    - [x] Expand and scroll to the proper move if it's there
    - [x] Open the move's sheet if not
- [x] Make sure we don't break Ironsworn
- [x] Update CHANGELOG.md
