### PR TITLE
Refactor slide transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Refactor some CSS ([#305](https://github.com/ben/foundry-ironsworn/pull/305))
+
 ## 1.10.47
 
 - Better oracles in the movesheet ([#303](https://github.com/ben/foundry-ironsworn/pull/303))

--- a/src/module/vue/bondset-sheet.vue
+++ b/src/module/vue/bondset-sheet.vue
@@ -21,21 +21,7 @@
 <style lang="less" scoped>
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.4s ease;
-  overflow: hidden;
   max-height: 93px;
-  opacity: 1;
-}
-.slide-enter,
-.slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-top: 0;
-  border-bottom: 0;
 }
 </style>
 

--- a/src/module/vue/character-sheet.vue
+++ b/src/module/vue/character-sheet.vue
@@ -145,21 +145,7 @@
 <style lang="less" scoped>
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.4s ease;
-  overflow: hidden;
   max-height: 83px;
-  opacity: 1;
-}
-.slide-enter,
-.slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-top: 0;
-  border-bottom: 0;
 }
 
 textarea.notes {

--- a/src/module/vue/components/asset/asset-fieldsedit.vue
+++ b/src/module/vue/components/asset/asset-fieldsedit.vue
@@ -46,21 +46,7 @@
 
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.3s ease;
-  overflow: hidden;
   max-height: 30px;
-  opacity: 1;
-}
-.slide-enter,
-.slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-top: 0;
-  border-bottom: 0;
 }
 </style>
 

--- a/src/module/vue/components/asset/asset-optionsedit.vue
+++ b/src/module/vue/components/asset/asset-optionsedit.vue
@@ -44,21 +44,7 @@
 }
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.3s ease;
-  overflow: hidden;
   max-height: 30px;
-  opacity: 1;
-}
-.slide-enter,
-.slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-top: 0;
-  border-bottom: 0;
 }
 </style>
 

--- a/src/module/vue/components/asset/asset.vue
+++ b/src/module/vue/components/asset/asset.vue
@@ -65,13 +65,7 @@
 <style lang="less" scoped>
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.25s ease;
-  overflow: hidden;
-  max-height: 250px;
-}
-.slide-enter,
-.slide-leave-to {
-  max-height: 0;
+  max-height: 350px;
 }
 </style>
 

--- a/src/module/vue/components/oracletree-node.vue
+++ b/src/module/vue/components/oracletree-node.vue
@@ -66,18 +66,7 @@
 }
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.4s ease;
-  max-height: 500px;
-  opacity: 1;
-}
-.slide-enter,
-.slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
+  max-height: 1000px;
 }
 </style>
 

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -32,19 +32,7 @@ i.fa-dice-d6 {
 
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.4s ease;
-  overflow: hidden;
   max-height: 1000px;
-  opacity: 1;
-}
-.slide-enter,
-.slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
 }
 </style>
 

--- a/src/module/vue/components/sf-tabs/sf-bonds.vue
+++ b/src/module/vue/components/sf-tabs/sf-bonds.vue
@@ -22,21 +22,7 @@
 <style lang="less" scoped>
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.4s ease;
-  overflow: hidden;
   max-height: 83px;
-  opacity: 1;
-}
-.slide-enter,
-.slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-top: 0;
-  border-bottom: 0;
 }
 </style>
 

--- a/src/module/vue/components/sf-tabs/sf-progresses.vue
+++ b/src/module/vue/components/sf-tabs/sf-progresses.vue
@@ -23,9 +23,9 @@
         <i :class="completedCaretClass"></i> {{ $t('IRONSWORN.Completed') }}
       </h3>
       <transition
-        name="completed-slide"
+        name="slide"
         tag="div"
-        class="nogrow"
+        class="nogrow completed"
         style="margin: 0; padding: 0"
       >
         <div v-if="expandCompleted">
@@ -59,30 +59,10 @@ h3 {
 }
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.4s ease;
-  overflow: hidden;
   max-height: 106px;
-  opacity: 1;
-}
-.completed-slide-enter-active,
-.completed-slide-leave-active {
-  transition: all 0.4s ease-out;
-  overflow: hidden;
-  max-height: 400px;
-  opacity: 1;
-}
-.slide-enter,
-.slide-leave-to,
-.completed-slide-enter,
-.completed-slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-top: 0;
-  border-bottom: 0;
+  &.completed {
+    max-height: 400px;
+  }
 }
 </style>
 

--- a/src/module/vue/components/sf-truth.vue
+++ b/src/module/vue/components/sf-truth.vue
@@ -51,21 +51,7 @@
 <style lang="less" scoped>
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.4s ease;
-  overflow: hidden;
   max-height: 225px;
-  opacity: 1;
-}
-.slide-enter,
-.slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-top: 0;
-  border-bottom: 0;
 }
 </style>
 

--- a/src/module/vue/progress-sheet.vue
+++ b/src/module/vue/progress-sheet.vue
@@ -116,21 +116,7 @@
 <style lang="less" scoped>
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.4s ease;
-  overflow: hidden;
   max-height: 93px;
-  opacity: 1;
-}
-.slide-enter,
-.slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-top: 0;
-  border-bottom: 0;
 }
 </style>
 

--- a/src/module/vue/shared-sheet.vue
+++ b/src/module/vue/shared-sheet.vue
@@ -51,21 +51,7 @@
 <style lang="less" scoped>
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.3s ease;
-  overflow: hidden;
   max-height: 83px;
-  opacity: 1;
-}
-.slide-enter,
-.slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-top: 0;
-  border-bottom: 0;
 }
 
 textarea.notes {

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -543,3 +543,22 @@ table td:first-child {
   white-space: nowrap;
   padding-right: 0.5rem;
 }
+
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.4s ease;
+  overflow: hidden;
+  max-height: 500px; // NOTE: fill this in where you know the right number
+  opacity: 1;
+}
+.slide-enter,
+.slide-leave-to {
+  max-height: 0 !important;
+  opacity: 0 !important;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  border-top: 0 !important;
+  border-bottom: 0 !important;
+}


### PR DESCRIPTION
This CSS was copy-pasted everywhere. This reduces duplication and lowers the barrier-to-entry for using the `slide` transition to 4 lines of LESS.

- [x] Refactor
- [x] Update CHANGELOG.md
