### PR TITLE
Restructure moves to look/act more like oracles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Update the starship sheet to be more useful ([#318](https://github.com/ben/foundry-ironsworn/pull/318))
+- Update the move sheet to better match the oracle sheet ([#320](https://github.com/ben/foundry-ironsworn/pull/320))
 
 ## 1.10.54
 

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -1,8 +1,11 @@
 <template>
-  <div class="item-row" :class="{ highlighted: move.highlighted }">
+  <div :class="{ highlighted: move.highlighted }">
     <h4 style="margin: 0" class="flexrow" :title="tooltip">
-      <i class="fa fa-dice-d6 clickable text nogrow" @click="rollMove" />
-      <span @click="expanded = !expanded">{{ move.foundryItem.name }}</span>
+      <span class="clickable text" @click="rollMove">
+        <i class="fa fa-dice-d6 nogrow" />
+        {{ move.foundryItem.name }}
+      </span>
+      <icon-button icon="eye" @click="expanded = !expanded" />
     </h4>
     <transition name="slide">
       <with-rolllisteners
@@ -72,7 +75,10 @@ export default {
 
   methods: {
     async rollMove() {
-      const move = await CONFIG.IRONSWORN.dataforgedHelpers.getFoundryMoveByDfId(this.move.$id)
+      const move =
+        await CONFIG.IRONSWORN.dataforgedHelpers.getFoundryMoveByDfId(
+          this.move.$id
+        )
       CONFIG.IRONSWORN.SFRollMoveDialog.show(this.$actor, move)
     },
 

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -22,6 +22,11 @@
 </template>
 
 <style lang="less" scoped>
+.move-summary {
+  border-left: 2px solid;
+  margin-left: 5px;
+  padding-left: 1rem;
+}
 h4 {
   margin: 0;
 }


### PR DESCRIPTION
Before/after:


![CleanShot 2022-04-27 at 06 47 44](https://user-images.githubusercontent.com/39902/165533546-ce992530-af45-418e-97aa-f5a003a14dba.jpg)

- [x] Add 👁️ icon and change click effects
- [x] Change display style
- [x] Update CHANGELOG.md
