### PR TITLE
Avoid multiple logging when creating progress/vow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Fix a bug where creating progress/vow items would output to chat multiple times ([#235](https://github.com/ben/foundry-ironsworn/pull/235))
+
 ## 1.10.24
 
 - Random planet names ([#231](https://github.com/ben/foundry-ironsworn/pull/231))

--- a/src/module/features/changelog.ts
+++ b/src/module/features/changelog.ts
@@ -39,7 +39,7 @@ export function activateChangelogListeners() {
     sendToChat(item.parent, `${itemName} ${content}`)
   })
 
-  Hooks.on('createItem', async (item: IronswornItem, options, _userId: number) => {
+  Hooks.on('preCreateItem', async (item: IronswornItem, options, _userId: number) => {
     if (!IronswornSettings.logCharacterChanges) return
     if (!item.parent) return // No logging for unowned items, they don't matter
     if (options.suppressLog) return


### PR DESCRIPTION
Fixes #233. Apparently the `preCreateItem` only fires in the browser creating the item, while the `createItem` hook fires on all clients.

- [x] Fix the bug
- [x] Update CHANGELOG.md
