### PR TITLE
Oracle hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Add the "path" to the rolled oracle to the chat card output ([#329](https://github.com/ben/foundry-ironsworn/pull/329))
+- Allow custom oracles ([#330](https://github.com/ben/foundry-ironsworn/pull/330))
 
 ## 1.10.57
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Assets are in their own compendium, drag them onto your character sheet.
 Now you're ready to create vows, embark on journeys, and slay beasts.
 Keep track of your story using journal entries.
 
+## Extensibility
+
+(TODO)
+
 ## How to hack on this
 
 1. Install Foundry 0.8.8 or later, and start it up.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ Keep track of your story using journal entries.
 
 ## Extensibility
 
-(TODO)
+**Custom oracles** can be added in one of two ways.
+The first is by creating a table folder called "Custom Oracles" (this name may be translated).
+Whatever folder and table structure is found there will be mirrored into the oracle sidebar.
+
+The second is more useful for modules, and involves intercepting the `ironswornOracles` hook.
+The type of object in the tree is shown in `customoracles.ts`.
 
 ## How to hack on this
 

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -1,5 +1,4 @@
-import { IOracle, IOracleCategory } from 'dataforged'
-import { starforged } from 'dataforged'
+import { starforged, IOracle, IOracleCategory } from 'dataforged'
 import { getFoundryTableByDfId } from '../dataforged'
 
 export interface OracleTreeNode {
@@ -15,9 +14,7 @@ const emptyNode = () =>
     children: [],
   } as OracleTreeNode)
 
-export async function createOracleTree(): Promise<OracleTreeNode> {
-  // TODO: are we doing Ironsworn or Starforged? SF only for now
-
+export async function createStarforgedOracleTree(): Promise<OracleTreeNode> {
   const rootNode = emptyNode()
 
   // Make sure the compendium is loaded

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -31,7 +31,8 @@ export async function createOracleTree(): Promise<OracleTreeNode> {
 
   // TODO: Add in custom oracles from a well-known directory
 
-  // TODO: fire the hook and allow extensions to modify the tree
+  // Fire the hook and allow extensions to modify the tree
+  Hooks.call('ironswornOracles', rootNode)
 
   return rootNode
 }

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -30,7 +30,7 @@ export async function createStarforgedOracleTree(): Promise<OracleTreeNode> {
   await augmentWithFolderContents(rootNode)
 
   // Fire the hook and allow extensions to modify the tree
-  Hooks.call('ironswornOracles', rootNode)
+  await Hooks.call('ironswornOracles', rootNode)
 
   return rootNode
 }

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -61,3 +61,19 @@ async function walkOracle(oracle: IOracle): Promise<OracleTreeNode> {
 
   return node
 }
+
+export function findPathToNodeByTableId(rootNode: OracleTreeNode, tableId: string): OracleTreeNode[] {
+  const ret: OracleTreeNode[] = []
+  function walk(node:OracleTreeNode) {
+    ret.push(node)
+    if (node.table?.id === tableId) return true
+    for (const child of node.children) {
+      if (walk(child)) return true
+    }
+    ret.pop()
+    return false
+  }
+
+  walk(rootNode)
+  return ret
+}

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -72,7 +72,7 @@ async function augmentWithFolderContents(node:OracleTreeNode) {
     // Add this folder
     const newNode:OracleTreeNode = {
       ...emptyNode(),
-      displayName: folder.name
+      displayName: folder.name || '(folder)'
     }
     parent.children.push(newNode)
 

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -1,0 +1,65 @@
+import { IOracle, IOracleCategory } from 'dataforged'
+import { starforged } from 'dataforged'
+import { getFoundryTableByDfId } from '../dataforged'
+
+export interface OracleTreeNode {
+  dataforgedNode?: IOracle | IOracleCategory
+  table?: RollTable
+  displayName: string
+  children: OracleTreeNode[]
+}
+
+const emptyNode = () =>
+  ({
+    displayName: '',
+    children: [],
+  } as OracleTreeNode)
+
+export async function createOracleTree(): Promise<OracleTreeNode> {
+  // TODO: are we doing Ironsworn or Starforged? SF only for now
+
+  const rootNode = emptyNode()
+
+  // Make sure the compendium is loaded
+  const pack = game.packs.get('foundry-ironsworn.starforgedoracles')
+  await pack?.getDocuments()
+
+  // Build the default tree
+  for (const category of starforged.oracles) {
+    rootNode.children.push(await walkOracleCategory(category))
+  }
+
+  // TODO: Add in custom oracles from a well-known directory
+
+  // TODO: fire the hook and allow extensions to modify the tree
+
+  return rootNode
+}
+
+async function walkOracleCategory(cat: IOracleCategory): Promise<OracleTreeNode> {
+  const node: OracleTreeNode = {
+    ...emptyNode(),
+    dataforgedNode: cat,
+    displayName: game.i18n.localize(`IRONSWORN.SFOracleCategories.${cat.Display.Title}`),
+  }
+
+  for (const childCat of cat.Categories ?? []) node.children.push(await walkOracleCategory(childCat))
+  for (const oracle of cat.Oracles ?? []) node.children.push(await walkOracle(oracle))
+
+  return node
+}
+
+async function walkOracle(oracle: IOracle): Promise<OracleTreeNode> {
+  const table = await getFoundryTableByDfId(oracle.$id)
+
+  const node: OracleTreeNode = {
+    ...emptyNode(),
+    dataforgedNode: oracle,
+    table,
+    displayName: table?.name || game.i18n.localize(`IRONSWORN.SFOracleCategories.${oracle.Display.Title}`),
+  }
+
+  for (const childOracle of oracle.Oracles ?? []) node.children.push(await walkOracle(childOracle))
+
+  return node
+}

--- a/src/module/vue/components/oracletree-node.vue
+++ b/src/module/vue/components/oracletree-node.vue
@@ -2,14 +2,14 @@
   <div class="flexcol nogrow" :class="{ hidden: hidden }">
     <!-- TODO: split this into two components, yo -->
     <!-- Leaf node -->
-    <div v-if="oracle.foundryTable">
+    <div v-if="node.table">
       <h4 class="clickable text flexrow">
         <span @click="rollOracle">
           <i class="isicon-d10-tilt juicy"></i>
-          {{ name }}
+          {{ node.displayName }}
         </span>
         <icon-button
-          v-if="oracle.foundryTable"
+          v-if="node.table"
           icon="eye"
           @click="descriptionExpanded = !descriptionExpanded"
         />
@@ -38,16 +38,16 @@
           <i v-if="expanded" class="fa fa-caret-down" />
           <i v-else class="fa fa-caret-right" />
         </span>
-        {{ name }}
+        {{ node.displayName }}
       </h4>
 
       <transition name="slide">
         <div class="flexcol" v-if="expanded" style="margin-left: 1rem">
           <oracletree-node
-            v-for="child in children"
-            :key="child.dfid"
+            v-for="child in node.children"
+            :key="child.displayName"
             :actor="actor"
-            :oracle="child"
+            :node="child"
             :searchQuery="searchQuery"
             :parentMatchesSearch="matchesSearch"
             ref="children"
@@ -75,7 +75,7 @@ h4 {
 export default {
   props: {
     actor: Object,
-    oracle: Object,
+    node: Object,
     searchQuery: String,
     parentMatchesSearch: Boolean,
   },
@@ -88,12 +88,7 @@ export default {
   },
 
   computed: {
-    children() {
-      return [...(this.oracle.Categories ?? []), ...(this.oracle.Oracles ?? [])]
-    },
-
     childMatchesSearch() {
-      this.searchQuery
       return this.$refs.children?.find((x) => x.matchesSearch)
     },
 
@@ -101,31 +96,24 @@ export default {
       return this.manuallyExpanded || !!this.searchQuery
     },
 
-    name() {
-      return (
-        this.oracle.foundryTable?.name ??
-        this.$t(`IRONSWORN.SFOracleCategories.${this.oracle.Display.Title}`)
-      )
-    },
-
     matchesSearch() {
       const re = new RegExp(this.searchQuery, 'i')
-      return re.test(this.name)
+      return re.test(this.node.displayName)
     },
 
     hidden() {
       if (!this.searchQuery) return false
       return !(
-        this.matchesSearch || // This matches
-        this.parentMatchesSearch || // Parent matches
+        this.matchesSearch ||
+        this.parentMatchesSearch ||
         this.childMatchesSearch
       )
     },
 
     tablePreview() {
-      const description = this.oracle.foundryTable.data.description || ''
+      const description = this.node.table.data.description || ''
       const tableRows = CONFIG.IRONSWORN._.sortBy(
-        this.oracle.foundryTable.data.results.contents.map((x) => ({
+        this.node.table.data.results.contents.map((x) => ({
           low: x.data.range[0],
           high: x.data.range[1],
           text: x.data.text,
@@ -144,16 +132,8 @@ export default {
   },
 
   methods: {
-    click() {
-      if (this.oracle.foundryTable) {
-        CONFIG.IRONSWORN.rollAndDisplayOracleResult(this.oracle.foundryTable)
-      } else {
-        this.manuallyExpanded = !this.manuallyExpanded
-      }
-    },
-
     rollOracle() {
-      CONFIG.IRONSWORN.rollAndDisplayOracleResult(this.oracle.foundryTable)
+      CONFIG.IRONSWORN.rollAndDisplayOracleResult(this.node.table)
     },
 
     moveclick(item) {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -98,6 +98,7 @@
     "Custom Moves": "Custom Moves",
     "CustomMoves": "Custom Moves",
     "Oracles": "Oracles",
+    "Custom Oracles": "Custom Oracles",
     "Search": "Search",
     "Plot": "Plot",
     "Location": "Location",


### PR DESCRIPTION
This should address most of #304. The idea here is that we create an oracle tree once when the oracle sheet is opened, creating a data structure that's easier to work with for the UI, and allows for extensions.

- [x] Generate the base DF tree
- [x] Look for a standard folder to do basic extensions
- [x] Fire the hook to allow modification of the tree
- [x] Document the hook
- [x] Update the oracle sheet and node structure to use the new tree
- [x] Update CHANGELOG.md
