### PR TITLE
Oracles can have multiple tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Oracle hooks can add tables to oracle nodes ([#333](https://github.com/ben/foundry-ironsworn/pull/333))
+
 ## 1.10.59
 
 - Fix oracle search ([#331](https://github.com/ben/foundry-ironsworn/pull/331))

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Whatever folder and table structure is found there will be mirrored into the ora
 
 The second is more useful for modules, and involves intercepting the `ironswornOracles` hook.
 The type of object in the tree is shown in `customoracles.ts`.
+Here's a simple hoook that adds more rows to the "Background Assets" oracle:
+
+```js
+Hooks.on('ironswornOracles', (root) => {
+  root.children[0].children[0].tables.push(game.tables.get('MSjHr7AahxxJXAqe'))
+})
+```
 
 ## How to hack on this
 

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -65,16 +65,16 @@ async function walkOracle(oracle: IOracle): Promise<OracleTreeNode> {
   return node
 }
 
-async function augmentWithFolderContents(node:OracleTreeNode) {
+async function augmentWithFolderContents(node: OracleTreeNode) {
   const name = game.i18n.localize('IRONSWORN.Custom Oracles')
-  const rootFolder = game.tables?.directory?.folders.find(x => x.name === name)
+  const rootFolder = game.tables?.directory?.folders.find((x) => x.name === name)
   if (!rootFolder) return
 
-  function walkFolder(parent:OracleTreeNode, folder: Folder) {
+  function walkFolder(parent: OracleTreeNode, folder: Folder) {
     // Add this folder
-    const newNode:OracleTreeNode = {
+    const newNode: OracleTreeNode = {
       ...emptyNode(),
-      displayName: folder.name || '(folder)'
+      displayName: folder.name || '(folder)',
     }
     parent.children.push(newNode)
 
@@ -98,9 +98,9 @@ async function augmentWithFolderContents(node:OracleTreeNode) {
 
 export function findPathToNodeByTableId(rootNode: OracleTreeNode, tableId: string): OracleTreeNode[] {
   const ret: OracleTreeNode[] = []
-  function walk(node:OracleTreeNode) {
+  function walk(node: OracleTreeNode) {
     ret.push(node)
-    const foundTable = node.tables.find(x => x.id === tableId)
+    const foundTable = node.tables.find((x) => x.id === tableId)
     if (foundTable) return true
     for (const child of node.children) {
       if (walk(child)) return true

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -67,8 +67,8 @@ async function walkOracle(oracle: IOracle): Promise<OracleTreeNode> {
 
 async function augmentWithFolderContents(node:OracleTreeNode) {
   const name = game.i18n.localize('IRONSWORN.Custom Oracles')
-  const folder = game.tables?.directory?.folders.find(x => x.name === name)
-  if (!folder) return
+  const rootFolder = game.tables?.directory?.folders.find(x => x.name === name)
+  if (!rootFolder) return
 
   function walkFolder(parent:OracleTreeNode, folder: Folder) {
     // Add this folder
@@ -93,7 +93,7 @@ async function augmentWithFolderContents(node:OracleTreeNode) {
     }
   }
 
-  walkFolder(node, folder)
+  walkFolder(node, rootFolder)
 }
 
 export function findPathToNodeByTableId(rootNode: OracleTreeNode, tableId: string): OracleTreeNode[] {

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -1,9 +1,10 @@
 import { starforged, IOracle, IOracleCategory } from 'dataforged'
+import { compact } from 'lodash'
 import { getFoundryTableByDfId } from '../dataforged'
 
 export interface OracleTreeNode {
   dataforgedNode?: IOracle | IOracleCategory
-  table?: RollTable
+  tables: RollTable[]
   displayName: string
   children: OracleTreeNode[]
 }
@@ -11,6 +12,7 @@ export interface OracleTreeNode {
 const emptyNode = () =>
   ({
     displayName: '',
+    tables: [],
     children: [],
   } as OracleTreeNode)
 
@@ -54,7 +56,7 @@ async function walkOracle(oracle: IOracle): Promise<OracleTreeNode> {
   const node: OracleTreeNode = {
     ...emptyNode(),
     dataforgedNode: oracle,
-    table,
+    tables: compact([table]),
     displayName: table?.name || game.i18n.localize(`IRONSWORN.SFOracleCategories.${oracle.Display.Title}`),
   }
 
@@ -85,7 +87,7 @@ async function augmentWithFolderContents(node:OracleTreeNode) {
     for (const table of folder.contents) {
       newNode.children.push({
         ...emptyNode(),
-        table,
+        tables: [table],
         displayName: table.name ?? '(table)',
       })
     }
@@ -98,7 +100,8 @@ export function findPathToNodeByTableId(rootNode: OracleTreeNode, tableId: strin
   const ret: OracleTreeNode[] = []
   function walk(node:OracleTreeNode) {
     ret.push(node)
-    if (node.table?.id === tableId) return true
+    const foundTable = node.tables.find(x => x.id === tableId)
+    if (foundTable) return true
     for (const child of node.children) {
       if (walk(child)) return true
     }


### PR DESCRIPTION
This addresses more of #304 by allowing each "oracle" entry in the tree to have more than one table, which effectively allows a hook to add more rows to an existing oracle.

- [x] Update the logic
- [x] Update hook docs
- [x] Update CHANGELOG.md
