### PR TITLE
Rework move display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 
 - Bump Dataforged and import new Sundered Isles assets ([#378](https://github.com/ben/foundry-ironsworn/pull/378))
+- Rework click areas for SF moves ([#379](https://github.com/ben/foundry-ironsworn/pull/379))
 
 ## 1.15.11
 

--- a/src/module/helpers/rolldialog-sf.ts
+++ b/src/module/helpers/rolldialog-sf.ts
@@ -13,8 +13,7 @@ function rollableOptions(trigger: IMoveTrigger) {
   if (!actionOptions.length) return []
 
   const allowedUsings = ['Edge', 'Iron', 'Heart', 'Shadow', 'Wits', 'Health', 'Spirit', 'Supply']
-  return actionOptions
-    .filter(x => (x.Using as string[]).every(u => allowedUsings.includes(u)))
+  return actionOptions.filter((x) => (x.Using as string[]).every((u) => allowedUsings.includes(u)))
 }
 
 export class SFRollMoveDialog extends Dialog {
@@ -67,6 +66,12 @@ export class SFRollMoveDialog extends Dialog {
     }).render(true)
   }
 
+  static moveHasRollableOptions(move: IronswornItem) {
+    const data = move.data as SFMoveDataProperties
+    const options = rollableOptions(data.data.Trigger)
+    return options.length > 0
+  }
+
   static async createDataforgedMoveChat(move: IronswornItem) {
     const params = {
       move,
@@ -78,7 +83,7 @@ export class SFRollMoveDialog extends Dialog {
       content,
     })
   }
-  }
+}
 
 function callback(opts: { actor: IronswornActor; move: IronswornItem; mode: string; stats: string[] }) {
   return async (x) => {

--- a/src/module/helpers/rolldialog-sf.ts
+++ b/src/module/helpers/rolldialog-sf.ts
@@ -35,7 +35,7 @@ export class SFRollMoveDialog extends Dialog {
     const data = move.data as SFMoveDataProperties
     const options = rollableOptions(data.data.Trigger)
     if (!options.length) {
-      return createDataforgedMoveChat(move)
+      return this.createDataforgedMoveChat(move)
     }
 
     const template = 'systems/foundry-ironsworn/templates/sf-move-roll-dialog.hbs'
@@ -66,7 +66,20 @@ export class SFRollMoveDialog extends Dialog {
       default: '0',
     }).render(true)
   }
-}
+
+  static async createDataforgedMoveChat(move: IronswornItem) {
+    const params = {
+      move,
+      nextOracles: await sfNextOracles(move),
+    }
+    const content = await renderTemplate('systems/foundry-ironsworn/templates/chat/sf-move.hbs', params)
+    ChatMessage.create({
+      speaker: ChatMessage.getSpeaker(),
+      content,
+    })
+  }
+  }
+
 function callback(opts: { actor: IronswornActor; move: IronswornItem; mode: string; stats: string[] }) {
   return async (x) => {
     // TODO: extract data from form and send to rollAndCreateChatMessage
@@ -120,17 +133,5 @@ async function rollAndCreateChatMessage(opts: {
     stats: normalizedStats,
     usedStat,
     bonus,
-  })
-}
-
-async function createDataforgedMoveChat(move: IronswornItem) {
-  const params = {
-    move,
-    nextOracles: await sfNextOracles(move),
-  }
-  const content = await renderTemplate('systems/foundry-ironsworn/templates/chat/sf-move.hbs', params)
-  ChatMessage.create({
-    speaker: ChatMessage.getSpeaker(),
-    content,
   })
 }

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -21,11 +21,11 @@
         <div class="flexrow">
           <button v-if="canRoll" @click="rollMove">
             <i class="isicon-d10-tilt"></i>
-            Roll
+            {{$t('IRONSWORN.Roll')}}
           </button>
           <button @click="sendToChat">
-            <i class="fas fa-comment"></i>
-            Chat
+            <i class="far fa-comment"></i>
+            {{$t('IRONSWORN.Chat')}}
           </button>
         </div>
         <div v-html="$enrichMarkdown(fulltext)" />

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -6,7 +6,9 @@
         style="padding-right: 0.5em"
         @click="rollMove"
       ></i>
-      <span class="clickable text" @click="expanded = !expanded"> {{ move.displayName }} </span>
+      <span class="clickable text" @click="expanded = !expanded">
+        {{ move.displayName }}
+      </span>
     </h4>
     <transition name="slide">
       <with-rolllisteners
@@ -17,11 +19,11 @@
         @moveclick="moveclick"
       >
         <div class="flexrow">
-          <button>
+          <button v-if="canRoll" @click="rollMove">
             <i class="isicon-d10-tilt"></i>
             Roll
           </button>
-          <button>
+          <button @click="sendToChat">
             <i class="fas fa-comment"></i>
             Chat
           </button>
@@ -74,6 +76,10 @@ export default {
     fulltext() {
       return this.move.moveItem?.data?.data?.Text
     },
+
+    canRoll() {
+      return true // TODO: move has useable triggers?
+    },
   },
 
   watch: {
@@ -87,8 +93,14 @@ export default {
   },
 
   methods: {
-    async rollMove() {
+    rollMove(e) {
+      e.preventDefault()
       CONFIG.IRONSWORN.SFRollMoveDialog.show(this.$actor, this.move.moveItem)
+    },
+
+    sendToChat(e) {
+      e.preventDefault()
+      CONFIG.IRONSWORN.SFRollMoveDialog.createDataforgedMoveChat(this.move.moveItem)
     },
 
     moveclick(item) {

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -79,7 +79,7 @@ export default {
     },
 
     canRoll() {
-      return true // TODO: move has useable triggers?
+      return CONFIG.IRONSWORN.SFRollMoveDialog.moveHasRollableOptions(this.move.moveItem)
     },
   },
 

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="movesheet-row" :class="{ highlighted: move.highlighted }">
-    <h4 style="margin: 0" class="clickable text flexrow" :title="tooltip">
-      <span @click="rollMove">
-        <i class="isicon-d10-tilt juicy"></i>
-        {{ move.displayName }}
-      </span>
-      <icon-button icon="eye" @click="expanded = !expanded" />
+    <h4 class="flexrow" :title="tooltip">
+      <i
+        class="isicon-d10-tilt juicy clickable text nogrow"
+        style="padding-right: 0.5em"
+        @click="rollMove"
+      ></i>
+      <span class="clickable text" @click="expanded = !expanded"> {{ move.displayName }} </span>
     </h4>
     <transition name="slide">
       <with-rolllisteners
@@ -29,6 +30,7 @@
 }
 h4 {
   margin: 0;
+  line-height: 1.4em;
 }
 .item-row {
   transition: all 0.4s ease;

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -16,6 +16,16 @@
         v-if="expanded"
         @moveclick="moveclick"
       >
+        <div class="flexrow">
+          <button>
+            <i class="isicon-d10-tilt"></i>
+            Roll
+          </button>
+          <button>
+            <i class="fas fa-comment"></i>
+            Chat
+          </button>
+        </div>
         <div v-html="$enrichMarkdown(fulltext)" />
       </with-rolllisteners>
     </transition>

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -69,8 +69,9 @@ export default {
 
   computed: {
     tooltip() {
-      // TODO: page number, when it shows up
-      return this.move.dataforgedMove?.Source?.Title
+      const {Title, Page} = this.move.dataforgedMove?.Source ?? {}
+      if (!Title) return undefined
+      return `${Title} p${Page}`
     },
 
     fulltext() {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -8,6 +8,7 @@
     "SaveYourTruths": "Save Your Truths",
     "CustomTruth": "Custom Truth",
     "Roll": "Roll",
+    "Chat": "Chat",
     "Rolling": "Rolling",
     "Bonus": "Bonus",
     "Versus": "vs.",


### PR DESCRIPTION
In #372, @rsek suggested a change in the layout of the move row. Here's an implementation of that idea that I think satisfies the requirements:

![CleanShot 2022-05-30 at 08 40 09](https://user-images.githubusercontent.com/39902/171025410-ad489d4f-63ef-47ef-997f-9e2ad16f6eec.jpg)


- [x] Remove the :eye: icon from the header
- [x] Clicking on the header text expands the move
- [x] Add buttons to the description area with explicit actions
    - [x] "Roll" only shows for moves where the roll dialog can be shown
    - [x] "Chat" always sends the move's full description to the chat bar
- [x] Update CHANGELOG.md
