### PR TITLE
Use "connections" instead of "bonds"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Catch bad regexes in search boxes
+- "Bonds" -> "Connections" ([#315](https://github.com/ben/foundry-ironsworn/pull/315))
 
 ## 1.10.51
 

--- a/src/module/vue/components/progress/progress-box.vue
+++ b/src/module/vue/components/progress/progress-box.vue
@@ -106,7 +106,9 @@ export default {
       return actor?.items.get(this.item._id)
     },
     subtitle() {
-      return this.$t(`IRONSWORN.${this.$capitalize(this.item.data.subtype)}`)
+      let subtype=this.$capitalize(this.item.data.subtype)
+      if (subtype === 'Bond') subtype = 'Connection' // translate name
+      return this.$t(`IRONSWORN.${subtype}`)
     },
     completedIcon() {
       const suffix = this.item.data.completed

--- a/src/module/vue/components/sf-tabs/sf-connections.vue
+++ b/src/module/vue/components/sf-tabs/sf-connections.vue
@@ -2,7 +2,7 @@
   <div class="flexcol">
     <transition-group name="slide" tag="div" class="nogrow">
       <progress-box
-        v-for="item in bonds"
+        v-for="item in connections"
         :key="item._id"
         :item="item"
         :actor="actor"
@@ -11,7 +11,7 @@
     </transition-group>
 
     <div class="flexrow nogrow" style="text-align: center">
-      <div class="clickable block" @click="newBond">
+      <div class="clickable block" @click="newConnection">
         <i class="fas fa-plus"></i>
         {{ $t('IRONSWORN.Bond') }}
       </div>
@@ -33,20 +33,20 @@ export default {
   },
 
   computed: {
-    bonds() {
+    connections() {
       return this.actor.items
         .filter((x) => x.type === 'progress')
-        .filter((x) => x.data.subtype === 'bond')
+        .filter((x) => x.data.subtype === 'bond') // legacy name
     },
   },
 
   methods: {
-    async newBond() {
+    async newConnection() {
       const item = await Item.create(
         {
-          name: 'Bond',
+          name: game.i18n.localize('IRONSWORN.Connection'),
           type: 'progress',
-          data: { subtype: 'bond' },
+          data: { subtype: 'bond' }, // legacy name
           sort: 9000000,
         },
         { parent: this.$actor }

--- a/src/module/vue/components/sf-tabs/sf-legacies.vue
+++ b/src/module/vue/components/sf-tabs/sf-legacies.vue
@@ -27,7 +27,6 @@
 </template>
 
 <script>
-import LegacyTrack from '../legacy-track.vue'
 export default {
   props: {
     actor: Object,

--- a/src/module/vue/progress-sheet.vue
+++ b/src/module/vue/progress-sheet.vue
@@ -14,7 +14,7 @@
     >
       <option value="vow">{{ $t('IRONSWORN.Vow') }}</option>
       <option value="progress">{{ $t('IRONSWORN.Progress') }}</option>
-      <option value="bond">{{ $t('IRONSWORN.Bond') }}</option>
+      <option value="bond">{{ $t('IRONSWORN.Connection') }}</option>
     </select>
 
     <hr class="nogrow" />

--- a/src/module/vue/sf-charactersheet.vue
+++ b/src/module/vue/sf-charactersheet.vue
@@ -126,7 +126,7 @@ export default {
       { titleKey: 'IRONSWORN.Legacies', component: 'sf-legacies' },
       { titleKey: 'IRONSWORN.Assets', component: 'sf-assets' },
       { titleKey: 'IRONSWORN.Progress', component: 'sf-progresses' },
-      { titleKey: 'IRONSWORN.Bonds', component: 'sf-bonds' },
+      { titleKey: 'IRONSWORN.Connections', component: 'sf-connections' },
       { titleKey: 'IRONSWORN.Notes', component: 'sf-notes' },
     ]
     return {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -80,6 +80,7 @@
     "Reroll": "Reroll",
     "Moves": "Moves",
     "Session": "Session",
+    "Connections": "Connections",
     "Connection": "Connection",
     "Exploration": "Exploration",
     "Recover": "Recover",


### PR DESCRIPTION
Fixes #316. Most of this is just visual replacement, but I did rename the `sf-bonds` Vue component to `sf-connections`.

- [x] Change the name everywhere
- [x] Update CHANGELOG.md
