### PR TITLE
Drop location when creating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Scene buttons generate actors in folders ([#237](https://github.com/ben/foundry-ironsworn/pull/237))
+- …and also drop a token in the center of the viewport ([#239](https://github.com/ben/foundry-ironsworn/pull/239))
 
 ## 1.10.25
 


### PR DESCRIPTION
When using the scene buttons, this drops a token for the new location in the center of the viewport.

- [x] Implement the logic
- [x] Update CHANGELOG.md
