### PR TITLE
Custom moves for Starforged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Custom moves from folder and hook ([#334](https://github.com/ben/foundry-ironsworn/pull/334))
+
 ## 1.10.60
 
 - Oracle hooks can add tables to oracle nodes ([#333](https://github.com/ben/foundry-ironsworn/pull/333))

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Hooks.on('ironswornOracles', (root) => {
 })
 ```
 
+**Custom moves** can be added in similar ways.
+They must be placed in an item folder called "Custom Moves" (translated), and regardless of the structure inside, they will show up in a "Custom Moves" section of the move sheet.
+
+There is also an `ironswornMoves` hook, which passes the final tree before display.
+See `custommoves.ts` for the structure of those objects.
+
 ## How to hack on this
 
 1. Install Foundry 0.8.8 or later, and start it up.

--- a/src/module/features/custommoves.ts
+++ b/src/module/features/custommoves.ts
@@ -1,6 +1,6 @@
 import { IMove, IMoveCategory, starforged } from 'dataforged'
 import { IronswornItem } from '../item/item'
-import { MoveDataProperties, MoveDataSource } from '../item/itemtypes'
+import { MoveDataSource } from '../item/itemtypes'
 
 export interface MoveCategory {
   displayName: string

--- a/src/module/features/custommoves.ts
+++ b/src/module/features/custommoves.ts
@@ -60,15 +60,15 @@ function walkCategory(category: IMoveCategory, compendiumMoves: IronswornItem[])
 
 async function augmentWithFolderContents(categories: MoveCategory[]) {
   const name = game.i18n.localize('IRONSWORN.Custom Moves')
-  const folder = game.items?.directory?.folders.find((x) => x.name === name)
+  const folder = (game.items?.directory as any)?.folders.find((x) => x.name === name) as Folder | undefined
   console.log(folder)
   if (!folder || folder.contents.length == 0) return
 
   categories.push({
     displayName: name,
-    moves: folder.contents.map(moveItem => ({
+    moves: folder.contents.map((moveItem) => ({
       displayName: moveItem.name,
       moveItem,
-    })) as Move[]
+    })) as Move[],
   })
 }

--- a/src/module/features/custommoves.ts
+++ b/src/module/features/custommoves.ts
@@ -1,0 +1,58 @@
+import { IMove, IMoveCategory, starforged } from 'dataforged'
+import { IronswornItem } from '../item/item'
+import { MoveDataProperties, MoveDataSource } from '../item/itemtypes'
+
+export interface MoveCategory {
+  displayName: string
+  moves: Move[]
+  dataforgedCategory?: IMoveCategory
+}
+
+export interface Move {
+  displayName: string
+  moveItem: IronswornItem
+  dataforgedMove?: IMove
+}
+
+export async function createStarforgedMoveTree(): Promise<MoveCategory[]> {
+  const ret = [] as MoveCategory[]
+
+  // Make sure compendium is loaded
+  const pack = game.packs.get('foundry-ironsworn.starforgedmoves')
+  const compendiumMoves = (await pack?.getDocuments()) as IronswornItem[]
+
+  // Construct the base tree
+  for (const category of starforged.moves) {
+    ret.push(walkCategory(category, compendiumMoves))
+  }
+
+  // TODO: Add custom moves from well-known folder
+
+  // Fire the hook and allow extensions to modify the list
+  await Hooks.call('ironswornMoves', ret)
+
+  return ret
+}
+
+function walkCategory(category: IMoveCategory, compendiumMoves: IronswornItem[]): MoveCategory {
+  const newCategory = {
+    displayName: game.i18n.localize(`IRONSWORN.${category.Name}`),
+    dataforgedCategory: category,
+    moves: [] as Move[],
+  }
+
+  for (const move of category.Moves) {
+    const moveItem = compendiumMoves?.find((x) => (x.data as MoveDataSource).data.dfid === move.$id)
+    if (moveItem) {
+      newCategory.moves.push({
+        dataforgedMove: move,
+        displayName: moveItem.name || move.Display.Title,
+        moveItem,
+      })
+    } else {
+      console.warn(`Couldn't find item for move ${move.$id}`)
+    }
+  }
+
+  return newCategory
+}

--- a/src/module/features/custommoves.ts
+++ b/src/module/features/custommoves.ts
@@ -26,7 +26,8 @@ export async function createStarforgedMoveTree(): Promise<MoveCategory[]> {
     ret.push(walkCategory(category, compendiumMoves))
   }
 
-  // TODO: Add custom moves from well-known folder
+  // Add custom moves from well-known folder
+  await augmentWithFolderContents(ret)
 
   // Fire the hook and allow extensions to modify the list
   await Hooks.call('ironswornMoves', ret)
@@ -55,4 +56,19 @@ function walkCategory(category: IMoveCategory, compendiumMoves: IronswornItem[])
   }
 
   return newCategory
+}
+
+async function augmentWithFolderContents(categories: MoveCategory[]) {
+  const name = game.i18n.localize('IRONSWORN.Custom Moves')
+  const folder = game.items?.directory?.folders.find((x) => x.name === name)
+  console.log(folder)
+  if (!folder || folder.contents.length == 0) return
+
+  categories.push({
+    displayName: name,
+    moves: folder.contents.map(moveItem => ({
+      displayName: moveItem.name,
+      moveItem,
+    })) as Move[]
+  })
 }

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -28,7 +28,7 @@ export async function createStarforgedOracleTree(): Promise<OracleTreeNode> {
     rootNode.children.push(await walkOracleCategory(category))
   }
 
-  // TODO: Add in custom oracles from a well-known directory
+  // Add in custom oracles from a well-known directory
   await augmentWithFolderContents(rootNode)
 
   // Fire the hook and allow extensions to modify the tree

--- a/src/module/item/itemtypes.ts
+++ b/src/module/item/itemtypes.ts
@@ -165,6 +165,7 @@ interface MoveDataSourceData {
   miss: string
   stats: string[]
   sourceId: string
+  dfid: string
 }
 interface MoveDataPropertiesData extends MoveDataSourceData {}
 

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -56,7 +56,7 @@ export default {
   computed: {
     tooltip() {
       // TODO: page number, when it shows up
-      return this.move.dataforgedMove.Source?.Title
+      return this.move.dataforgedMove?.Source?.Title
     },
 
     fulltext() {

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -3,7 +3,7 @@
     <h4 style="margin: 0" class="clickable text flexrow" :title="tooltip">
       <span @click="rollMove">
         <i class="isicon-d10-tilt juicy"></i>
-        {{ move.foundryItem.name }}
+        {{ move.moveItem.name }}
       </span>
       <icon-button icon="eye" @click="expanded = !expanded" />
     </h4>
@@ -15,7 +15,7 @@
         v-if="expanded"
         @moveclick="moveclick"
       >
-        <div v-html="$enrichMarkdown(move.foundryItem.data.Text)" />
+        <div v-html="$enrichMarkdown(fulltext)" />
       </with-rolllisteners>
     </transition>
   </div>
@@ -56,11 +56,11 @@ export default {
   computed: {
     tooltip() {
       // TODO: page number, when it shows up
-      return this.move.Source?.Title
+      return this.move.dataforgedMove.Source?.Title
     },
 
     fulltext() {
-      return this.move.foundryItem?.data?.data?.fulltext
+      return this.move.moveItem?.data?.data?.Text
     },
   },
 
@@ -76,11 +76,7 @@ export default {
 
   methods: {
     async rollMove() {
-      const move =
-        await CONFIG.IRONSWORN.dataforgedHelpers.getFoundryMoveByDfId(
-          this.move.$id
-        )
-      CONFIG.IRONSWORN.SFRollMoveDialog.show(this.$actor, move)
+      CONFIG.IRONSWORN.SFRollMoveDialog.show(this.$actor, this.move.moveItem)
     },
 
     moveclick(item) {


### PR DESCRIPTION
Much like #330, this refactors the construction of the move tree to a central location, and allows customization by two methods.

- [x] Construct the base tree from Dataforged data
- [x] Walk a folder for more moves
- [x] Fire the hook
- [x] Update the customization documentation
    - [ ] Also update the Foundry directory once this ships
- [x] Update the move sheet to use this new structure
- [x] Update CHANGELOG.md
