### PR TITLE
Update properly when editing a location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Derelict/vault/settlement token images ([#244](https://github.com/ben/foundry-ironsworn/pull/244))
 - Ensure planets are drawn behind their neighbors ([#246](https://github.com/ben/foundry-ironsworn/pull/246))
+- Better updating of token images when editing a locaiton ([#247](https://github.com/ben/foundry-ironsworn/pull/247))
 
 ## 1.10.28
 

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -432,14 +432,16 @@ export default {
     },
 
     async saveSubtype(subtype) {
+      const img = randomImage(subtype, this.actor.data.klass)
       await this.$actor.update({ data: { subtype } })
+      await this.updateAllTokens({ img, scale: 2 })
     },
     async saveKlass(klass) {
       const { subtype } = this.actor.data
       const img = randomImage(subtype, klass)
 
       await this.$actor.update({ img, data: { klass } })
-      await this.updateAllTokens({ img })
+      await this.updateAllTokens({ img, scale: 2 })
     },
 
     async randomizeName() {


### PR DESCRIPTION
This updates the image of location tokens when changing the subtype, and also changes the scale to 2 to work with the built-in images.

- [x] Fix the logic
- [x] Update CHANGELOG.md
