### PR TITLE
Chat bar move-card oracle buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Provide oracle-rolling buttons on move chat cards ([#287](https://github.com/ben/foundry-ironsworn/pull/287))
+- Implement "best of" and "worst of" move rolling (also [#287](https://github.com/ben/foundry-ironsworn/pull/287))
 
 ## 1.10.40
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Provide oracle-rolling buttons on move chat cards ([#287](https://github.com/ben/foundry-ironsworn/pull/287))
+
 ## 1.10.40
 
 - Fix location token and oracle bugs ([#284](https://github.com/ben/foundry-ironsworn/pull/284))

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import { IronswornActor } from './module/actor/actor'
 import { CreateActorDialog } from './module/applications/createActorDialog'
 import { createIronswornChatRoll, createIronswornDenizenChat } from './module/chat/chatrollhelpers'
 import { RANKS, RANK_INCREMENTS } from './module/constants'
-import { cleanDollars, getTableByDfId, getMoveByDfId, importFromDataforged } from './module/dataforged'
+import { cleanDollars, getFoundryTableByDfId, getFoundryMoveByDfId, importFromDataforged } from './module/dataforged'
 import { importFromDatasworn } from './module/datasworn'
 import { defaultActor } from './module/helpers/actors'
 import { moveDataByName } from './module/helpers/data'
@@ -47,8 +47,8 @@ export interface IronswornConfig {
   sfOracleJsonByDataforgedId: typeof sfOracleJsonByDataforgedId
 
   Dataforged: typeof Dataforged
-  getTableByDfId: typeof getTableByDfId
-  getMoveByDfId: typeof getMoveByDfId
+  getTableByDfId: typeof getFoundryTableByDfId
+  getMoveByDfId: typeof getFoundryMoveByDfId
   cleanDollars: typeof cleanDollars
 
   _: typeof lodash
@@ -81,8 +81,8 @@ export const IRONSWORN: IronswornConfig = {
   sfOracleJsonByDataforgedId,
 
   Dataforged,
-  getTableByDfId,
-  getMoveByDfId,
+  getTableByDfId: getFoundryTableByDfId,
+  getMoveByDfId: getFoundryMoveByDfId,
   cleanDollars,
 
   _: lodash,

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -196,7 +196,7 @@ export class IronswornChatCard {
     ev.preventDefault()
     const pack = game.packs.get('foundry-ironsworn.starforgedoracles')
     const { tableid } = ev.target.dataset
-    const table = pack?.get(tableid) as any | undefined
+    const table = await pack?.getDocument(tableid) as any | undefined
     table?.draw()
   }
 

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -34,6 +34,7 @@ export class IronswornChatCard {
     html.find('.ironsworn__revealdanger__roll').on('click', (ev) => this._revealDanger.call(this, ev))
     html.find('.ironsworn__sojourn__extra__roll').on('click', (ev) => this._sojournExtra.call(this, ev))
     html.find('.ironsworn__paytheprice__roll').on('click', (ev) => this._payThePriceExtra.call(this, ev))
+    html.find('.starforged__oracle__roll').on('click', (ev) => this._sfOracleRoll.call(this, ev))
   }
 
   async _moveNavigate(ev: JQuery.ClickEvent) {
@@ -76,11 +77,11 @@ export class IronswornChatCard {
       result = theMove && theMove[capitalize(hittype.toLowerCase())]
       bonusContent = MoveContentCallbacks[move]?.call(this, { hitType: hittype as HIT_TYPE, stat })
     } else {
-      // I wish this were easier
-      const i18nKey =
-        hittype === HIT_TYPE.STRONG ? 'StrongHit' :
-        hittype === HIT_TYPE.WEAK ? 'WeakHit' :
-        'Miss'
+      const i18nKey = {
+        [HIT_TYPE.STRONG]: 'StrongHit',
+        [HIT_TYPE.WEAK]: 'WeakHit',
+        [HIT_TYPE.MISS]: 'Miss',
+      }[hittype]
       result = `<strong>${game.i18n.localize('IRONSWORN.' + i18nKey)}</strong>`
     }
 
@@ -189,6 +190,14 @@ export class IronswornChatCard {
         </h4>
       `
     )
+  }
+
+  async _sfOracleRoll(ev: JQuery.ClickEvent) {
+    ev.preventDefault()
+    const pack = game.packs.get('foundry-ironsworn.starforgedoracles')
+    const { tableid } = ev.target.dataset
+    const table = pack?.get(tableid) as any | undefined
+    table?.draw()
   }
 
   async replaceSelectorWith(el: HTMLElement, selector: string, newContent: string) {

--- a/src/module/chat/chatrollhelpers.ts
+++ b/src/module/chat/chatrollhelpers.ts
@@ -1,5 +1,7 @@
+import { compact } from 'lodash'
 import { IronswornActor } from '../actor/actor'
 import { DenizenSlot } from '../actor/actortypes'
+import { getDFMoveByDfId, getFoundryTableByDfId } from '../dataforged'
 import { EnhancedDataswornMove } from '../helpers/data'
 import { IronswornSettings } from '../helpers/settings'
 import { capitalize } from '../helpers/util'
@@ -23,6 +25,7 @@ interface SFRollMessageParams {
   move: IronswornItem
   mode: string
   stats: string[]
+  usedStat: string
   bonus: number
 }
 
@@ -127,7 +130,7 @@ function calculateCardTitle(params: RollMessageParams) {
 }
 
 function calculateSFCardTitle(params: SFRollMessageParams) {
-  return `${params.move.name} (${game.i18n.localize('IRONSWORN.' + capitalize(params.stats[0]))})`
+  return `${params.move.name} (${game.i18n.localize('IRONSWORN.' + capitalize(params.usedStat))})`
 }
 
 function calculateMoveResultText(type: HIT_TYPE, move?: EnhancedDataswornMove): string | undefined {

--- a/src/module/dataforged.ts
+++ b/src/module/dataforged.ts
@@ -53,12 +53,12 @@ async function hash(str: string): Promise<string> {
   return hexarr.join('').substring(48)
 }
 
-export async function getTableByDfId(dfid: string): Promise<RollTable | undefined> {
+export async function getFoundryTableByDfId(dfid: string): Promise<RollTable | undefined> {
   const pack = game.packs.get('foundry-ironsworn.starforgedoracles')
   return pack?.get(await hashLookup(dfid))
 }
 
-export async function getMoveByDfId(dfid: string): Promise<IronswornItem | undefined> {
+export async function getFoundryMoveByDfId(dfid: string): Promise<IronswornItem | undefined> {
   const pack = game.packs.get('foundry-ironsworn.starforgedmoves')
   return pack?.get(await hashLookup(dfid)) as any
 }

--- a/src/module/dataforged.ts
+++ b/src/module/dataforged.ts
@@ -63,6 +63,15 @@ export async function getFoundryMoveByDfId(dfid: string): Promise<IronswornItem 
   return pack?.get(await hashLookup(dfid)) as any
 }
 
+export async function getDFMoveByDfId(dfid: string): Promise<IMove | undefined> {
+  for (const category of Dataforged.moves) {
+    for (const move of category.Moves) {
+      if (move.$id === dfid) return move
+    }
+  }
+  return undefined
+}
+
 async function generateIdMap(data: typeof Dataforged): Promise<{ [key: string]: string }> {
   const ret = {}
 
@@ -97,7 +106,7 @@ function renderLinksInStr(text: any, idMap: { [key: string]: string }): any {
   })
 }
 
-function renderMarkdown(md:string, idMap: { [key: string]: string }, markedFn = marked.parse) {
+function renderMarkdown(md: string, idMap: { [key: string]: string }, markedFn = marked.parse) {
   return markedFn(renderLinksInStr(md, idMap))
 }
 

--- a/src/module/helpers/rolldialog-sf.ts
+++ b/src/module/helpers/rolldialog-sf.ts
@@ -1,6 +1,6 @@
 import { maxBy, minBy } from 'lodash'
 import { IronswornActor } from '../actor/actor'
-import { createStarforgedMoveRollChat } from '../chat/chatrollhelpers'
+import { createStarforgedMoveRollChat, sfNextOracles } from '../chat/chatrollhelpers'
 import { IronswornItem } from '../item/item'
 import { SFMoveDataProperties } from '../item/itemtypes'
 import { IronswornSettings } from './settings'
@@ -112,7 +112,11 @@ async function rollAndCreateChatMessage(opts: { actor: IronswornActor; move: Iro
 }
 
 async function createDataforgedMoveChat(move: IronswornItem) {
-  const content = await renderTemplate('systems/foundry-ironsworn/templates/chat/sf-move.hbs', { move })
+  const params = {
+    move,
+    nextOracles: await sfNextOracles(move),
+  }
+  const content = await renderTemplate('systems/foundry-ironsworn/templates/chat/sf-move.hbs', params)
   ChatMessage.create({
     speaker: ChatMessage.getSpeaker(),
     content,

--- a/src/module/helpers/rolldialog-sf.ts
+++ b/src/module/helpers/rolldialog-sf.ts
@@ -77,19 +77,19 @@ function callback(opts: { actor: IronswornActor; move: IronswornItem; mode: stri
 
 async function rollAndCreateChatMessage(opts: { actor: IronswornActor; move: IronswornItem; mode: string; stats: string[]; bonus: number }) {
   const { actor, move, mode, stats, bonus } = opts
-  let usedStat = stats[0].toLowerCase()
 
+  const normalizedStats = stats.map((x) => x.toLowerCase())
+  let usedStat = normalizedStats[0]
   if (mode === 'Best of' || mode === 'Worst of') {
     const statMap = {}
-    for (const x of stats) {
-      statMap[x.toLowerCase()] = actor.data.data[x.toLowerCase()]
+    for (const x of normalizedStats) {
+      statMap[x] = actor.data.data[x]
     }
-    const fn = (mode === 'Best of') ? maxBy : minBy
-    usedStat = fn(Object.keys(statMap), x => statMap[x]) ?? stats[0]
-  }
-  else if (mode !== 'Stat') {
+    const fn = mode === 'Best of' ? maxBy : minBy
+    usedStat = fn(Object.keys(statMap), (x) => statMap[x]) ?? stats[0]
+  } else if (mode !== 'Stat') {
     console.log({ actor, move, mode, stats, bonus })
-    return // TODO: implement best/worst/all of
+    return // TODO: all of
   }
 
   let actionExpr = 'd6'
@@ -105,7 +105,7 @@ async function rollAndCreateChatMessage(opts: { actor: IronswornActor; move: Iro
     actor,
     move,
     mode,
-    stats,
+    stats: normalizedStats,
     usedStat,
     bonus,
   })

--- a/src/module/item/itemtypes.ts
+++ b/src/module/item/itemtypes.ts
@@ -176,7 +176,9 @@ export interface MoveDataProperties {
 
 ///////////////////////////////
 
-interface SFMoveDataPropertiesData extends IMove {}
+interface SFMoveDataPropertiesData extends IMove {
+  dfid: string
+}
 
 export interface SFMoveDataSource {
   type: 'sfmove'

--- a/system/templates/chat/roll-sf.hbs
+++ b/system/templates/chat/roll-sf.hbs
@@ -33,9 +33,20 @@ themeClass: "theme-ironsworn"
     <p>{{{localize 'IRONSWORN.BurnForUpgrade' type=momentumHitTypeI18n}}}</p>
     <button class="burn-momentum-sf" data-actor="{{actor.id}}" data-move="{{move.id}}" data-mode="{{mode}}"
       data-stats="{{stats}}" data-hittype="{{momentumHitType}}">
+      <i class="fas fa-fire"></i>
       {{localize 'IRONSWORN.Burn'}}
     </button>
   </div>
+  {{/if}}
+
+  {{#if nextOracles}}
+  <hr>
+  {{#each nextOracles}}
+  <button class="sf-oracle" data-tableId="{{id}}">
+    <i class="fas fa-dice-d6"></i>
+    {{name}}
+  </button>
+  {{/each}}
   {{/if}}
 
 </div>

--- a/system/templates/chat/roll-sf.hbs
+++ b/system/templates/chat/roll-sf.hbs
@@ -42,7 +42,7 @@ themeClass: "theme-ironsworn"
   {{#if nextOracles}}
   <hr>
   {{#each nextOracles}}
-  <button class="starforged__oracle__roll" data-tableId="{{id}}">
+  <button class="starforged__oracle__roll" data-tableid="{{id}}">
     <i class="fas fa-dice-d6"></i>
     {{name}}
   </button>

--- a/system/templates/chat/roll-sf.hbs
+++ b/system/templates/chat/roll-sf.hbs
@@ -42,7 +42,7 @@ themeClass: "theme-ironsworn"
   {{#if nextOracles}}
   <hr>
   {{#each nextOracles}}
-  <button class="sf-oracle" data-tableId="{{id}}">
+  <button class="starforged__oracle__roll" data-tableId="{{id}}">
     <i class="fas fa-dice-d6"></i>
     {{name}}
   </button>

--- a/system/templates/chat/sf-move.hbs
+++ b/system/templates/chat/sf-move.hbs
@@ -14,7 +14,7 @@
   {{#if nextOracles}}
   <hr>
   {{#each nextOracles}}
-  <button class="sf-oracle" data-tableId="{{id}}">
+  <button class="starforged__oracle__roll" data-tableId="{{id}}">
     <i class="fas fa-dice-d6"></i>
     {{name}}
   </button>

--- a/system/templates/chat/sf-move.hbs
+++ b/system/templates/chat/sf-move.hbs
@@ -11,4 +11,14 @@
     </div>
   </div>
 
+  {{#if nextOracles}}
+  <hr>
+  {{#each nextOracles}}
+  <button class="sf-oracle" data-tableId="{{id}}">
+    <i class="fas fa-dice-d6"></i>
+    {{name}}
+  </button>
+  {{/each}}
+  {{/if}}
+
 </div>

--- a/system/templates/chat/sf-move.hbs
+++ b/system/templates/chat/sf-move.hbs
@@ -14,7 +14,7 @@
   {{#if nextOracles}}
   <hr>
   {{#each nextOracles}}
-  <button class="starforged__oracle__roll" data-tableId="{{id}}">
+  <button class="starforged__oracle__roll" data-tableid="{{id}}">
     <i class="fas fa-dice-d6"></i>
     {{name}}
   </button>


### PR DESCRIPTION
Dataforged includes a list of oracles that might be useful for moves. This uses that list to generate a series of buttons to make it easier to roll on an oracle after activating a move.

- [x] Render the buttons
- [x] Roll on tables
- [x] Update CHANGELOG.md
