### PR TITLE
Ironsworn sheet: HTML notes editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - A new HTML editor for the SF character notes tab ([#250](https://github.com/ben/foundry-ironsworn/pull/250))
 - A "foe" actor type so that a progress item can have a token ([#252](https://github.com/ben/foundry-ironsworn/pull/252))
+- Use the HTML editor for the IS notes box ([#253](https://github.com/ben/foundry-ironsworn/pull/253))
 
 ## 1.10.29
 

--- a/src/module/vue/character-sheet.vue
+++ b/src/module/vue/character-sheet.vue
@@ -94,12 +94,7 @@
               <progress-controls :actor="actor" />
             </div>
 
-            <textarea
-              class="notes"
-              :placeholder="$t('IRONSWORN.Notes')"
-              v-model="actor.data.biography"
-              @blur="saveNotes"
-            />
+            <quill-editor v-model="actor.data.biography" />
           </div>
         </div>
 
@@ -189,6 +184,12 @@ export default {
     },
     assets() {
       return this.actor.items.filter((x) => x.type === 'asset')
+    },
+  },
+
+  watch: {
+    'actor.data.biography'() {
+      this.saveNotes()
     },
   },
 

--- a/src/module/vue/components/quill-editor.vue
+++ b/src/module/vue/components/quill-editor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div style="border: 1px solid black">
     <VueEditor
       :placeholder="placeholder"
       :editorToolbar="toolbar"
@@ -7,7 +7,7 @@
       v-bind:value="value"
       @input="$emit('input', $event)"
       class="flexcol"
-      style="height: 100%"
+      style="height: 100%; width: 100%"
     />
   </div>
 </template>
@@ -15,6 +15,9 @@
 <style lang="less">
 .ql-container {
   font-family: var(--font-primary) !important;
+}
+.ql-editor {
+  width: 100%;
 }
 .ql-tooltip {
   z-index: 100;

--- a/src/module/vue/components/sf-tabs/sf-notes.vue
+++ b/src/module/vue/components/sf-tabs/sf-notes.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flexcol" style="margen: 1rem">
+  <div class="flexcol">
     <quill-editor v-model="actor.data.notes" />
   </div>
 </template>


### PR DESCRIPTION
Rolling out the editor added in #250 to the Ironsworn Vue sheet, and fixing a couple of styling bugs.

- [x] Make sure the editor fills its space
- [x] Border for editor
- [x] Use the editor in the IS sheet  
- [x] Update CHANGELOG.md
