### PR TITLE
Starforged isn't beta any longer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix the stellar-object-type oracle roll button
 - Add a first-start dialog so the player can choose some options ([#346](https://github.com/ben/foundry-ironsworn/pull/346))
+- Move starforged content out of beta ([#348](https://github.com/ben/foundry-ironsworn/pull/348))
 
 ## 1.10.64
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,12 +73,10 @@ Hooks.once('init', async () => {
     types: ['character'],
     makeDefault: true,
   })
-  if (CONFIG.IRONSWORN.IronswornSettings.starforgedBeta) {
-    Actors.registerSheet('ironsworn', StarforgedCharacterSheet, {
-      label: 'Starforged character sheet',
-      types: ['character'],
-    })
-  }
+  Actors.registerSheet('ironsworn', StarforgedCharacterSheet, {
+    label: 'Starforged character sheet',
+    types: ['character'],
+  })
   Actors.registerSheet('ironsworn', IronswornCompactCharacterSheet, {
     label: 'Compact sheet',
     types: ['character'],

--- a/src/module/applications/createActorDialog.ts
+++ b/src/module/applications/createActorDialog.ts
@@ -20,13 +20,13 @@ export class CreateActorDialog extends FormApplication<CreateActorDialogOptions>
       resizable: false,
       classes: ['ironsworn', 'sheet', 'new-actor', `theme-${IronswornSettings.theme}`],
       width: 500,
-      height: IronswornSettings.toolbox === 'starforged' ? 365 : 200,
+      height: IronswornSettings.starforgedToolsEnabled ? 365 : 200,
     } as FormApplication.Options)
   }
 
   getData(_options?: Application.RenderOptions): any {
     return {
-      sfenabled: IronswornSettings.toolbox === 'starforged',
+      sfenabled: IronswornSettings.starforgedToolsEnabled,
     }
   }
 

--- a/src/module/applications/createActorDialog.ts
+++ b/src/module/applications/createActorDialog.ts
@@ -20,13 +20,13 @@ export class CreateActorDialog extends FormApplication<CreateActorDialogOptions>
       resizable: false,
       classes: ['ironsworn', 'sheet', 'new-actor', `theme-${IronswornSettings.theme}`],
       width: 500,
-      height: IronswornSettings.starforgedBeta ? 365 : 200,
+      height: IronswornSettings.toolbox === 'starforged' ? 365 : 200,
     } as FormApplication.Options)
   }
 
   getData(_options?: Application.RenderOptions): any {
     return {
-      sfenabled: IronswornSettings.starforgedBeta,
+      sfenabled: IronswornSettings.toolbox === 'starforged',
     }
   }
 

--- a/src/module/applications/createActorDialog.ts
+++ b/src/module/applications/createActorDialog.ts
@@ -19,8 +19,8 @@ export class CreateActorDialog extends FormApplication<CreateActorDialogOptions>
       id: 'new-actor-dialog',
       resizable: false,
       classes: ['ironsworn', 'sheet', 'new-actor', `theme-${IronswornSettings.theme}`],
-      width: 500,
-      height: IronswornSettings.starforgedToolsEnabled ? 365 : 200,
+      width: 650,
+      height: 200,
     } as FormApplication.Options)
   }
 

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -104,7 +104,7 @@ function newVault() {
 }
 
 export function activateSceneButtonListeners() {
-  if (IronswornSettings.toolbox !== 'starforged') return
+  if (!IronswornSettings.starforgedToolsEnabled) return
 
   CONFIG.Canvas.layers['ironsworn'] = { layerClass: IronswornCanvasLayer, group: 'primary' }
 

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -104,7 +104,7 @@ function newVault() {
 }
 
 export function activateSceneButtonListeners() {
-  if (!IronswornSettings.starforgedBeta) return
+  if (IronswornSettings.toolbox !== 'starforged') return
 
   CONFIG.Canvas.layers['ironsworn'] = { layerClass: IronswornCanvasLayer, group: 'primary' }
 

--- a/src/module/helpers/settings.ts
+++ b/src/module/helpers/settings.ts
@@ -59,16 +59,6 @@ export class IronswornSettings {
       default: true,
     })
 
-    game.settings.register('foundry-ironsworn', 'starforged-beta', {
-      name: 'IRONSWORN.Settings.SFBeta.Name',
-      hint: 'IRONSWORN.Settings.SFBeta.Hint',
-      scope: 'world',
-      config: true,
-      type: Boolean,
-      default: false,
-      onChange: reload,
-    })
-
     game.settings.register('foundry-ironsworn', 'data-version', {
       scope: 'world',
       config: false,
@@ -83,10 +73,6 @@ export class IronswornSettings {
 
   static get toolbox(): string {
     return game.settings.get('foundry-ironsworn', 'toolbox') as string
-  }
-
-  static get starforgedBeta(): boolean {
-    return game.settings.get('foundry-ironsworn', 'starforged-beta') as boolean
   }
 
   static get logCharacterChanges(): boolean {

--- a/src/module/helpers/settings.ts
+++ b/src/module/helpers/settings.ts
@@ -75,6 +75,15 @@ export class IronswornSettings {
     return game.settings.get('foundry-ironsworn', 'toolbox') as string
   }
 
+  static get starforgedToolsEnabled(): boolean {
+    if (this.toolbox === 'ironsworn') return false
+    if (this.toolbox === 'starforged') return true
+
+    // Set to "match sheet, so check the sheet"
+    const sheetClasses = game.settings.get('core', 'sheetClasses') as any
+    return sheetClasses.Actor.character === 'ironsworn.StarforgedCharacterSheet'
+  }
+
   static get logCharacterChanges(): boolean {
     return game.settings.get('foundry-ironsworn', 'log-changes') as boolean
   }

--- a/system/templates/actor/create.hbs
+++ b/system/templates/actor/create.hbs
@@ -1,5 +1,6 @@
 {{#*inline "createBox"}}
-<div class="flexrow box clickable block ironsworn__{{type}}__create" style="align-items: center; padding: 1rem;" data-img="{{img}}">
+<div class="flexrow box clickable block ironsworn__{{type}}__create" style="align-items: center; padding: 1rem;"
+  data-img="{{img}}">
   <div class="flexcol" style="align-items: center;">
     <img src="{{img}}" width="75" height="75" alt="">
     <h4 style="margin: 0.1rem 0;">{{localize labelkey}}</h4>
@@ -8,30 +9,24 @@
 {{/inline}}
 
 <form class='{{cssClass}} flexcol' autocomplete='off'>
-  {{#if sfenabled}}
-  <h4 class="nogrow" style="text-align: center;">Ironsworn</h4>
-  {{/if}}
   <div class="flexcol">
     <div class="flexrow boxrow">
       {{>createBox type="character" labelkey="IRONSWORN.Character" img="icons/creatures/eyes/human-single-blue.webp"}}
-      {{>createBox type="shared" labelkey="IRONSWORN.SharedSheet" img="icons/environment/settlement/wagon-black.webp"}}
+      {{>createBox type="shared" labelkey="IRONSWORN.SharedSheet"
+      img="icons/environment/settlement/wagon-black.webp"}}
+      {{#if sfenabled}}
+      {{>createBox type="sfship" labelkey="IRONSWORN.Starship" img="icons/environment/settlement/wizard-castle.webp"}}
+      {{>createBox type="sflocation" labelkey="IRONSWORN.Location"
+      img="systems/foundry-ironsworn/assets/planets/Starforged-Planet-Token-Ocean-02.webp"}}
+      {{else}}
       {{>createBox type="site" labelkey="IRONSWORN.DelveSite"
       img="icons/environment/wilderness/cave-entrance-vulcano.webp"}}
+      {{/if}}
       {{>createBox type="foe" labelkey="IRONSWORN.Foe" img="icons/creatures/eyes/lizard-single-slit-pink.webp"}}
     </div>
   </div>
 
   {{#if sfenabled}}
-  <hr class="nogrow">
-  <h4 class="boxrow nogrow" style="text-align: center;">Starforged</h4>
-  <div class="flexcol">
-    <div class="flexrow boxrow">
-
-      {{>createBox type="sfcharacter" labelkey="IRONSWORN.Character" img="icons/creatures/eyes/human-single-brown.webp"}}
-      {{>createBox type="sfship" labelkey="IRONSWORN.Starship" img="icons/environment/settlement/wizard-castle.webp"}}
-      {{>createBox type="sflocation" labelkey="IRONSWORN.Location" img="systems/foundry-ironsworn/assets/planets/Starforged-Planet-Token-Ocean-02.webp"}}
-
-    </div>
-    {{/if}}
+  {{/if}}
   </div>
 </form>


### PR DESCRIPTION
After #346, Starforged is front and center on the first-start experience, so this setting doesn't make sense any more. Let's deprecate it, and instead use the "toolbox" choice to power whether we have location scene buttons and whatnot.

- [x] Remove the setting
- [x] Retarget where it was being used
- [x] Unify the create-actor dialog
- [x] Update CHANGELOG.md
