### PR TITLE
Editor drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- HTML editor can now handle Foundry item drops ([#256](https://github.com/ben/foundry-ironsworn/pull/256))
+
 ## 1.10.31
 
 - HTML editor has configurable theme and can do image uploads ([#254](https://github.com/ben/foundry-ironsworn/pull/254))

--- a/src/module/applications/vueapp.ts
+++ b/src/module/applications/vueapp.ts
@@ -26,7 +26,6 @@ export class VueApplication extends Application {
       if (this._state == states.RENDERING || this._state == states.RENDERED) {
         // Update the Vue app with our updated item/flag data.
         if (appData?.data) Vue.set(this._vm.item, 'data', appData.data)
-        if (appData?.item?.flags) Vue.set(this._vm.item, 'flags', appData.item.flags)
         this.activateVueListeners($(this.element), true)
         return this
       }

--- a/src/module/item/vueitemsheet.ts
+++ b/src/module/item/vueitemsheet.ts
@@ -40,6 +40,7 @@ export class IronswornVueItemSheet extends ItemSheet {
       const states = Application.RENDER_STATES
       if (this._state == states.RENDERING || this._state == states.RENDERED) {
         // Update the Vue app with our updated item/flag data.
+        if (sheetData?.item) Vue.set(this._vm, 'item', sheetData.item)
         if (sheetData?.data) Vue.set(this._vm.item, 'data', sheetData.data)
         if (sheetData?.item?.flags) Vue.set(this._vm.item, 'flags', sheetData.item.flags)
         this._updateEditors($(this.element))

--- a/src/module/vue/components/quill-editor.vue
+++ b/src/module/vue/components/quill-editor.vue
@@ -1,5 +1,13 @@
 <template>
-  <div style="border: 1px solid black">
+  <div
+    style="border: 1px solid"
+    :style="style"
+    @dragenter="highlight"
+    @dragleave="dehighlight"
+    @dragover="highlight"
+    @dragend="dehighlight"
+    @drop="dropHandler"
+  >
     <VueEditor
       :placeholder="placeholder"
       :editorOptions="options"
@@ -59,6 +67,9 @@ export default {
 
   data() {
     return {
+      style: {
+        'border-color': 'black'
+      },
       options: {
         theme: this.theme,
         modules: {
@@ -84,6 +95,24 @@ export default {
         },
       },
     }
+  },
+
+  methods: {
+    highlight(ev) {
+      ev.preventDefault()
+      this.style['border-color'] = 'red'
+      return false
+    },
+    dehighlight(ev) {
+      ev.preventDefault()
+      this.style['border-color'] = 'black'
+      return false
+    },
+
+    dropHandler(ev) {
+      ev.preventDefault()
+      console.log(ev)
+    },
   },
 }
 </script>

--- a/src/module/vue/components/quill-editor.vue
+++ b/src/module/vue/components/quill-editor.vue
@@ -1,11 +1,11 @@
 <template>
   <div
-    style="border: 1px solid"
-    :style="style"
-    @dragenter="highlight"
-    @dragleave="dehighlight"
-    @dragover="highlight"
-    @dragend="dehighlight"
+    style="border: 1px solid black"
+    :class="cssClasses"
+    @dragenter="dragHandler($event, true)"
+    @dragover="dragHandler($event, true)"
+    @dragleave="dragHandler($event, false)"
+    @dragend="dragHandler($event, false)"
     @drop="dropHandler"
   >
     <VueEditor
@@ -67,8 +67,8 @@ export default {
 
   data() {
     return {
-      style: {
-        'border-color': 'black'
+      cssClasses: {
+        'drag-highlight': false,
       },
       options: {
         theme: this.theme,
@@ -98,20 +98,17 @@ export default {
   },
 
   methods: {
-    highlight(ev) {
+    dragHandler(ev, highlight) {
+      console.log({ ev, highlight })
+      this.cssClasses['drag-highlight'] = highlight
       ev.preventDefault()
-      this.style['border-color'] = 'red'
-      return false
-    },
-    dehighlight(ev) {
-      ev.preventDefault()
-      this.style['border-color'] = 'black'
       return false
     },
 
     dropHandler(ev) {
       ev.preventDefault()
-      console.log(ev)
+      this.cssClasses['drag-highlight'] = false
+      console.log('Drop!', ev)
     },
   },
 }

--- a/src/module/vue/components/quill-editor/foundry-link.js
+++ b/src/module/vue/components/quill-editor/foundry-link.js
@@ -1,0 +1,57 @@
+import { Quill } from 'vue2-editor'
+
+const Inline = Quill.import('blots/inline')
+const Embed = Quill.import('blots/embed')
+
+
+export default class FoundryLink extends Embed {
+  static create(value) {
+    return FoundryLink.render(value)
+  }
+
+  static value(domNode) {
+    const { type, pack, id } = domNode.dataset
+    return { type, pack, id }
+  }
+
+  html() {
+    return FoundryLink.render(this.value())
+  }
+
+  static render(value) {
+    // {type: 'JournalEntry', id: 'SGjaokGHk4vmTWpt'}
+    // {type: 'Actor', pack: 'foundry-ironsworn.foeactorsis', id: 'VcHQfffDX9tNZTJw'}
+
+    // Fetch the document
+    let document
+    if (value.pack) {
+      const pack = game.packs.get(value.pack)
+      document = pack.get(value.id)
+    } else {
+      const collection = game.collections.get(value.type)
+      document = collection.get(value.id)
+    }
+
+    // Construct the node
+    // <a class="entity-link content-link" draggable="true" data-type="Item" data-entity="Item" data-id="Qis1cOG7uJqudomf"><i class="fas fa-suitcase"></i> hey</a>
+    // <a class="entity-link content-link" draggable="true" data-pack="foundry-ironsworn.foeactorsis" data-id="A4nXqwLbSNh7xQy4"><i class="fas fa-user"></i> Basilisk</a>
+    const node = super.create(value)
+    node.classList.add('entity-link')
+    node.classList.add('content-link')
+    node.draggable = 'true'
+    node.dataset.type = value.type
+    node.dataset.entity = value.type
+    node.dataset.id = value.id
+    if (value.pack) node.dataset.pack = value.pack
+    node.innerHTML = `
+      <i class="${CONFIG[value.type].sidebarIcon}"></i> ${document.name}
+    `
+    console.log(node)
+    return node
+  }
+}
+FoundryLink.blotName = 'foundrylink'
+FoundryLink.className = 'foundrylink'
+FoundryLink.tagName = 'a'
+
+Quill.register('formats/foundrylink', FoundryLink)

--- a/src/module/vue/components/quill-editor/quill-editor.vue
+++ b/src/module/vue/components/quill-editor/quill-editor.vue
@@ -23,6 +23,13 @@
 <style lang="less">
 .ql-container {
   font-family: var(--font-primary) !important;
+  display: flex;
+  flex-grow: 1;
+
+  a.entity-link.content-link {
+    text-decoration: none;
+    color: #555;
+  }
 }
 .ql-editor {
   width: 100%;
@@ -33,68 +40,12 @@
 .ql-toolbar {
   flex-grow: 0;
 }
-.ql-container {
-  display: flex;
-  flex-grow: 1;
-}
 </style>
 
 <script>
-import { VueEditor, Quill } from 'vue2-editor'
+import { VueEditor } from 'vue2-editor'
 import Delta from 'quill-delta'
-
-// TODO: move this to its own file
-const Inline = Quill.import('blots/inline')
-class FoundryLink extends Inline {
-  static create(value) {
-    console.log(value)
-    // {type: 'JournalEntry', id: 'SGjaokGHk4vmTWpt'}
-    // {type: 'Actor', pack: 'foundry-ironsworn.foeactorsis', id: 'VcHQfffDX9tNZTJw'}
-
-    // Fetch the document
-    let document
-    if (value.pack) {
-      const pack = game.packs.get(value.pack)
-      document = pack.get(value.id)
-    } else {
-      const collection = game.collections.get(value.type)
-      document = collection.get(value.id)
-    }
-
-    // Construct the node
-    // <a class="entity-link content-link" draggable="true" data-type="Item" data-entity="Item" data-id="Qis1cOG7uJqudomf"><i class="fas fa-suitcase"></i> hey</a>
-    // <a class="entity-link content-link" draggable="true" data-pack="foundry-ironsworn.foeactorsis" data-id="A4nXqwLbSNh7xQy4"><i class="fas fa-user"></i> Basilisk</a>
-    const node = super.create(value)
-    node.classList = 'entity-link content-link'
-    node.dataset.type = value.type
-    node.dataset.entity = value.type
-    if (value.pack) node.dataset.pack = value.pack
-    node.innerHTML = `
-      <i class="${CONFIG[value.type].sidebarIcon}"></i> ${document.name}
-    `
-    console.log(node)
-    return node
-  }
-
-  static formats(domNode) {
-    console.log(domNode)
-    return domNode.getAttribute('class').match(/(entity|content)-link/)
-  }
-
-  format(name, value) {
-    console.log({ name, value })
-    if (name !== this.statics.blotName || !value) {
-      super.format(name, value)
-    } else {
-      this.domNode.setAttribute('href', this.constructor.sanitize(value))
-    }
-  }
-}
-FoundryLink.blotName = 'foundrylink'
-FoundryLink.tagName = 'a'
-console.log(Inline)
-
-Quill.register('formats/foundrylink', FoundryLink)
+import FoundryLink from './foundry-link'
 
 export default {
   components: { VueEditor },


### PR DESCRIPTION
This extends the Quill editor so that it can handle drops of Foundry items. Fixes #255.

- [x] Update CHANGELOG.md
- [x] Handle drops
- [x] Make sure it re-renders on load 