### PR TITLE
SF: Quill editor for notes tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- A new HTML editor for the SF character notes tab ([#250](https://github.com/ben/foundry-ironsworn/pull/250))
+
 ## 1.10.29
 
 - Derelict/vault/settlement token images ([#244](https://github.com/ben/foundry-ironsworn/pull/244))

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@types/lodash": "^4.14.170",
         "gulp": "^4.0.2",
         "gulp-less": "^5.0.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "vue2-editor": "^2.10.3"
       },
       "devDependencies": {
         "@league-of-foundry-developers/foundry-vtt-types": "^0.8.8-0",
@@ -2657,7 +2658,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
       "dependencies": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -3795,6 +3795,11 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+    },
     "node_modules/fast-glob": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
@@ -4655,7 +4660,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -5155,7 +5159,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -5225,7 +5228,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -5360,7 +5362,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -6646,7 +6647,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
       "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -6915,6 +6915,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -7551,6 +7556,37 @@
         }
       ]
     },
+    "node_modules/quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/quill/node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -7894,7 +7930,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
       "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -10005,6 +10040,14 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "node_modules/vue2-editor": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/vue2-editor/-/vue2-editor-2.10.3.tgz",
+      "integrity": "sha512-99rWL93xfGeFRrq8NY5L7U+Cog/Uenx+UOOJragtxtbhBE9Rv5/C3P/YhJhjMECSbQyHFjUriqv1S3mghvU9Kg==",
+      "dependencies": {
+        "quill": "^1.3.6"
+      }
     },
     "node_modules/watchpack": {
       "version": "2.3.1",
@@ -13093,7 +13136,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -14015,6 +14057,11 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+    },
     "fast-glob": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
@@ -14682,7 +14729,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -15073,7 +15119,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -15127,7 +15172,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -15222,7 +15266,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -16201,7 +16244,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
       "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -16398,6 +16440,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -16862,6 +16909,36 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "requires": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+          "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+        }
+      }
+    },
+    "quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -17130,7 +17207,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
       "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -18811,6 +18887,14 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue2-editor": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/vue2-editor/-/vue2-editor-2.10.3.tgz",
+      "integrity": "sha512-99rWL93xfGeFRrq8NY5L7U+Cog/Uenx+UOOJragtxtbhBE9Rv5/C3P/YhJhjMECSbQyHFjUriqv1S3mghvU9Kg==",
+      "requires": {
+        "quill": "^1.3.6"
+      }
     },
     "watchpack": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "@types/lodash": "^4.14.170",
     "gulp": "^4.0.2",
     "gulp-less": "^5.0.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "vue2-editor": "^2.10.3"
   },
   "devDependencies": {
     "@league-of-foundry-developers/foundry-vtt-types": "^0.8.8-0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ Hooks.once('init', async () => {
   Actors.registerSheet('ironsworn', StarforgedLocationSheet, {
     types: ['location'],
     label: 'Starforged Location Sheet',
-    makeDefault: true
+    makeDefault: true,
   })
 
   Actors.registerSheet('ironsworn', IronswornSiteSheetV2, {
@@ -180,6 +180,13 @@ Hooks.once('ready', async () => {
 
   CONFIG.IRONSWORN.applications.createActorDialog = new CreateActorDialog({})
   WorldTruthsDialog.maybeShow()
+
+  // Quill theme stylesheet
+  const link = document.createElement('link')
+  // link.type = 'text/css'
+  link.rel = 'stylesheet'
+  link.href = '//cdn.quilljs.com/1.3.6/quill.bubble.css'
+  document.head.appendChild(link)
 })
 
 Hooks.once('setup', () => {

--- a/src/module/vue/components/quill-editor.vue
+++ b/src/module/vue/components/quill-editor.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <VueEditor
+      :placeholder="placeholder"
+      :editorToolbar="toolbar"
+      :editorOptions="options"
+      v-bind:value="value"
+      @input="$emit('input', $event)"
+    />
+  </div>
+</template>
+
+<style lang="less">
+.ql-container {
+  font-family: var(--font-primary) !important;
+}
+.ql-tooltip {
+  z-index: 100;
+}
+</style>
+
+<script>
+import { VueEditor } from 'vue2-editor'
+
+export default {
+  components: { VueEditor },
+
+  props: {
+    placeholder: String,
+    value: String,
+
+    toolbar: {
+      type: Array,
+      default: [
+        [{ header: [false, 1, 2, 3, 4] }],
+        ['bold', 'italic', 'underline'],
+        [{ list: 'ordered' }, { list: 'bullet' }],
+        ['blockquote', 'code-block'],
+        ['clean'],
+      ],
+    },
+
+    options: {
+      type: Object,
+      default: {
+        theme: 'bubble',
+      },
+    },
+  },
+}
+</script>

--- a/src/module/vue/components/quill-editor.vue
+++ b/src/module/vue/components/quill-editor.vue
@@ -6,6 +6,8 @@
       :editorOptions="options"
       v-bind:value="value"
       @input="$emit('input', $event)"
+      class="flexcol"
+      style="height: 100%"
     />
   </div>
 </template>
@@ -16,6 +18,13 @@
 }
 .ql-tooltip {
   z-index: 100;
+}
+.ql-toolbar {
+  flex-grow: 0;
+}
+.ql-container {
+  display: flex;
+  flex-grow: 1;
 }
 </style>
 
@@ -32,10 +41,9 @@ export default {
     toolbar: {
       type: Array,
       default: [
-        [{ header: [false, 1, 2, 3, 4] }],
-        ['bold', 'italic', 'underline'],
+        [{ header: [false, 1, 2, 3, 4] }, 'bold', 'italic', 'underline'],
         [{ list: 'ordered' }, { list: 'bullet' }],
-        ['blockquote', 'code-block'],
+        ['link', 'image'],
         ['clean'],
       ],
     },

--- a/src/module/vue/components/quill-editor.vue
+++ b/src/module/vue/components/quill-editor.vue
@@ -43,7 +43,10 @@ export default {
       default: [
         [{ header: [false, 1, 2, 3, 4] }, 'bold', 'italic', 'underline'],
         [{ list: 'ordered' }, { list: 'bullet' }],
-        ['link', 'image'],
+        [
+          'link',
+          // 'image'
+        ],
         ['clean'],
       ],
     },

--- a/src/module/vue/components/sf-tabs/sf-notes.vue
+++ b/src/module/vue/components/sf-tabs/sf-notes.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flexcol" style="margen: 1rem">
-    <VueEditor v-model="actor.data.notes" />
+    <VueEditor :editorToolbar="toolbar" v-model="actor.data.notes" />
   </div>
 </template>
 
@@ -13,6 +13,18 @@ export default {
 
   props: {
     actor: Object,
+  },
+
+  data() {
+    return {
+      toolbar: [
+        [{ header: [false, 1, 2, 3, 4] }],
+        ['bold', 'italic', 'underline'],
+        [{ list: 'ordered' }, { list: 'bullet' }],
+        ['blockquote', 'code-block'],
+        ['clean'],
+      ],
+    }
   },
 
   watch: {

--- a/src/module/vue/components/sf-tabs/sf-notes.vue
+++ b/src/module/vue/components/sf-tabs/sf-notes.vue
@@ -1,26 +1,28 @@
 <template>
   <div class="flexcol" style="margen: 1rem">
-    <textarea
-      v-model="actor.data.notes"
-      @blur="save"
-    ></textarea>
+    <VueEditor v-model="actor.data.notes" />
   </div>
 </template>
 
-<style lang="less" scoped>
-input,
-textarea {
-  border-color: rgba(0, 0, 0, 0.1);
-  border-radius: 1px;
-  font-family: var(--font-primary);
-  resize: none;
-}
-</style>
-
 <script>
+import { debounce } from 'lodash'
+import { VueEditor } from 'vue2-editor'
+
 export default {
+  components: { VueEditor },
+
   props: {
     actor: Object,
+  },
+
+  watch: {
+    'actor.data.notes'() {
+      this.debouncedSave()
+    },
+  },
+
+  created() {
+    this.debouncedSave = debounce(this.save, 500)
   },
 
   methods: {

--- a/src/module/vue/components/sf-tabs/sf-notes.vue
+++ b/src/module/vue/components/sf-tabs/sf-notes.vue
@@ -1,16 +1,13 @@
 <template>
   <div class="flexcol" style="margen: 1rem">
-    <VueEditor :editorToolbar="toolbar" v-model="actor.data.notes" />
+    <quill-editor v-model="actor.data.notes" :editorToolbar="toolbar" :editorOptions="options" />
   </div>
 </template>
 
 <script>
 import { debounce } from 'lodash'
-import { VueEditor } from 'vue2-editor'
 
 export default {
-  components: { VueEditor },
-
   props: {
     actor: Object,
   },
@@ -24,6 +21,9 @@ export default {
         ['blockquote', 'code-block'],
         ['clean'],
       ],
+      options: {
+        theme: 'bubble'
+      }
     }
   },
 

--- a/src/module/vue/components/sf-tabs/sf-notes.vue
+++ b/src/module/vue/components/sf-tabs/sf-notes.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flexcol" style="margen: 1rem">
-    <quill-editor v-model="actor.data.notes" :editorToolbar="toolbar" :editorOptions="options" />
+    <quill-editor v-model="actor.data.notes" />
   </div>
 </template>
 
@@ -10,21 +10,6 @@ import { debounce } from 'lodash'
 export default {
   props: {
     actor: Object,
-  },
-
-  data() {
-    return {
-      toolbar: [
-        [{ header: [false, 1, 2, 3, 4] }],
-        ['bold', 'italic', 'underline'],
-        [{ list: 'ordered' }, { list: 'bullet' }],
-        ['blockquote', 'code-block'],
-        ['clean'],
-      ],
-      options: {
-        theme: 'bubble'
-      }
-    }
   },
 
   watch: {


### PR DESCRIPTION
The notes tab is getting an upgrade. This adds a component that wraps a [`VueEditor`](https://www.npmjs.com/package/vue2-editor), which in turn is wrapping a [Quill editor](https://quilljs.com/), and slaps that into the notes tab. It supports HTML, but not drop-links to other Foundry objects (yet).

- [x] New component to wrap defaults
- [x] Use it for the notes tab 
- [x] Update CHANGELOG.md
