### PR TITLE
Fixing vue warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Chat log when the "completed" flag changes ([#270](https://github.com/ben/foundry-ironsworn/pull/270))
 - Fix a typo in an Ironsworn oracle (Thanks @Porges! [#271](https://github.com/ben/foundry-ironsworn/pull/271))
 - Update the Spanish translation files (Thanks @WallaceMcGregor! [#268](https://github.com/ben/foundry-ironsworn/pull/268))
+- Updated a few functions to adhere to reactive data functionality ([#273](https://github.com/ben/foundry-ironsworn/pull/273))
 
 ## 1.10.35
 

--- a/src/module/vue/components/foe-sheet.vue
+++ b/src/module/vue/components/foe-sheet.vue
@@ -75,6 +75,9 @@ export default {
     foundryFoe() {
       return this.$actor.items.get(this.foe._id)
     },
+    rankText() {
+      return this.$t(CONFIG.IRONSWORN.Ranks[this.actor.data.rank])
+    },
   },
 
   watch: {

--- a/src/module/vue/components/quill-editor/quill-editor.vue
+++ b/src/module/vue/components/quill-editor/quill-editor.vue
@@ -61,12 +61,15 @@ export default {
 
     toolbarOptions: {
       type: Array,
-      default: [
-        [{ header: [false, 1, 2, 3, 4] }, 'bold', 'italic', 'underline'],
-        [{ list: 'ordered' }, { list: 'bullet' }],
-        ['link', 'image'],
-        ['clean'],
-      ],
+      default (){
+        return 
+          [
+            [{ header: [false, 1, 2, 3, 4] }, 'bold', 'italic', 'underline'],
+            [{ list: 'ordered' }, { list: 'bullet' }],
+            ['link', 'image'],
+            ['clean'],
+          ]
+      },
     },
   },
 


### PR DESCRIPTION
# Vue - Reactive Data Warning Fixes
- [x] `foe-sheet.vue` - added function to determine rankText and ensure reactive data properties
- [x] `quill-editor.vue` - updated syntax of default property of toolbarOptions object to ensure reactive data
- [x] Update CHANGELOG.md
