### PR TITLE
Mix and match IS/SF sheets and moves/oracles

### DIFF
--- a/src/module/helpers/settings.ts
+++ b/src/module/helpers/settings.ts
@@ -18,6 +18,20 @@ export class IronswornSettings {
       onChange: reload,
     })
 
+    game.settings.register('foundry-ironsworn', 'toolbox', {
+      name: 'IRONSWORN.Settings.Tools.Name',
+      hint: 'IRONSWORN.Settings.Tools.Hint',
+      scope: 'world',
+      config: true,
+      type: String,
+      choices: {
+        sheet: 'IRONSWORN.Settings.Tools.Sheet',
+        ironsworn: 'IRONSWORN.Ironsworn',
+        starforged: 'IRONSWORN.Starforged',
+      },
+      default: 'ironsworn',
+    })
+
     game.settings.register('foundry-ironsworn', 'shared-supply', {
       name: 'IRONSWORN.Settings.SharedSupply.Name',
       hint: 'IRONSWORN.Settings.SharedSupply.Hint',
@@ -65,6 +79,10 @@ export class IronswornSettings {
 
   static get theme(): string {
     return game.settings.get('foundry-ironsworn', 'theme') as string
+  }
+
+  static get toolbox(): string {
+    return game.settings.get('foundry-ironsworn', 'toolbox') as string
   }
 
   static get starforgedBeta(): boolean {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -1,5 +1,7 @@
 {
   "IRONSWORN": {
+    "Ironsworn": "Ironsworn",
+    "Starforged": "Starforged",
     "CreateActor": "Create Actor",
     "YourWorldTruths": "Your World: Truths",
     "TruthQuestStarter": "Quest Starter:",
@@ -200,6 +202,11 @@
         "Hint": "Select the visual look for this game. Requires a reload.",
         "Ironsworn": "Ironsworn Classic",
         "Starforged": "Starforged (experimental)"
+      },
+      "Tools": {
+        "Name": "Character Tools",
+        "Hint": "Which set of moves and oracles will appear when opening a character sheet.",
+        "Sheet": "Match sheet"
       },
       "SharedSupply": {
         "Name": "Shared Supply Tracker",


### PR DESCRIPTION
The simplest thing that could possibly work: a setting that lets you change which movesheet appears when you open a character sheet. In the future this probably just means choosing datasets for the SF movesheet, but for now we'll use the IS one whole hog.

- [ ] Register a setting
- [ ] Use the setting when creating the sheet
- [ ] Update CHANGELOG.md
