### PR TITLE
Reroll button in oracle-draw chat cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Refactor some CSS ([#305](https://github.com/ben/foundry-ironsworn/pull/305))
+- Add a "reroll" button to oracle-roll chat cards ([#306](https://github.com/ben/foundry-ironsworn/pull/306))
 
 ## 1.10.47
 

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -37,6 +37,7 @@ export class IronswornChatCard {
     html.find('.ironsworn__sojourn__extra__roll').on('click', (ev) => this._sojournExtra.call(this, ev))
     html.find('.ironsworn__paytheprice__roll').on('click', (ev) => this._payThePriceExtra.call(this, ev))
     html.find('.starforged__oracle__roll').on('click', (ev) => this._sfOracleRoll.call(this, ev))
+    html.find('.starforged__oracle__reroll').on('click', (ev) => this._sfOracleReroll.call(this, ev))
   }
 
   async _moveNavigate(ev: JQuery.ClickEvent) {
@@ -235,6 +236,15 @@ export class IronswornChatCard {
     const pack = game.packs.get('foundry-ironsworn.starforgedoracles')
     const { tableid } = ev.target.dataset
     const table = await pack?.getDocument(tableid) as any | undefined
+    rollAndDisplayOracleResult(table)
+  }
+
+  async _sfOracleReroll(ev: JQuery.ClickEvent) {
+    ev.preventDefault()
+    const pack = game.packs.get('foundry-ironsworn.starforgedoracles')
+    const parent = $(ev.target).parent('.table-draw')
+    const tableId = parent.data('table-id')
+    const table = await pack?.getDocument(tableId) as any | undefined
     rollAndDisplayOracleResult(table)
   }
 

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -77,6 +77,7 @@
     "Vow": "Vow",
     "Vows": "Vows",
     "Progress": "Progress",
+    "Reroll": "Reroll",
     "Moves": "Moves",
     "Session": "Session",
     "Connection": "Connection",

--- a/system/templates/chat/oracle-roll.hbs
+++ b/system/templates/chat/oracle-roll.hbs
@@ -33,4 +33,8 @@ table: RollTable {parent: null, pack: 'foundry-ironsworn.starforgedoracles', dat
     </tbody>
   </table>
 
+  <button class="starforged__oracle__reroll">
+    <i class="fas fa-undo-alt"></i>
+    {{localize 'IRONSWORN.Reroll'}}
+  </button>
 </div>


### PR DESCRIPTION
This adds a "reroll" button to chat cards for oracle rolls:

![CleanShot 2022-04-24 at 13 50 08](https://user-images.githubusercontent.com/39902/164996029-9ff36c6d-cf60-4f4b-8276-5556d833afda.jpg)


- [x] Add the button
- [x] Implement the button
- [x] Update CHANGELOG.md
