### PR TITLE
Reorder progresses

### DIFF
--- a/src/module/vue/components/order-buttons.vue
+++ b/src/module/vue/components/order-buttons.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="flexcol nogrow">
+    <i
+      class="clickable block fas fa-caret-up nogrow"
+      :class="{ disabled: i == 0 }"
+      @click="$emit('sortUp', i)"
+    ></i>
+    <i
+      class="clickable block fas fa-caret-down nogrow"
+      :class="{ disabled: i == length - 1 }"
+      @click="$emit('sortDown', i)"
+    ></i>
+  </div>
+</template>
+
+<style lang="less" scoped>
+div {
+  padding-right: 3px;
+
+  i {
+    padding: 2px;
+  }
+}
+</style>
+
+<script>
+export default {
+  props: {
+    i: Number,
+    length: Number,
+  },
+}
+</script>

--- a/src/module/vue/components/progress/progress-box.vue
+++ b/src/module/vue/components/progress/progress-box.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flexrow item-row nogrow">
+  <div class="flexrow item-row">
     <h5 class="vertical-v2 nogrow">{{ subtitle }}</h5>
     <div class="flexcol">
       <div class="flexrow">

--- a/src/module/vue/components/sf-character-sheet-tabs/sf-assets.vue
+++ b/src/module/vue/components/sf-character-sheet-tabs/sf-assets.vue
@@ -2,18 +2,13 @@
   <div class="flexcol ironsworn__drop__target" data-drop-type="asset">
     <transition-group name="slide" tag="div" class="nogrow">
       <div class="flexrow" v-for="(asset, i) in assets" :key="asset._id">
-        <div class="flexcol nogrow sortcontrols" v-if="editMode">
-          <i
-            class="clickable block fas fa-caret-up nogrow"
-            :class="{ disabled: i == 0 }"
-            @click="sortUp(i)"
-          ></i>
-          <i
-            class="clickable block fas fa-caret-down nogrow"
-            :class="{ disabled: i == assets.length - 1 }"
-            @click="sortDown(i)"
-          ></i>
-        </div>
+        <order-buttons
+          v-if="editMode"
+          :i="i"
+          :length="assets.length"
+          @sortUp="sortUp"
+          @sortDown="sortDown"
+        />
         <asset :actor="actor" :asset="asset" />
       </div>
     </transition-group>
@@ -25,16 +20,6 @@
     </div>
   </div>
 </template>
-
-<style lang="less" scoped>
-.sortcontrols {
-  padding-right: 3px;
-
-  i {
-    padding: 2px;
-  }
-}
-</style>
 
 <script>
 import { sortBy } from 'lodash'

--- a/src/module/vue/components/sf-character-sheet-tabs/sf-progresses.vue
+++ b/src/module/vue/components/sf-character-sheet-tabs/sf-progresses.vue
@@ -2,14 +2,21 @@
   <div class="flexcol">
     <div class="flexcol ironsworn__drop__target" data-drop-type="progress">
       <transition-group name="slide" tag="div" class="nogrow">
-        <progress-box
-          v-for="item in activeItems"
-          :key="item._id"
-          :item="item"
-          :actor="actor"
-          :showStar="true"
-          @completed="progressCompleted"
-        />
+        <div class="flexrow nogrow" v-for="item in activeItems" :key="item._id">
+          <order-buttons
+            v-if="editMode"
+            :i="i"
+            :length="activeItems.length"
+            @sortUp="sortUp"
+            @sortDown="sortDown"
+          />
+          <progress-box
+            :item="item"
+            :actor="actor"
+            :showStar="true"
+            @completed="progressCompleted"
+          />
+        </div>
       </transition-group>
       <progress-controls :actor="actor" foeCompendium="starforgedencounters" />
     </div>
@@ -30,13 +37,16 @@
       >
         <div v-if="expandCompleted">
           <transition-group name="slide" tag="div" class="nogrow">
-            <progress-box
-              v-for="item in completedItems"
-              :key="item._id"
-              :item="item"
-              :actor="actor"
-              :showStar="true"
-            />
+            <div class="flexrow" v-for="(item, i) in completedItems" :key="item._id">
+              <order-buttons
+                v-if="editMode"
+                :i="i"
+                :length="completedItems.length"
+                @sortUp="completedSortUp"
+                @sortDown="completedSortDown"
+              />
+              <progress-box :item="item" :actor="actor" :showStar="true" />
+            </div>
           </transition-group>
         </div>
       </transition>
@@ -92,6 +102,10 @@ export default {
     },
     completedItems() {
       return this.progressItems.filter((x) => x.data.completed)
+    },
+
+    editMode() {
+      return this.actor.flags['foundry-ironsworn']?.['edit-mode']
     },
 
     completedCaretClass() {


### PR DESCRIPTION
Following on from #368, this adds the same functionality to the "progresses" tab.

- [ ] Refactor the buttons into a component
- [ ] Add buttons to progresses tab, both active and completed items
- [ ] Update CHANGELOG.md
