### PR TITLE
Asset re-ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Re-ordering for assets ([#368](https://github.com/ben/foundry-ironsworn/pull/368))
+
 ## 1.15.2
 
 - Fix some placeholder text

--- a/src/module/vue/components/asset/asset.vue
+++ b/src/module/vue/components/asset/asset.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="item-row ironsworn__asset nogrow">
-    <div class="asset-entry" @click="toggle">
+  <div class="item-row flexcol ironsworn__asset">
+    <div class="asset-entry nogrow" @click="toggle">
       <div class="flexrow">
         <h4 style="margin: 0; line-height: 20px">{{ asset.name }}</h4>
         <icon-button v-if="editMode" icon="trash" @click="destroy" />

--- a/src/module/vue/components/sf-character-sheet-tabs/sf-assets.vue
+++ b/src/module/vue/components/sf-character-sheet-tabs/sf-assets.vue
@@ -1,12 +1,21 @@
 <template>
   <div class="flexcol ironsworn__drop__target" data-drop-type="asset">
     <transition-group name="slide" tag="div" class="nogrow">
-      <asset
-        v-for="asset in assets"
-        :key="asset._id"
-        :actor="actor"
-        :asset="asset"
-      />
+      <div class="flexrow" v-for="(asset, i) in assets" :key="asset._id">
+        <div class="flexcol nogrow sortcontrols" v-if="editMode">
+          <i
+            class="clickable block fas fa-caret-up nogrow"
+            :class="{ disabled: i == 0 }"
+            @click="sortUp(i)"
+          ></i>
+          <i
+            class="clickable block fas fa-caret-down nogrow"
+            :class="{ disabled: i == assets.length - 1 }"
+            @click="sortdown(i)"
+          ></i>
+        </div>
+        <asset :actor="actor" :asset="asset" />
+      </div>
     </transition-group>
     <div class="flexrow nogrow" style="text-align: center">
       <div class="clickable block" @click="openCompendium">
@@ -17,13 +26,29 @@
   </div>
 </template>
 
+<style lang="less" scoped>
+.sortcontrols {
+  padding-right: 3px;
+
+  i {
+    padding: 2px;
+  }
+}
+</style>
+
 <script>
+import { sortBy } from 'lodash'
+
 export default {
   props: {
     actor: Object,
   },
 
   computed: {
+    editMode() {
+      return this.actor.flags['foundry-ironsworn']?.['edit-mode']
+    },
+
     assets() {
       return this.actor.items.filter((x) => x.type === 'asset')
     },

--- a/src/module/vue/components/sf-character-sheet-tabs/sf-assets.vue
+++ b/src/module/vue/components/sf-character-sheet-tabs/sf-assets.vue
@@ -11,7 +11,7 @@
           <i
             class="clickable block fas fa-caret-down nogrow"
             :class="{ disabled: i == assets.length - 1 }"
-            @click="sortdown(i)"
+            @click="sortDown(i)"
           ></i>
         </div>
         <asset :actor="actor" :asset="asset" />
@@ -50,7 +50,8 @@ export default {
     },
 
     assets() {
-      return this.actor.items.filter((x) => x.type === 'asset')
+      const assets = this.actor.items.filter((x) => x.type === 'asset')
+      return sortBy(assets, (x) => x.sort)
     },
   },
 
@@ -58,6 +59,28 @@ export default {
     openCompendium() {
       const pack = game.packs?.get('foundry-ironsworn.starforgedassets')
       pack?.render(true)
+    },
+
+    async applySort(oldI, newI, before) {
+      const foundryItems = this.$actor.items
+        .filter((x) => x.type === 'asset')
+        .sort((a, b) => (a.data.sort || 0) - (b.data.sort || 0))
+
+      const updates = SortingHelpers.performIntegerSort(foundryItems[oldI], {
+        target: foundryItems[newI],
+        siblings: foundryItems,
+        sortBefore: before,
+      })
+      await Promise.all(
+        updates.map(({ target, update }) => target.update(update))
+      )
+    },
+
+    sortUp(i) {
+      this.applySort(i, i - 1, true)
+    },
+    sortDown(i) {
+      this.applySort(i, i + 1, false)
     },
   },
 }

--- a/src/module/vue/components/sf-character-sheet-tabs/sf-assets.vue
+++ b/src/module/vue/components/sf-character-sheet-tabs/sf-assets.vue
@@ -61,7 +61,7 @@ export default {
       pack?.render(true)
     },
 
-    async applySort(oldI, newI, before) {
+    async applySort(oldI, newI, sortBefore) {
       const foundryItems = this.$actor.items
         .filter((x) => x.type === 'asset')
         .sort((a, b) => (a.data.sort || 0) - (b.data.sort || 0))
@@ -69,7 +69,7 @@ export default {
       const updates = SortingHelpers.performIntegerSort(foundryItems[oldI], {
         target: foundryItems[newI],
         siblings: foundryItems,
-        sortBefore: before,
+        sortBefore,
       })
       await Promise.all(
         updates.map(({ target, update }) => target.update(update))


### PR DESCRIPTION
This adds arrow buttons so that assets can be re-ordered by the player.

- [x] Add buttons in edit mode
- [x] Use `SortingHelpers.performIntegerSort` to compute and apply updates
- [x] Update CHANGELOG.md
