### PR TITLE
Location sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Add a sector-edit dialog ([#224](https://github.com/ben/foundry-ironsworn/pull/225))
+- Add a location sheet with planet-gen tools ([#226](https://github.com/ben/foundry-ironsworn/pull/226))
 
 ## 1.10.22
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ import { defaultActor } from './module/helpers/actors'
 import { moveDataByName } from './module/helpers/data'
 import { attachInlineRollListeners, RollDialog, rollSiteFeature } from './module/helpers/roll'
 import { IronswornSettings } from './module/helpers/settings'
+import { sfOracleByDataforgedId } from './module/helpers/util'
 import { AssetItem } from './module/item/asset/assetitem'
 import { BaseItem } from './module/item/baseitem'
 import { BondsetItem } from './module/item/bondset/bondsetitem'
@@ -38,6 +39,7 @@ export interface IronswornConfig {
   rollSiteFeature: typeof rollSiteFeature
   moveDataByName: typeof moveDataByName
   defaultActor: typeof defaultActor
+  sfOracleByDataforgedId: typeof sfOracleByDataforgedId
   _: typeof lodash
 }
 
@@ -62,5 +64,6 @@ export const IRONSWORN: IronswornConfig = {
   rollSiteFeature,
   moveDataByName,
   defaultActor,
+  sfOracleByDataforgedId,
   _: lodash,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { IronswornCharacterSheet } from './module/actor/sheets/charactersheet'
 import { IronswornCharacterSheetV2 } from './module/actor/sheets/charactersheet-v2'
 import { IronswornCompactCharacterSheet } from './module/actor/sheets/compactsheet'
 import { StarforgedCharacterSheet } from './module/actor/sheets/sf-charactersheet'
+import { StarforgedLocationSheet } from './module/actor/sheets/sf-locationsheet'
 import { IronswornSharedSheet } from './module/actor/sheets/sharedsheet'
 import { IronswornSharedSheetV2 } from './module/actor/sheets/sharedsheet-v2'
 import { IronswornSiteSheet } from './module/actor/sheets/sitesheet'
@@ -97,6 +98,12 @@ Hooks.once('init', async () => {
     types: ['starship'],
     label: 'Starship sheet',
     makeDefault: true,
+  })
+
+  Actors.registerSheet('ironsworn', StarforgedLocationSheet, {
+    types: ['location'],
+    label: 'Starforged Location Sheet',
+    makeDefault: true
   })
 
   Actors.registerSheet('ironsworn', IronswornSiteSheetV2, {

--- a/src/module/actor/actortypes.ts
+++ b/src/module/actor/actortypes.ts
@@ -118,6 +118,23 @@ export interface StarshipDataProperties {
 
 ////////////////////////////////////////
 
+interface LocationDataSourceData {
+  subtype: string
+  klass: string
+}
+interface LocationDataPropertiesData extends LocationDataSourceData {}
+
+export interface LocationDataSource {
+  type: 'location'
+  data: LocationDataSourceData
+}
+export interface LocationDataProperties {
+  type: 'location'
+  data: LocationDataPropertiesData
+}
+
+////////////////////////////////////////
+
 export type ActorDataSource = CharacterDataSource | SharedDataSource | SiteDataSource | StarshipDataSource
 export type ActorDataProperties = CharacterDataProperties | SharedDataProperties | SiteDataProperties | StarshipDataProperties
 

--- a/src/module/actor/sheets/sf-locationsheet.ts
+++ b/src/module/actor/sheets/sf-locationsheet.ts
@@ -1,0 +1,29 @@
+import { IronswornSettings } from "../../helpers/settings";
+import { IronswornVueActorSheet } from "../vueactorsheet";
+
+export class StarforgedLocationSheet extends IronswornVueActorSheet {
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      classes: ['ironsworn', 'sheet', 'actor', `theme-${IronswornSettings.theme}`],
+      width: 400,
+      height: 500,
+      submitOnClose: true,
+      submitOnChange: true,
+      template: 'systems/foundry-ironsworn/templates/actor/sf-location.hbs',
+    })
+  }
+
+  getData() {
+    let data: any = super.getData()
+
+    // Allow every itemtype to add data to the actorsheet
+    for (const itemType of CONFIG.IRONSWORN.itemClasses) {
+      data = itemType.getActorSheetData(data, this)
+    }
+
+    data.actor = this.actor.toObject(false)
+    data.data = data.actor.data
+
+    return data
+  }
+}

--- a/src/module/actor/vueactorsheet.ts
+++ b/src/module/actor/vueactorsheet.ts
@@ -22,6 +22,7 @@ export class IronswornVueActorSheet extends ActorSheet {
       const states = Application.RENDER_STATES
       if (this._state == states.RENDERING || this._state == states.RENDERED) {
         // Update the Vue app with our updated actor/item/flag data.
+        if (sheetData?.actor) Vue.set(this._vm, 'actor', sheetData.actor)
         if (sheetData?.data) Vue.set(this._vm.actor, 'data', sheetData.data)
         if (sheetData?.actor?.items) Vue.set(this._vm.actor, 'items', sheetData.actor.items)
         if (sheetData?.actor?.flags) Vue.set(this._vm.actor, 'flags', sheetData.actor.flags)

--- a/src/module/helpers/util.ts
+++ b/src/module/helpers/util.ts
@@ -2,3 +2,15 @@ export function capitalize(txt: string) {
   const [first, ...rest] = txt
   return `${first.toUpperCase()}${rest.join('')}`
 }
+
+export async function sfOracleByDataforgedId(dataforgedId: string): Promise<RollTable | undefined> {
+  // Find the DF oracle by ID
+  const idMap = await fetch('systems/foundry-ironsworn/assets/sf-ids.json').then((x) => x.json())
+  const documentId = idMap[dataforgedId]
+  if (!documentId) return undefined
+
+  // Look it up in the pack
+  const pack = game.packs.get('foundry-ironsworn.starforgedoracles')
+  await pack?.getDocuments()
+  return pack?.get(documentId)
+}

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -1,0 +1,3 @@
+<template>
+  <h4>Location</h4>
+</template>

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -67,17 +67,21 @@
       </div>
     </header>
 
-    <section class="boxgroup flexcol nogrow" v-if="actor.data.subtype === 'planet'">
+    <section
+      class="boxgroup flexcol nogrow"
+      v-if="actor.data.subtype === 'planet'"
+    >
       <div class="boxrow">
         <div class="clickable block box">First look</div>
       </div>
-      <div class="flexrow boxrow">
-        <div class="clickable block box">Observed from orbit (1-2)</div>
-        <div class="clickable block box">Planetside feature (1-2)</div>
-      </div>
-      <div class="flexrow boxrow">
-        <div class="clickable block box">Settlements</div>
-        <div class="clickable block box">Life</div>
+      <div class="flexrow boxrow" v-for="(row, i) of oracles" :key="`row${i}`">
+        <div
+          class="clickable block box"
+          v-for="oracle of row"
+          :key="oracle.dfId"
+        >
+          {{ oracle.title }}
+        </div>
       </div>
     </section>
 
@@ -92,6 +96,12 @@
     </section>
   </div>
 </template>
+
+<style lang="less" scoped>
+.box {
+  padding: 7px;
+}
+</style>
 
 <script>
 import { capitalize } from 'lodash'
@@ -155,6 +165,43 @@ export default {
         { value: 'artificial', label: 'Artificial Star' },
         { value: 'unstable', label: 'Unstable Star' },
       ]
+    },
+
+    oracles() {
+      const { subtype, klass } = this.actor.data
+      const kc = capitalize(klass)
+      if (subtype === 'planet') {
+        return [
+          [
+            {
+              title: 'Atmosphere',
+              dfId: `Oracles / Planets / ${kc} / Atmosphere`,
+            },
+            {
+              title: 'From Space',
+              dfId: `Oracles / Planets / ${kc} / Observed From Space`,
+            },
+          ],
+          [
+            {
+              title: 'Planetside Feature',
+              dfId: `Oracles / Planets / ${kc} / Feature`,
+            },
+            { title: 'Life', dfId: `Oracles / Planets / ${kc} / Life` },
+            {
+              title: 'Settlements',
+              dfId: `Oracles / Planets / ${kc} / Settlements`,
+            },
+          ],
+          [
+            { title: 'Peril', dfId: `Oracles / Planets / Peril / ${kc}` },
+            {
+              title: 'Opportunity',
+              dfId: `Oracles / Planets / Opportunity / ${kc}`,
+            },
+          ],
+        ]
+      }
     },
   },
 

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -80,6 +80,7 @@
           class="clickable block box"
           @mouseenter="firstLookHighlight = true"
           @mouseleave="firstLookHighlight = false"
+          @click="rollFirstLook"
         >
           <i class="fas fa-eye"></i> &nbsp; First look
         </div>
@@ -90,6 +91,7 @@
           v-for="oracle of row"
           :class="{ highlighted: oracle.fl && firstLookHighlight }"
           :key="oracle.dfId"
+          @click="rollOracle(oracle.dfId)"
         >
           {{ oracle.title }}
         </div>
@@ -213,10 +215,21 @@ export default {
             },
           ],
           [
-            { title: 'Peril', dfId: `Oracles / Planets / Peril / ${kc}` },
             {
-              title: 'Opportunity',
-              dfId: `Oracles / Planets / Opportunity / ${kc}`,
+              title: 'Peril (life)',
+              dfId: `Oracles / Planets / Peril / Lifebearing`,
+            },
+            {
+              title: 'Peril (no life)',
+              dfId: `Oracles / Planets / Peril / Lifeless`,
+            },
+            {
+              title: 'Opportunity (life)',
+              dfId: `Oracles / Planets / Opportunity / Lifebearing`,
+            },
+            {
+              title: 'Opportunity (no life)',
+              dfId: `Oracles / Planets / Opportunity / Lifeless`,
             },
           ],
         ]
@@ -263,6 +276,15 @@ export default {
       if (option) {
         this.saveKlass(option.value)
       }
+    },
+
+    async rollFirstLook() {
+      console.log('first look!')
+    },
+    async rollOracle(dfId) {
+      const table = await CONFIG.IRONSWORN.sfOracleByDataforgedId(dfId)
+      const drawResult = await table?.draw()
+      console.log(drawResult?.results[0]?.data.text)
     },
   },
 }

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -67,25 +67,29 @@
       </div>
     </header>
 
-    <section class="nogrow">
-      <div class="boxgroup boxrow"></div>
+    <section class="boxgroup flexcol nogrow" v-if="actor.data.subtype === 'planet'">
+      <div class="boxrow">
+        <div class="clickable block box">First look</div>
+      </div>
+      <div class="flexrow boxrow">
+        <div class="clickable block box">Observed from orbit (1-2)</div>
+        <div class="clickable block box">Planetside feature (1-2)</div>
+      </div>
+      <div class="flexrow boxrow">
+        <div class="clickable block box">Settlements</div>
+        <div class="clickable block box">Life</div>
+      </div>
     </section>
 
-    <!-- if planet -->
-    <button>settlements</button>
-    <!-- "create" button at right, auto triggered when rolled -->
-
-    <button>Observed</button>
-    <button>Planetside</button>
-    <button>Life</button>
-
-    <editor
-      target="data.description"
-      :owner="true"
-      :button="true"
-      :editable="true"
-      :content="actor.data.description"
-    />
+    <section>
+      <editor
+        target="data.description"
+        :owner="true"
+        :button="true"
+        :editable="true"
+        :content="actor.data.description"
+      />
+    </section>
   </div>
 </template>
 

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -46,7 +46,11 @@
 
           <!-- Klass -->
           <div class="flexrow" style="flex-basis: 200px">
-            <select v-model="actor.data.klass" @change="klassChanged">
+            <select
+              v-model="actor.data.klass"
+              @change="klassChanged"
+              :class="{ highlighted: firstLookHighlight }"
+            >
               <option
                 v-for="opt in klassOptions"
                 :key="opt.value"
@@ -72,12 +76,19 @@
       v-if="actor.data.subtype === 'planet'"
     >
       <div class="boxrow">
-        <div class="clickable block box">First look</div>
+        <div
+          class="clickable block box"
+          @mouseenter="firstLookHighlight = true"
+          @mouseleave="firstLookHighlight = false"
+        >
+          <i class="fas fa-eye"></i> &nbsp; First look
+        </div>
       </div>
       <div class="flexrow boxrow" v-for="(row, i) of oracles" :key="`row${i}`">
         <div
           class="clickable block box"
           v-for="oracle of row"
+          :class="{ highlighted: oracle.fl && firstLookHighlight }"
           :key="oracle.dfId"
         >
           {{ oracle.title }}
@@ -100,6 +111,9 @@
 <style lang="less" scoped>
 .box {
   padding: 7px;
+}
+.highlighted {
+  background: lightyellow;
 }
 </style>
 
@@ -124,6 +138,7 @@ export default {
     const region = scene.getFlag('foundry-ironsworn', 'region') || 'terminus'
     return {
       region,
+      firstLookHighlight: false,
     }
   },
 
@@ -170,27 +185,31 @@ export default {
     oracles() {
       const { subtype, klass } = this.actor.data
       const kc = capitalize(klass)
+      const rc = capitalize(this.region)
       if (subtype === 'planet') {
         return [
           [
             {
               title: 'Atmosphere',
               dfId: `Oracles / Planets / ${kc} / Atmosphere`,
+              fl: true,
             },
             {
               title: 'From Space',
               dfId: `Oracles / Planets / ${kc} / Observed From Space`,
+              fl: true,
             },
           ],
           [
             {
-              title: 'Planetside Feature',
-              dfId: `Oracles / Planets / ${kc} / Feature`,
+              title: 'Settlements',
+              dfId: `Oracles / Planets / ${kc} / Settlements / ${rc}`,
+              fl: true,
             },
             { title: 'Life', dfId: `Oracles / Planets / ${kc} / Life` },
             {
-              title: 'Settlements',
-              dfId: `Oracles / Planets / ${kc} / Settlements`,
+              title: 'Planetside Feature',
+              dfId: `Oracles / Planets / ${kc} / Feature`,
             },
           ],
           [

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -1,8 +1,24 @@
 <template>
   <div class="flexcol">
     <header class="sheet-header flexrow nogrow">
-      <document-img :document="actor" size="82px" />
+      <document-img :document="actor" size="82px" style="margin-top: 5px" />
       <div class="flexcol">
+        <div class="flexrow nogrow">
+          <document-name :document="actor" />
+          <div
+            class="clickable block disabled nogrow"
+            style="
+              margin: 5px 0px;
+              padding: 0 5px;
+              line-height: 50px;
+              margin-left: 5px;
+            "
+            @click="randomizeName"
+          >
+            <i class="fa fa-dice-d6" />
+          </div>
+        </div>
+
         <div class="flexrow nogrow">
           <select
             style="margin-right: 5px; flex-basis: 150px"
@@ -31,22 +47,6 @@
             >
               <i class="fa fa-dice-d6" />
             </div>
-          </div>
-        </div>
-
-        <div class="flexrow nogrow">
-          <document-name :document="actor" />
-          <div
-            class="clickable block disabled nogrow"
-            style="
-              margin: 5px 0px;
-              padding: 0 5px;
-              line-height: 50px;
-              margin-left: 5px;
-            "
-            @click="randomizeName"
-          >
-            <i class="fa fa-dice-d6" />
           </div>
         </div>
       </div>

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -5,7 +5,7 @@
       <div class="flexcol">
         <div class="flexrow nogrow">
           <select
-            style="margin-right: 5px"
+            style="margin-right: 5px; flex-basis: 150px"
             v-model="actor.data.subtype"
             @change="subtypeChanged"
           >
@@ -14,7 +14,7 @@
             <option value="star">Stellar Object</option>
           </select>
 
-          <div class="flexrow">
+          <div class="flexrow" style="flex-basis: 200px">
             <select v-model="actor.data.klass" @change="klassChanged">
               <option
                 v-for="opt in klassOptions"
@@ -141,7 +141,6 @@ export default {
     klassChanged(evt) {
       this.saveKlass(evt.target.value)
     },
-
 
     saveSubtype(subtype) {
       this.$actor.update({ data: { subtype } })

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -75,6 +75,15 @@
 </template>
 
 <script>
+import { capitalize } from 'lodash'
+function randomImage(subtype, klass) {
+  if (subtype === 'planet') {
+    const name = capitalize(klass)
+    const i = Math.floor(Math.random() * 2) + 1
+    return `systems/foundry-ironsworn/assets/planets/Starforged-Planet-Token-${name}-0${i}.webp`
+  }
+}
+
 export default {
   props: {
     actor: Object,
@@ -107,14 +116,17 @@ export default {
   },
 
   methods: {
-    saveSubtype() {
-      const subtype = this.actor.data.subtype
+    saveSubtype(evt) {
+      const subtype = evt.target.value
       this.$actor.update({ data: { subtype } })
     },
-    saveKlass() {
-      // TODO: update the image
-      const klass = this.actor.data.klass
-      this.$actor.update({ data: { klass } })
+    saveKlass(evt) {
+      const klass = evt.target.value
+      const { subtype } = this.actor.data
+      const img = randomImage(subtype, klass)
+
+      this.$actor.update({ img, data: { klass } })
+      // TODO: update prototype and all linked tokens
     },
     randomizeName() {},
     randomizeKlass() {},

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -111,7 +111,27 @@ export default {
           { value: 'vital', label: 'Vital World' },
         ]
       }
-      return [] // TODO: settlements and stellar objects
+      if (this.actor.data.subtype === 'settlement') {
+        return [
+          { value: 'planetside', label: 'Planetside' },
+          { value: 'orbital', label: 'Orbital' },
+          { value: 'deepspace', label: 'Deep Space' },
+        ]
+      }
+      return [
+        { value: 'smoldering', label: 'Smoldering Red Star' },
+        { value: 'glowing', label: 'Glowing Orange Star' },
+        { value: 'burning', label: 'Burning Yellow Star' },
+        { value: 'blazing', label: 'Blazing Blue Star' },
+        { value: 'young', label: 'Young Star' },
+        { value: 'whitedwarf', label: 'White Dwarf' },
+        { value: 'corrupted', label: 'Corrupted Star' },
+        { value: 'neutron', label: 'Neutron Star' },
+        { value: 'double', label: 'Binary Stars' },
+        { value: 'blackhole', label: 'Black Hole' },
+        { value: 'artificial', label: 'Artificial Star' },
+        { value: 'unstable', label: 'Unstable Star' },
+      ]
     },
   },
 

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -37,7 +37,7 @@
         <div class="flexrow nogrow">
           <document-name :document="actor" />
           <div
-            class="clickable block nogrow"
+            class="clickable block disabled nogrow"
             style="
               margin: 5px 0px;
               padding: 0 5px;
@@ -153,7 +153,14 @@ export default {
       this.$actor.update({ img, data: { klass } })
       // TODO: update prototype and all linked tokens
     },
-    randomizeName() {},
+
+    async randomizeName() {
+      // no oracle for this
+      const klass = capitalize(this.actor.data.klass)
+      const table = await CONFIG.IRONSWORN.sfOracleByDataforgedId(
+        `Oracles / Planets / ${this.actor} / Name`
+      )
+    },
     async randomizeKlass() {
       const table = await CONFIG.IRONSWORN.sfOracleByDataforgedId(
         'Oracles / Planets / Class'

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -20,6 +20,20 @@
         </div>
 
         <div class="flexrow nogrow">
+          <!-- Region -->
+          <select v-model="region" style="margin-right: 5px; flex-basis: 150px">
+            <option value="terminus">
+              {{ $t('IRONSWORN.Terminus') }}
+            </option>
+            <option value="outlands">
+              {{ $t('IRONSWORN.Outlands') }}
+            </option>
+            <option value="expanse">
+              {{ $t('IRONSWORN.Expanse') }}
+            </option>
+          </select>
+
+          <!-- Subtype -->
           <select
             style="margin-right: 5px; flex-basis: 150px"
             v-model="actor.data.subtype"
@@ -30,6 +44,7 @@
             <option value="star">Stellar Object</option>
           </select>
 
+          <!-- Klass -->
           <div class="flexrow" style="flex-basis: 200px">
             <select v-model="actor.data.klass" @change="klassChanged">
               <option
@@ -90,7 +105,12 @@ export default {
   },
 
   data() {
-    return {}
+    const sceneId = game.user.viewedScene
+    const scene = game.scenes.get(sceneId)
+    const region = scene.getFlag('foundry-ironsworn', 'region') || 'terminus'
+    return {
+      region,
+    }
   },
 
   computed: {

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -7,7 +7,7 @@
           <select
             style="margin-right: 5px"
             v-model="actor.data.subtype"
-            @change="saveSubtype"
+            @change="subtypeChanged"
           >
             <option value="planet">Planet</option>
             <option value="settlement">Settlement</option>
@@ -15,7 +15,7 @@
           </select>
 
           <div class="flexrow">
-            <select v-model="actor.data.klass" @change="saveKlass">
+            <select v-model="actor.data.klass" @change="klassChanged">
               <option
                 v-for="opt in klassOptions"
                 :key="opt.value"
@@ -97,7 +97,6 @@ export default {
     klassOptions() {
       if (this.actor.data.subtype === 'planet') {
         return [
-          { value: '', label: '(Planet Class)' },
           { value: 'desert', label: 'Desert World' },
           { value: 'furnace', label: 'Furnace World' },
           { value: 'grave', label: 'Grave World' },
@@ -136,12 +135,18 @@ export default {
   },
 
   methods: {
-    saveSubtype(evt) {
-      const subtype = evt.target.value
+    subtypeChanged(evt) {
+      this.saveSubtype(evt.target.value)
+    },
+    klassChanged(evt) {
+      this.saveKlass(evt.target.value)
+    },
+
+
+    saveSubtype(subtype) {
       this.$actor.update({ data: { subtype } })
     },
-    saveKlass(evt) {
-      const klass = evt.target.value
+    saveKlass(klass) {
       const { subtype } = this.actor.data
       const img = randomImage(subtype, klass)
 
@@ -149,7 +154,20 @@ export default {
       // TODO: update prototype and all linked tokens
     },
     randomizeName() {},
-    randomizeKlass() {},
+    async randomizeKlass() {
+      const table = await CONFIG.IRONSWORN.sfOracleByDataforgedId(
+        'Oracles / Planets / Class'
+      )
+      const result = await table?.draw()
+      const rawText = result?.results[0]?.data.text
+      if (!rawText) return
+
+      const lctext = rawText.toLowerCase()
+      const option = this.klassOptions.find((x) => lctext.match(x.value))
+      if (option) {
+        this.saveKlass(option.value)
+      }
+    },
   },
 }
 </script>

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -1,3 +1,41 @@
 <template>
-  <h4>Location</h4>
+  <div class="flexcol">
+    <header class="sheet-header flexrow">
+      <document-img :document="actor" size="82px" />
+      <div class="flexcol">
+        <div class="flexrow nogrow">
+          <select style="flex-basis: 300px">
+            <option>planet or settlement</option>
+          </select>
+          <button style="flex-basis: 100px">random name</button>
+        </div>
+        <document-name :document="actor" />
+      </div>
+    </header>
+
+    <!-- if planet -->
+    <button>class</button>
+    <button>settlements</button>
+    <!-- "create" button at right, auto triggered when rolled -->
+
+    <button>Observed</button>
+    <button>Planetside</button>
+    <button>Life</button>
+
+    <editor
+      target="data.description"
+      :owner="true"
+      :button="true"
+      :editable="true"
+      :content="actor.data.description"
+    />
+  </div>
 </template>
+
+<script>
+export default {
+  props: {
+    actor: Object,
+  },
+}
+</script>

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -1,20 +1,62 @@
 <template>
   <div class="flexcol">
-    <header class="sheet-header flexrow">
+    <header class="sheet-header flexrow nogrow">
       <document-img :document="actor" size="82px" />
       <div class="flexcol">
         <div class="flexrow nogrow">
-          <select style="flex-basis: 300px">
-            <option>planet or settlement</option>
+          <select
+            style="margin-right: 5px"
+            v-model="actor.data.subtype"
+            @change="saveSubtype"
+          >
+            <option value="planet">Planet</option>
+            <option value="settlement">Settlement</option>
+            <option value="star">Stellar Object</option>
           </select>
-          <button style="flex-basis: 100px">random name</button>
+
+          <div class="flexrow">
+            <select v-model="actor.data.klass" @change="saveKlass">
+              <option
+                v-for="opt in klassOptions"
+                :key="opt.value"
+                :value="opt.value"
+              >
+                {{ opt.label }}
+              </option>
+            </select>
+            <div
+              class="clickable block nogrow"
+              style="margin-left: 5px; padding: 5px"
+              @click="randomizeKlass"
+            >
+              <i class="fa fa-dice-d6" />
+            </div>
+          </div>
         </div>
-        <document-name :document="actor" />
+
+        <div class="flexrow nogrow">
+          <document-name :document="actor" />
+          <div
+            class="clickable block nogrow"
+            style="
+              margin: 5px 0px;
+              padding: 0 5px;
+              line-height: 50px;
+              margin-left: 5px;
+            "
+            @click="randomizeName"
+          >
+            <i class="fa fa-dice-d6" />
+          </div>
+        </div>
       </div>
     </header>
 
+    <section class="nogrow">
+      <div class="boxgroup boxrow"></div>
+    </section>
+
     <!-- if planet -->
-    <button>class</button>
     <button>settlements</button>
     <!-- "create" button at right, auto triggered when rolled -->
 
@@ -36,6 +78,46 @@
 export default {
   props: {
     actor: Object,
+  },
+
+  data() {
+    return {}
+  },
+
+  computed: {
+    klassOptions() {
+      if (this.actor.data.subtype === 'planet') {
+        return [
+          { value: '', label: '(Planet Class)' },
+          { value: 'desert', label: 'Desert World' },
+          { value: 'furnace', label: 'Furnace World' },
+          { value: 'grave', label: 'Grave World' },
+          { value: 'ice', label: 'Ice World' },
+          { value: 'jovian', label: 'Jovian World' },
+          { value: 'jungle', label: 'Jungle World' },
+          { value: 'ocean', label: 'Ocean World' },
+          { value: 'rocky', label: 'Rocky World' },
+          { value: 'shattered', label: 'Shattered World' },
+          { value: 'tainted', label: 'Tainted World' },
+          { value: 'vital', label: 'Vital World' },
+        ]
+      }
+      return [] // TODO: settlements and stellar objects
+    },
+  },
+
+  methods: {
+    saveSubtype() {
+      const subtype = this.actor.data.subtype
+      this.$actor.update({ data: { subtype } })
+    },
+    saveKlass() {
+      // TODO: update the image
+      const klass = this.actor.data.klass
+      this.$actor.update({ data: { klass } })
+    },
+    randomizeName() {},
+    randomizeKlass() {},
   },
 }
 </script>

--- a/system/template.json
+++ b/system/template.json
@@ -4,7 +4,8 @@
       "character",
       "shared",
       "site",
-      "starship"
+      "starship",
+      "location"
     ],
     "character": {
       "biography": "",
@@ -136,6 +137,9 @@
         "battered": false,
         "cursed": false
       }
+    },
+    "location": {
+      "subtype": "planet"
     }
   },
   "Item": {

--- a/system/template.json
+++ b/system/template.json
@@ -139,7 +139,8 @@
       }
     },
     "location": {
-      "subtype": "planet"
+      "subtype": "planet",
+      "klass": ""
     }
   },
   "Item": {

--- a/system/templates/actor/sf-location.hbs
+++ b/system/templates/actor/sf-location.hbs
@@ -1,0 +1,5 @@
+<form class="{{cssClass}} flexcol" autocomplete="off">
+  <sf-locationsheet class="ironsworn-vueport" dependencies="vue vuecomponents" :actor="actor">
+    Loading…
+  </sf-locationsheet>
+</form>


### PR DESCRIPTION
This adds a `location` actor type and a Vue sheet for it, with oracle tools and some free-form text.

Inspiration from @DiceT's system:
![CleanShot 2022-03-12 at 17 19 18](https://user-images.githubusercontent.com/39902/158040751-a8857c18-c120-4155-96fd-37773a21aac3.jpg)

And also from [Stargazer](https://nboughton.uk/apps/stargazer):
![CleanShot 2022-03-12 at 17 19 27](https://user-images.githubusercontent.com/39902/158040766-aeec944b-170f-4055-b6fe-51797ec44e59.jpg)

The goal here is to get a usable planet generator going, settlements and linkages thereof will come later.

- [x] New actor type with `subtype` field
- [x] Wire up the sheet
- [x] Wire up an editor for the description
- [x] Oracle dashboard for planets
    - [x] "First look" button that uses the `Initial` key in Dataforged oracles
    - [x] Do actual table rolls, including chat output
- [x] Update CHANGELOG.md
