### PR TITLE
"Completed" area for the shared sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## In progress
 
+- Update the in-Foundry setup-screen name of the system
+- Add a "completed items" area to the shared sheet ([#353](https://github.com/ben/foundry-ironsworn/pull/353))
+
 ## 1.11.3
 
 - Decorate rolltable compendia with category information ([#350](https://github.com/ben/foundry-ironsworn/pull/350))


### PR DESCRIPTION
Bringing this up to parity with the Starforged sheet's progresses area. Fixes #341.

<img width="367" alt="CleanShot 2022-05-08 at 15 00 30" src="https://user-images.githubusercontent.com/39902/167317534-22b1064a-8801-4e77-aa1d-b1a38464fe61.png">

- [x] Add a "shared" area and partition the progresses
- [x] Update CHANGELOG.md
