### PR TITLE
No double logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Centralize Dataforged import and improve encounter display ([#297](https://github.com/ben/foundry-ironsworn/pull/297))
 - Bump to latest Dataforged, which changes IDs and breaks links ([#299](https://github.com/ben/foundry-ironsworn/pull/299))
+- Fix double-logging of item deletion ([#300](https://github.com/ben/foundry-ironsworn/pull/300))
 
 ## 1.10.44
 

--- a/src/module/features/changelog.ts
+++ b/src/module/features/changelog.ts
@@ -47,7 +47,7 @@ export function activateChangelogListeners() {
     sendToChat(item.parent, game.i18n.format('IRONSWORN.ChangeLog.Added', { name: item.name }))
   })
 
-  Hooks.on('deleteItem', async (item: IronswornItem, options, _userId: number) => {
+  Hooks.on('preDeleteItem', async (item: IronswornItem, options, _userId: number) => {
     if (!IronswornSettings.logCharacterChanges) return
     if (!item.parent) return // No logging for unowned items, they don't matter
     if (options.suppressLog) return

--- a/src/module/features/changelog.ts
+++ b/src/module/features/changelog.ts
@@ -7,6 +7,8 @@ import { IronswornSettings } from '../helpers/settings'
 import { IronswornItem } from '../item/item'
 import { AssetDataProperties, BondsetDataProperties, ProgressDataProperties } from '../item/itemtypes'
 
+type ActorTypeHandler = (IronswornActor, any) => string | undefined
+
 export function activateChangelogListeners() {
   Hooks.on('preUpdateActor', async (actor: IronswornActor, data: any, options, _userId: number) => {
     if (!IronswornSettings.logCharacterChanges) return
@@ -56,7 +58,6 @@ export function activateChangelogListeners() {
   })
 }
 
-type ActorTypeHandler = (IronswornActor, any) => string | undefined
 const ACTOR_TYPE_HANDLERS: { [key: string]: ActorTypeHandler } = {
   character: (actor: IronswornActor, data) => {
     const characterData = actor.data as CharacterDataProperties


### PR DESCRIPTION
Fixes #298. Turns out we want to always be using the `preXXX` hooks, because they only fire on the browser of the person doing the action.

- [x] Fix double-logging of item deletion
- [x] Update CHANGELOG.md
