### PR TITLE
Open the right compendium for SF foes

### DIFF
--- a/src/module/vue/components/progress-controls.vue
+++ b/src/module/vue/components/progress-controls.vue
@@ -8,7 +8,7 @@
       <i class="fas fa-plus"></i>
       {{ $t('IRONSWORN.Progress') }}
     </div>
-    <div class="clickable block" @click="openCompendium('ironswornfoes')">
+    <div class="clickable block" @click="openCompendium(foeCompendium)">
       <i class="fas fa-atlas"></i>
       {{ $t('IRONSWORN.Foes') }}
     </div>
@@ -19,6 +19,10 @@
 export default {
   props: {
     actor: Object,
+    foeCompendium: {
+      type: String,
+      default: "ironswornfoes"
+    }
   },
 
   methods: {

--- a/src/module/vue/components/sf-tabs/sf-progresses.vue
+++ b/src/module/vue/components/sf-tabs/sf-progresses.vue
@@ -11,7 +11,7 @@
           @completed="progressCompleted"
         />
       </transition-group>
-      <progress-controls :actor="actor" />
+      <progress-controls :actor="actor" foeCompendium="starforgedencounters" />
     </div>
 
     <div class="item-row nogrow" style="margin-top: 1rem">


### PR DESCRIPTION
It was opening the Ironsworn foes, which doesn't really make sense.

- [ ] Fix the bug
- [ ] Update CHANGELOG.md
