### PR TITLE
Oracle rolls: display neighbors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Provide oracle-rolling buttons on move chat cards ([#287](https://github.com/ben/foundry-ironsworn/pull/287))
 - Implement "best of" and "worst of" move rolling (also [#287](https://github.com/ben/foundry-ironsworn/pull/287))
+- Display neighboring results when rolling oracles ([#288](https://github.com/ben/foundry-ironsworn/pull/288))
 
 ## 1.10.40
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import * as lodash from 'lodash'
 import { marked } from 'marked'
 import { IronswornActor } from './module/actor/actor'
 import { CreateActorDialog } from './module/applications/createActorDialog'
-import { createIronswornChatRoll, createIronswornDenizenChat } from './module/chat/chatrollhelpers'
+import { createIronswornChatRoll, createIronswornDenizenChat, rollAndDisplayOracleResult } from './module/chat/chatrollhelpers'
 import { RANKS, RANK_INCREMENTS } from './module/constants'
 import { cleanDollars, getFoundryTableByDfId, getFoundryMoveByDfId, importFromDataforged } from './module/dataforged'
 import { importFromDatasworn } from './module/datasworn'
@@ -45,6 +45,7 @@ export interface IronswornConfig {
   defaultActor: typeof defaultActor
   sfOracleByDataforgedId: typeof sfOracleByDataforgedId
   sfOracleJsonByDataforgedId: typeof sfOracleJsonByDataforgedId
+  rollAndDisplayOracleResult: typeof rollAndDisplayOracleResult
 
   Dataforged: typeof Dataforged
   getTableByDfId: typeof getFoundryTableByDfId
@@ -79,6 +80,7 @@ export const IRONSWORN: IronswornConfig = {
   defaultActor,
   sfOracleByDataforgedId,
   sfOracleJsonByDataforgedId,
+  rollAndDisplayOracleResult,
 
   Dataforged,
   getTableByDfId: getFoundryTableByDfId,

--- a/src/module/actor/sheets/charactermovesheet.ts
+++ b/src/module/actor/sheets/charactermovesheet.ts
@@ -1,4 +1,5 @@
 import { negate } from 'lodash'
+import { rollAndDisplayOracleResult } from '../../chat/chatrollhelpers'
 import { cachedMoves, moveDataByName } from '../../helpers/data'
 import { attachInlineRollListeners, RollDialog } from '../../helpers/rolldialog'
 import { IronswornSettings } from '../../helpers/settings'
@@ -202,9 +203,8 @@ export class CharacterMoveSheet extends FormApplication<any, any, IronswornActor
         }
       }
     }
-    ; (table as any)?.draw()
+    rollAndDisplayOracleResult(table)
   }
-
 
   async highlightMove(move: IronswornItem) {
     console.log({ move })

--- a/src/module/applications/createActorDialog.ts
+++ b/src/module/applications/createActorDialog.ts
@@ -1,5 +1,6 @@
 import { ActorDataConstructorData } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/actorData'
 import { IronswornActor } from '../actor/actor'
+import { getFoundryTableByDfId } from '../dataforged'
 import { IronswornSettings } from '../helpers/settings'
 
 interface CreateActorDialogOptions extends FormApplication.Options {
@@ -118,12 +119,9 @@ export class CreateActorDialog extends FormApplication<CreateActorDialogOptions>
     const pack = game.packs.get('foundry-ironsworn.starforgedoracles')
     if (!pack) return undefined
 
-    const firstOid = pack?.index.find((x: any) => x.name === 'Characters / Name / Given Name') as any
-    const lastOid = pack?.index.find((x: any) => x.name === 'Characters / Name / Family Name') as any
-    if (!firstOid || !lastOid) return undefined
-
-    const firstTable = await pack.getDocument(firstOid._id) as any // really a RollTable
-    const lastTable = await pack.getDocument(lastOid._id) as any // really a RollTable
+    const firstTable = await getFoundryTableByDfId('Oracles/Characters/Name/Given_Name') as any
+    const lastTable = await getFoundryTableByDfId('Oracles/Characters/Name/Family_Name') as any
+    console.log(firstTable, lastTable)
     if (!firstTable || !lastTable) return undefined
 
     const first = await firstTable.draw({ displayChat: false })

--- a/src/module/applications/createActorDialog.ts
+++ b/src/module/applications/createActorDialog.ts
@@ -121,7 +121,6 @@ export class CreateActorDialog extends FormApplication<CreateActorDialogOptions>
 
     const firstTable = await getFoundryTableByDfId('Oracles/Characters/Name/Given_Name') as any
     const lastTable = await getFoundryTableByDfId('Oracles/Characters/Name/Family_Name') as any
-    console.log(firstTable, lastTable)
     if (!firstTable || !lastTable) return undefined
 
     const first = await firstTable.draw({ displayChat: false })

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -1,7 +1,7 @@
 import { capitalize } from 'lodash'
 import { moveDataByName, MoveOracle, MoveOracleEntry } from '../helpers/data'
 import { MoveContentCallbacks } from './movecontentcallbacks'
-import { HIT_TYPE } from './chatrollhelpers'
+import { HIT_TYPE, rollAndDisplayOracleResult } from './chatrollhelpers'
 import { DelveDomainDataProperties, DelveThemeDataProperties } from '../item/itemtypes'
 import { IronswornActor } from '../actor/actor'
 import { maybeShowDice, RollDialog } from '../helpers/rolldialog'
@@ -197,7 +197,7 @@ export class IronswornChatCard {
     const pack = game.packs.get('foundry-ironsworn.starforgedoracles')
     const { tableid } = ev.target.dataset
     const table = await pack?.getDocument(tableid) as any | undefined
-    table?.draw()
+    rollAndDisplayOracleResult(table)
   }
 
   async replaceSelectorWith(el: HTMLElement, selector: string, newContent: string) {

--- a/src/module/chat/chatrollhelpers.ts
+++ b/src/module/chat/chatrollhelpers.ts
@@ -342,6 +342,7 @@ export async function rollAndDisplayOracleResult(table?: RollTable): Promise<str
 
   // Render the chat message content
   const renderData = {
+    themeClass: `theme-${IronswornSettings.theme}`,
     table,
     roll,
     displayRows,
@@ -361,5 +362,5 @@ export async function rollAndDisplayOracleResult(table?: RollTable): Promise<str
   await ChatMessage.create(messageData)
 
   // Return the raw text
-  return tableDraw?.results[0].data.text
+  return resultRow.text
 }

--- a/src/module/chat/chatrollhelpers.ts
+++ b/src/module/chat/chatrollhelpers.ts
@@ -1,4 +1,4 @@
-import { compact } from 'lodash'
+import { compact, sortBy } from 'lodash'
 import { IronswornActor } from '../actor/actor'
 import { DenizenSlot } from '../actor/actortypes'
 import { getDFMoveByDfId } from '../dataforged'
@@ -310,8 +310,56 @@ export async function createIronswornDenizenChat(params: DenizenChatInput) {
   } as any)
 }
 
-// Crack open that message type
-// declare global {
-//   interface ChatMessage {
-//   }
-// }
+export async function rollAndDisplayOracleResult(table?: RollTable): Promise<string | undefined> {
+  console.log(table)
+  if (!table) {
+    return undefined
+  }
+
+  // Do the random roll
+  const tableDraw = await (table as any).draw({ displayChat: false })
+
+  // Parse the table rows
+  const tableRows = sortBy(
+    table.data.results.contents.map((x) => ({
+      low: x.data.range[0],
+      high: x.data.range[1],
+      text: x.data.text,
+      selected: false,
+    })),
+    'low'
+  )
+
+  // Grab the relevant rows
+  const roll = tableDraw.roll as Roll
+  const resultRow = tableRows.find((x) => x.low <= roll.result && roll.result <= x.high)
+  const resultIdx = tableRows.indexOf(resultRow)
+  const displayRows = compact([
+    tableRows[resultIdx - 1],
+    { ...resultRow, selected: true },
+    tableRows[resultIdx + 1]
+  ])
+
+  // Render the chat message content
+  const renderData = {
+    table,
+    roll,
+    displayRows,
+    result: tableDraw.results[0],
+  }
+  const content = await renderTemplate('systems/foundry-ironsworn/templates/chat/oracle-roll.hbs', renderData)
+
+  // Send out the chat card
+  const messageData = {
+    user: game.user,
+    speaker: ChatMessage.getSpeaker(),
+    type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+    roll: tableDraw.roll,
+    sound: tableDraw.roll ? CONFIG.sounds.dice : null,
+    content,
+  } as any
+  await ChatMessage.create(messageData)
+
+  // Return the raw text
+  return tableDraw?.results[0].data.text
+}

--- a/src/module/dataforged.ts
+++ b/src/module/dataforged.ts
@@ -55,7 +55,7 @@ async function hash(str: string): Promise<string> {
 
 export async function getFoundryTableByDfId(dfid: string): Promise<RollTable | undefined> {
   const pack = game.packs.get('foundry-ironsworn.starforgedoracles')
-  return pack?.get(await hashLookup(dfid))
+  return (await pack?.getDocument(await hashLookup(dfid))) || undefined
 }
 
 export async function getFoundryMoveByDfId(dfid: string): Promise<IronswornItem | undefined> {

--- a/src/module/vue/components/oracletree-node.vue
+++ b/src/module/vue/components/oracletree-node.vue
@@ -82,7 +82,7 @@ export default {
   methods: {
     async click() {
       if (this.oracle.foundryTable) {
-        this.oracle.foundryTable.draw()
+        CONFIG.IRONSWORN.rollAndDisplayOracleResult(this.oracle.foundryTable)
       } else {
         this.manuallyExpanded = !this.manuallyExpanded
       }

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -475,8 +475,7 @@ export default {
         const table = await CONFIG.IRONSWORN.sfOracleByDataforgedId(
           'Oracles/Settlements/Name'
         )
-        const result = await table?.draw()
-        name = result?.results[0]?.data.text
+        name = await CONFIG.IRONSWORN.rollAndDisplayOracleResult(table)
       }
 
       if (name) {
@@ -500,8 +499,7 @@ export default {
       }
 
       const table = await CONFIG.IRONSWORN.sfOracleByDataforgedId(tableKey)
-      const result = await table?.draw()
-      const rawText = result?.results[0]?.data.text
+      const rawText = await CONFIG.IRONSWORN.rollAndDisplayOracleResult(table)
       if (!rawText) return
 
       const lctext = rawText.toLowerCase()
@@ -522,8 +520,7 @@ export default {
     },
     async rollOracle(oracle) {
       const table = await CONFIG.IRONSWORN.sfOracleByDataforgedId(oracle.dfId)
-      const drawResult = await table?.draw()
-      const drawText = drawResult?.results[0]?.data.text
+      const drawText = await CONFIG.IRONSWORN.rollAndDisplayOracleResult(table)
       if (!drawText) return
 
       // Append to description

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -538,3 +538,8 @@ hr {
 .bonus-content .dice-formula {
   word-break: normal;
 }
+
+.chat-message table td:first-child {
+  white-space: nowrap;
+  padding-right: 0.5rem;
+}

--- a/src/styles/themes/ironsworn.less
+++ b/src/styles/themes/ironsworn.less
@@ -175,4 +175,10 @@
       background-color: @background-color;
     }
   }
+
+  table tr.selected {
+    background-color: @text-color;
+    color: @light-color;
+  }
 }
+

--- a/src/styles/themes/starforged.less
+++ b/src/styles/themes/starforged.less
@@ -184,4 +184,9 @@ input.highlight:focus {
       }
     }
   }
+
+  table tr.selected {
+    background-color: @text-light-color;
+    color: @dark-color;
+  }
 }

--- a/system/templates/chat/oracle-roll.hbs
+++ b/system/templates/chat/oracle-roll.hbs
@@ -1,0 +1,36 @@
+{{!--
+displayRows: Array(3)
+  0: {low: 36, high: 42, text: 'Glassy impact craters', selected: false}
+result: TableResult {apps: {…}, _sheet: null, parent: RollTable, pack: 'foundry-ironsworn.starforgedoracles', data:
+TableResultData}
+roll: Roll {data: {…}, options: {…}, terms: Array(1), _dice: Array(0), _formula: 'd100', …}
+table: RollTable {parent: null, pack: 'foundry-ironsworn.starforgedoracles', data: RollTableData, …}
+--}}
+
+<div class="table-draw" data-table-id="{{table.id}}">
+  <h4>{{table.name}}</h4>
+
+  {{!-- Roll result --}}
+  <div class="dice-roll">
+    <div class="dice-result">
+      <h4 class="dice-total">
+        <i class="fas fa-dice"></i>
+        {{roll.total}}
+      </h4>
+    </div>
+  </div>
+
+  {{!-- Table rows --}}
+  <table>
+    <tbody>
+      {{#each displayRows}}
+      <tr>
+        <td>{{#if selected}}<i class="fas fa-arrow-right"></i>{{/if}}</td>
+        <td>{{low}}-{{high}}</td>
+        <td>{{text}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+  </table>
+
+</div>

--- a/system/templates/chat/oracle-roll.hbs
+++ b/system/templates/chat/oracle-roll.hbs
@@ -14,7 +14,7 @@ table: RollTable {parent: null, pack: 'foundry-ironsworn.starforgedoracles', dat
   <div class="dice-roll">
     <div class="dice-result">
       <h4 class="dice-total">
-        <i class="fas fa-dice"></i>
+        <i class="fas fa-dice-d20"></i>
         {{roll.total}}
       </h4>
     </div>

--- a/system/templates/chat/oracle-roll.hbs
+++ b/system/templates/chat/oracle-roll.hbs
@@ -7,7 +7,7 @@ roll: Roll {data: {…}, options: {…}, terms: Array(1), _dice: Array(0), _form
 table: RollTable {parent: null, pack: 'foundry-ironsworn.starforgedoracles', data: RollTableData, …}
 --}}
 
-<div class="table-draw" data-table-id="{{table.id}}">
+<div class="table-draw {{themeClass}}" data-table-id="{{table.id}}">
   <h4>{{table.name}}</h4>
 
   {{!-- Roll result --}}
@@ -24,10 +24,10 @@ table: RollTable {parent: null, pack: 'foundry-ironsworn.starforgedoracles', dat
   <table>
     <tbody>
       {{#each displayRows}}
-      <tr>
-        <td>{{#if selected}}<i class="fas fa-arrow-right"></i>{{/if}}</td>
+      <tr class="{{#if selected}}selected{{/if}}">
         <td>{{low}}-{{high}}</td>
         <td>{{text}}</td>
+        <td>{{#if selected}}<i class="fas fa-arrow-left"></i>{{/if}}</td>
       </tr>
       {{/each}}
     </tbody>

--- a/system/templates/chat/oracle-roll.hbs
+++ b/system/templates/chat/oracle-roll.hbs
@@ -1,6 +1,6 @@
 {{!--
 displayRows: Array(3)
-  0: {low: 36, high: 42, text: 'Glassy impact craters', selected: false}
+0: {low: 36, high: 42, text: 'Glassy impact craters', selected: false}
 result: TableResult {apps: {…}, _sheet: null, parent: RollTable, pack: 'foundry-ironsworn.starforgedoracles', data:
 TableResultData}
 roll: Roll {data: {…}, options: {…}, terms: Array(1), _dice: Array(0), _formula: 'd100', …}
@@ -8,7 +8,7 @@ table: RollTable {parent: null, pack: 'foundry-ironsworn.starforgedoracles', dat
 --}}
 
 <div class="table-draw {{themeClass}}" data-table-id="{{table.id}}">
-  <h4>{{table.name}}</h4>
+  <h3>{{table.name}}</h3>
 
   {{!-- Roll result --}}
   <div class="dice-roll">
@@ -27,7 +27,7 @@ table: RollTable {parent: null, pack: 'foundry-ironsworn.starforgedoracles', dat
       <tr class="{{#if selected}}selected{{/if}}">
         <td>{{low}}-{{high}}</td>
         <td>{{text}}</td>
-        <td>{{#if selected}}<i class="fas fa-arrow-left"></i>{{/if}}</td>
+        <td style="padding: 0 0.5rem;">{{#if selected}}<i class="fas fa-arrow-left"></i>{{/if}}</td>
       </tr>
       {{/each}}
     </tbody>


### PR DESCRIPTION
When rolling oracles, the books both suggest "jiggling" the result to a neighbor on the table if the one rolled doesn't quite fit. This updates the chat output of oracle rolls to include the neighboring results:

![CleanShot 2022-04-17 at 08 32 22](https://user-images.githubusercontent.com/39902/163721483-435b5a8a-78c3-41b3-b50f-f35f6cf2d56f.jpg)

- [x] Display neighboring results
- [x] Style table to avoid wrapping numbers
- [x] (Fix a character-name-generation bug)
- [x] Update CHANGELOG.md
