### PR TITLE
Oracle roll path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Add the "path" to the rolled oracle to the chat card output ([#329](https://github.com/ben/foundry-ironsworn/pull/329))
+
 ## 1.10.57
 
 - Fix oracle-result links to "action+theme" and strip undisplayable characters ([#328](https://github.com/ben/foundry-ironsworn/pull/328))

--- a/src/module/chat/chatrollhelpers.ts
+++ b/src/module/chat/chatrollhelpers.ts
@@ -1,7 +1,7 @@
 import { compact, sortBy } from 'lodash'
 import { IronswornActor } from '../actor/actor'
 import { DenizenSlot } from '../actor/actortypes'
-import { getDFMoveByDfId, getFoundryTableByDfId } from '../dataforged'
+import { getDFMoveByDfId, getFoundryTableByDfId, i18nOraclePath } from '../dataforged'
 import { EnhancedDataswornMove } from '../helpers/data'
 import { IronswornSettings } from '../helpers/settings'
 import { capitalize } from '../helpers/util'
@@ -344,6 +344,7 @@ export async function rollAndDisplayOracleResult(table?: RollTable): Promise<str
   const renderData = {
     themeClass: `theme-${IronswornSettings.theme}`,
     table,
+    oraclePath: i18nOraclePath(table.data.flags.dfId),
     roll,
     displayRows,
     result: tableDraw.results[0],

--- a/src/module/chat/chatrollhelpers.ts
+++ b/src/module/chat/chatrollhelpers.ts
@@ -1,7 +1,7 @@
 import { compact, sortBy } from 'lodash'
 import { IronswornActor } from '../actor/actor'
 import { DenizenSlot } from '../actor/actortypes'
-import { getDFMoveByDfId, getFoundryTableByDfId, i18nOraclePath } from '../dataforged'
+import { findOracleWithIntermediateNodes, getDFMoveByDfId, getFoundryTableByDfId } from '../dataforged'
 import { EnhancedDataswornMove } from '../helpers/data'
 import { IronswornSettings } from '../helpers/settings'
 import { capitalize } from '../helpers/util'
@@ -340,11 +340,16 @@ export async function rollAndDisplayOracleResult(table?: RollTable): Promise<str
     tableRows[resultIdx + 1]
   ])
 
+  // Calculate the "path" to this oracle
+  const oracleNodes = findOracleWithIntermediateNodes(table.data.flags.dfId)
+  const pathNames = oracleNodes.map(x => x.Display.Title)
+  pathNames.pop()
+
   // Render the chat message content
   const renderData = {
     themeClass: `theme-${IronswornSettings.theme}`,
     table,
-    oraclePath: i18nOraclePath(table.data.flags.dfId),
+    oraclePath: pathNames.join(' / '),
     roll,
     displayRows,
     result: tableDraw.results[0],

--- a/src/module/dataforged.ts
+++ b/src/module/dataforged.ts
@@ -102,7 +102,7 @@ export function getDFOracleByDfId(dfid: string): IOracle | IOracleCategory | und
 export function i18nOraclePath(dfid: string): Promise<string | undefined> {
   // Depth-first, translate on the way back up
   function walkCategory(node: IOracleCategory) {
-    const i18nkey = `IRONSWORN.SFOracleCategories.${node.Name}`
+    const i18nkey = `IRONSWORN.SFOracleCategories.${node.Display.Title}`
     for (const oracle of node.Oracles ?? []) {
       if (testLeaf(oracle)) return game.i18n.localize(i18nkey)
       const ret = walkOracleContainer(oracle)
@@ -118,7 +118,7 @@ export function i18nOraclePath(dfid: string): Promise<string | undefined> {
   function walkOracleContainer(node:IOracleCategory | IOracle) {
     for (const child of node.Oracles ?? []) {
       if (testLeaf(child)) {
-        return game.i18n.localize(`IRONSWORN.SFOracleCategories.${node.Name}`)
+        return game.i18n.localize(`IRONSWORN.SFOracleCategories.${node.Display.Title}`)
       }
     }
   }

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -546,10 +546,15 @@ table td:first-child {
   padding-right: 0.5rem;
 }
 
-.table-draw table {
-  td:first-child,
-  td:last-child {
-    width: 0;
+.table-draw {
+  h2 {
+    border: none;
+  }
+  table {
+    td:first-child,
+    td:last-child {
+      width: 0;
+    }
   }
 }
 

--- a/system/templates/chat/oracle-roll.hbs
+++ b/system/templates/chat/oracle-roll.hbs
@@ -8,7 +8,7 @@ table: RollTable {parent: null, pack: 'foundry-ironsworn.starforgedoracles', dat
 --}}
 
 <div class="table-draw {{themeClass}}" data-table-id="{{table.id}}">
-  <h3>{{table.name}}</h3>
+  <h2>{{table.name}}</h2>
 
   {{!-- Table rows --}}
   <table>

--- a/system/templates/chat/oracle-roll.hbs
+++ b/system/templates/chat/oracle-roll.hbs
@@ -8,6 +8,7 @@ table: RollTable {parent: null, pack: 'foundry-ironsworn.starforgedoracles', dat
 --}}
 
 <div class="table-draw {{themeClass}}" data-table-id="{{table.id}}">
+  <small>{{oraclePath}}</small>
   <h2>{{table.name}}</h2>
 
   {{!-- Table rows --}}


### PR DESCRIPTION
Including the oracle's "path" in the display, like so:

![CleanShot 2022-04-30 at 09 19 59](https://user-images.githubusercontent.com/39902/166113730-7cf90748-a11c-4cb1-8091-6ce903e8c9ad.jpg)

- [x] Write a correct tree walk for oracles and categories
- [x] Translate each part of the path
- [x] Display the path in the roll output
- [x] Update CHANGELOG.md
