### PR TITLE
Easy buttons for token rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Derelict/vault/settlement token images ([#244](https://github.com/ben/foundry-ironsworn/pull/244))
 - Ensure planets are drawn behind their neighbors ([#246](https://github.com/ben/foundry-ironsworn/pull/246))
 - Better updating of token images when editing a locaiton ([#247](https://github.com/ben/foundry-ironsworn/pull/247))
+- Token HUD buttons for 60° rotation ([#248](https://github.com/ben/foundry-ironsworn/pull/248))
 
 ## 1.10.28
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { activateChangelogListeners } from './module/features/changelog'
 import { maybePromptForDependencies } from './module/features/dependencies'
 import { activateDragDropListeners } from './module/features/dragdrop'
 import { activateSceneButtonListeners } from './module/features/sceneButtons'
+import { registerTokenHUDButtons } from './module/features/tokenRotateButtons'
 import { registerZIndexHook } from './module/features/z-index'
 import { IronswornHandlebarsHelpers } from './module/helpers/handlebars'
 import { runDataMigrations } from './module/helpers/migrations'
@@ -166,6 +167,7 @@ Hooks.once('init', async () => {
   IronswornChatCard.registerHooks()
   activateSceneButtonListeners()
   registerZIndexHook()
+  registerTokenHUDButtons()
 })
 
 Hooks.once('ready', async () => {

--- a/src/module/features/tokenRotateButtons.ts
+++ b/src/module/features/tokenRotateButtons.ts
@@ -1,0 +1,30 @@
+// https://github.com/zeel01/TokenHUDArtButton/blob/master/artbutton.js#L281
+
+function rotateTokenBy(ev: JQuery.ClickEvent, tokenData: any, angle: number) {
+  ev.preventDefault()
+  const token = canvas?.scene?.tokens.get(tokenData._id)
+  if (!token) return
+  const rotation = token.data.rotation + angle
+  canvas?.scene?.updateEmbeddedDocuments('Token', [{ _id: token.id, rotation }])
+}
+
+function HUDCallback(_hud, html, token) {
+  const leftButton = document.createElement('div')
+  leftButton.classList.add('control-icon')
+  leftButton.innerHTML = '<i class="fas fa-undo" />'
+  leftButton.title = game.i18n.localize('IRONSWORN.RotateCCW')
+  $(leftButton).on('click', (ev) => rotateTokenBy(ev, token, -60))
+
+  const rightButton = document.createElement('div')
+  rightButton.classList.add('control-icon')
+  rightButton.innerHTML = '<i class="fas fa-redo" />'
+  rightButton.title = game.i18n.localize('IRONSWORN.RotateCW')
+  $(rightButton).on('click', (ev) => rotateTokenBy(ev, token, 60))
+
+  html.find('div.left').prepend(leftButton)
+  html.find('div.right').prepend(rightButton)
+}
+
+export async function registerTokenHUDButtons() {
+  Hooks.on('renderTokenHUD', HUDCallback)
+}

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -149,6 +149,8 @@
     "Terminus": "Terminus",
     "Outlands": "Outlands",
     "Expanse": "Expanse",
+    "RotateCCW": "Rotate counter-clockwise",
+    "RotateCW": "Rotate clockwise",
     "ChangeLog": {
       "Renamed": "Renamed to {name}",
       "renamed": "renamed to {name}",


### PR DESCRIPTION
This adds buttons to make it easy to rotate tokens in 60° increments, so you can place locations around planets.

![CleanShot 2022-03-22 at 09 38 22](https://user-images.githubusercontent.com/39902/159530066-bfe289c7-1998-4f5d-8a10-71f592bbbe7e.jpg)


- [x] Add the buttons
- [x] Update CHANGELOG.md
