### PR TITLE
Deprecate shared bonds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Decorate rolltable compendia with category information ([#350](https://github.com/ben/foundry-ironsworn/pull/350))
+- Remove the bond track from shared sheets (in most cases) ([#352](https://github.com/ben/foundry-ironsworn/pull/352))
 
 ## 1.11.2
 

--- a/src/module/vue/shared-sheet.vue
+++ b/src/module/vue/shared-sheet.vue
@@ -19,7 +19,7 @@
       />
     </section>
 
-    <section class="sheet-area nogrow">
+    <section v-if="hasBonds" class="sheet-area nogrow">
       <bonds :actor="actor" />
     </section>
 
@@ -76,6 +76,12 @@ export default {
         ...this.actor.items.filter((x) => x.type === 'vow'),
         ...this.actor.items.filter((x) => x.type === 'progress'),
       ]
+    },
+
+    hasBonds() {
+      const bonds = this.actor.items.find(x => x.type === 'bondset')
+      const markedBonds = bonds?.data?.bonds?.length
+      return markedBonds && markedBonds > 0
     },
   },
 

--- a/system/template.json
+++ b/system/template.json
@@ -184,10 +184,7 @@
       "menace": 0
     },
     "bondset": {
-      "bonds": [{
-        "name": "A community",
-        "notes": ""
-      }]
+      "bonds": []
     },
     "site": {
       "templates": [


### PR DESCRIPTION
Fixes #340. This removes the bonds track on shared sheets that don't have any bonds marked, and ensures that new shared sheets won't have any bonds marked. So

* Games with shared sheets
  * …where players have ignored the bonds track: this will still show the track with 1 tick, since bondsets have been created with "A community" marked (this dates from the first version which was designed to support a brand-new Ironsworn character)
  * …where players have manually cleared the bonds track: it will be hidden
* Newly-created shared sheets will not show the track, since the new default bondset doesn't have anything marked.

So there's still a case where one will be displayed when it oughtn't, but this properly serves :a: established players who _want_ the shared bonds track and :b: new players who shouldn't be seeing it.

- [x] Hide the widget for empty bonds tracks
- [x] New boneset items should be empty
- [x] Update CHANGELOG.md
