### PR TITLE
Add a render hook to decorate the oracle compendia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Decorate rolltable compendia with category information ([#350](https://github.com/ben/foundry-ironsworn/pull/350))
+
 ## 1.11.2
 
 - Fix bonds on the shared sheet

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { CreateActorDialog } from './module/applications/createActorDialog'
 import { FirstStartDialog } from './module/applications/firstStartDialog'
 import { IronswornChatCard } from './module/chat/cards'
 import { activateChangelogListeners } from './module/features/changelog'
+import { registerCompendiumCategoryHook } from './module/features/compendium-categories'
 import { maybePromptForDependencies } from './module/features/dependencies'
 import { activateDragDropListeners } from './module/features/dragdrop'
 import { activateSceneButtonListeners } from './module/features/sceneButtons'
@@ -177,6 +178,7 @@ Hooks.once('init', async () => {
   IronswornChatCard.registerHooks()
   activateSceneButtonListeners()
   registerZIndexHook()
+  registerCompendiumCategoryHook()
   registerTokenHUDButtons()
 })
 

--- a/src/module/features/compendium-categories.ts
+++ b/src/module/features/compendium-categories.ts
@@ -1,0 +1,16 @@
+export function registerCompendiumCategoryHook() {
+  Hooks.on('renderCompendium', async (_app, html: JQuery, opts) => {
+    if (opts.documentCls !== 'rolltable') return
+
+    const collection = opts.collection
+    for (const el of html.find('.directory-item')) {
+      const table = await collection.getDocument(el.dataset.documentId) as RollTable
+      if (table?.data?.flags?.category) {
+        const cat = table.data.flags.category
+          .replace(/(Starforged|Ironsworn)\/Oracles\//, '')
+          .replace(/_/g, ' ')
+        $(el).append(`<small style="flex-grow: 0; white-space: nowrap">${cat}</small>`)
+      }
+    }
+  })
+}


### PR DESCRIPTION
Adds a hook to decorate the oracle compendia with category information. Fixes #339.

![CleanShot 2022-05-08 at 09 00 59](https://user-images.githubusercontent.com/39902/167304611-047fee56-033e-46e1-b5e6-98cb2d5b0c93.jpg)


- [x] Write the hook
- [x] Update CHANGELOG.md
