### PR TITLE
Chat move clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Use the Quill editor in the location sheet ([#267](https://github.com/ben/foundry-ironsworn/pull/267))
+- Clicking on moves in chat cards does a move-sheet navigation ([#269](https://github.com/ben/foundry-ironsworn/pull/269))
 
 ## 1.10.34
 

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -53,7 +53,11 @@ export class IronswornChatCard {
     }
 
     console.log(item)
-    // TODO: if a move sheet is open, navaigate to this move's entry
+    for (const actor of game.actors?.contents || []) {
+      if (actor.moveSheet && actor.moveSheet._state >= 0 && actor.moveSheet.highlightMove) {
+        return actor.moveSheet.highlightMove(item)
+      }
+    }
     item.sheet?.render(true)
   }
 

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -6,6 +6,7 @@ import { DelveDomainDataProperties, DelveThemeDataProperties } from '../item/ite
 import { IronswornActor } from '../actor/actor'
 import { maybeShowDice, RollDialog } from '../helpers/roll'
 import { defaultActor } from '../helpers/actors'
+import { IronswornItem } from '../item/item'
 
 export class IronswornChatCard {
   id?: string | null
@@ -24,11 +25,36 @@ export class IronswornChatCard {
     this.id = message.id
     this.roll = message.isRoll ? message.roll : undefined
 
+    html
+      .find('a.content-link')
+      .removeClass('content-link') // Prevent default Foundry behavior
+      .on('click', (ev) => this._moveNavigate.call(this, ev))
     html.find('.burn-momentum').on('click', (ev) => this._burnMomentum.call(this, ev))
     html.find('.ironsworn__delvedepths__roll').on('click', (ev) => this._delveDepths.call(this, ev))
     html.find('.ironsworn__revealdanger__roll').on('click', (ev) => this._revealDanger.call(this, ev))
     html.find('.ironsworn__sojourn__extra__roll').on('click', (ev) => this._sojournExtra.call(this, ev))
     html.find('.ironsworn__paytheprice__roll').on('click', (ev) => this._payThePriceExtra.call(this, ev))
+  }
+
+  async _moveNavigate(ev: JQuery.ClickEvent) {
+    ev.preventDefault()
+    const { pack, id } = ev.target.dataset
+
+    let item: IronswornItem | undefined
+    if (pack) {
+      const fPack = game.packs.get(pack)
+      item = (await fPack?.getDocument(id)) as IronswornItem
+    } else {
+      item = await game.items?.get(id)
+    }
+    if (item?.data.type !== 'move') {
+      console.log('falling through')
+      return (TextEditor as any)._onClickContentLink(ev)
+    }
+
+    console.log(item)
+    // TODO: if a move sheet is open, navaigate to this move's entry
+    item.sheet?.render(true)
   }
 
   async _burnMomentum(ev: JQuery.ClickEvent) {

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -54,7 +54,7 @@ export class IronswornChatCard {
 
     console.log(item)
     for (const actor of game.actors?.contents || []) {
-      if (actor.moveSheet && actor.moveSheet._state >= 0 && actor.moveSheet.highlightMove) {
+      if ((actor.moveSheet as any)?._state >= 0 && actor.moveSheet?.highlightMove) {
         return actor.moveSheet.highlightMove(item)
       }
     }


### PR DESCRIPTION
Fixes #265. When a player clicks on a move-compendium link in a chat card, and there's a SF move sheet open, this highlights the move on that sheet. If there's no available sheet open, we fall back to the default behavior and open the move item sheet.

- [x] Interpret clicks differently
- [x] Update CHANGELOG.md
