### PR TITLE
Journal all the things

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { registerChatAlertHooks } from './module/features/chat-alert'
 import { registerCompendiumCategoryHook } from './module/features/compendium-categories'
 import { maybePromptForDependencies } from './module/features/dependencies'
 import { registerDragAndDropHooks } from './module/features/drag-and-drop'
+import { registerJournalHooks } from './module/features/journal-progress'
 import { primeCommonPackCaches } from './module/features/pack-cache'
 import { activateSceneButtonListeners } from './module/features/sceneButtons'
 import { registerTokenHUDButtons } from './module/features/tokenRotateButtons'
@@ -184,6 +185,7 @@ Hooks.once('init', async () => {
   registerZIndexHook()
   registerCompendiumCategoryHook()
   registerTokenHUDButtons()
+  registerJournalHooks()
 })
 
 Hooks.once('ready', async () => {

--- a/src/module/applications/vueapp.ts
+++ b/src/module/applications/vueapp.ts
@@ -30,6 +30,9 @@ export class VueApplication extends Application {
       const states = Application.RENDER_STATES
       if (this._state == states.RENDERING || this._state == states.RENDERED) {
         // Update the Vue app with our updated item/flag data.
+        for (const k of Object.keys(appData)) {
+          Vue.set(this._vm, k, appData[k])
+        }
         this.activateVueListeners($(this.element), true)
         return this
       }

--- a/src/module/features/journal-progress.ts
+++ b/src/module/features/journal-progress.ts
@@ -1,0 +1,15 @@
+export function registerJournalHooks() {
+  Hooks.on('getJournalSheetHeaderButtons', (sheet, buttons) => {
+    console.log(sheet, buttons)
+    buttons.unshift({
+      class: 'ironsworn-sidebar',
+      label: 'Progress',
+      icon: 'fas fa-spinner',
+      onclick: (e) => console.log(e),
+    })
+  })
+
+  Hooks.on('renderJournalSheet', (sheet, el, data) => {
+    console.log(sheet, el, data)
+  })
+}

--- a/src/module/features/journal-progress.ts
+++ b/src/module/features/journal-progress.ts
@@ -1,15 +1,37 @@
+import { JournalEntrySidebar } from '../journalentry/sidebar'
+
 export function registerJournalHooks() {
   Hooks.on('getJournalSheetHeaderButtons', (sheet, buttons) => {
-    console.log(sheet, buttons)
     buttons.unshift({
       class: 'ironsworn-sidebar',
       label: 'Progress',
       icon: 'fas fa-spinner',
-      onclick: (e) => console.log(e),
+      onclick: (_e) => {
+        const anySheet = sheet as any
+        anySheet.sidebar ||= new JournalEntrySidebar(sheet.object, {
+          left: (sheet.options.left ?? 0) + (sheet.options.width ?? 0),
+        })
+        anySheet.sidebar.render(true, { focus: true })
+      },
     })
   })
 
-  Hooks.on('renderJournalSheet', (sheet, el, data) => {
-    console.log(sheet, el, data)
+  Hooks.on('renderJournalSheet', (sheet: JournalSheet, el: JQuery, _data) => {
+    // If this is a progress JE, just open the sheet
+    const anySheet = sheet as any
+    if (
+      anySheet._state <= Application.RENDER_STATES.RENDERING &&
+      sheet.document.getFlag('foundry-ironsworn', 'isProgress')
+    ) {
+      anySheet.sidebar ||= new JournalEntrySidebar(sheet.object, {
+        left: el.position().left + (el.width() ?? 100) + 5,
+        top: el.position().top,
+      })
+      anySheet.sidebar.render(true)
+    }
+  })
+
+  Hooks.on('closeJournalSheet', (sheet) => {
+    sheet.sidebar?.close()
   })
 }

--- a/src/module/features/journal-progress.ts
+++ b/src/module/features/journal-progress.ts
@@ -4,8 +4,8 @@ export function registerJournalHooks() {
   Hooks.on('getJournalSheetHeaderButtons', (sheet, buttons) => {
     buttons.unshift({
       class: 'ironsworn-sidebar',
-      label: 'Progress',
-      icon: 'fas fa-spinner',
+      label: 'Tools',
+      icon: 'fas fa-toolbox',
       onclick: (_e) => {
         const anySheet = sheet as any
         anySheet.sidebar ||= new JournalEntrySidebar(sheet.object, {

--- a/src/module/journalentry/sidebar.ts
+++ b/src/module/journalentry/sidebar.ts
@@ -1,0 +1,54 @@
+import { IronswornSettings } from '../helpers/settings'
+
+export class JournalEntrySidebar extends FormApplication<
+  FormApplicationOptions,
+  any,
+  JournalEntry
+> {
+  constructor(object, options?: any) {
+    super(object, options)
+  }
+
+  async _updateObject() {
+    console.log(this)
+    // No update necessary.
+  }
+
+  static get defaultOptions(): FormApplicationOptions {
+    return mergeObject(FormApplication.defaultOptions, {
+      template: 'systems/foundry-ironsworn/templates/journalentry/sidebar.hbs',
+      resizable: true,
+      classes: [
+        'ironsworn',
+        'sheet',
+        'journalentry',
+        `theme-${IronswornSettings.theme}`,
+      ],
+      width: 200,
+      height: 400,
+      left: 755,
+    })
+  }
+
+  getData(options?: Partial<FormApplicationOptions> | undefined) {
+    const data = super.getData(options)
+    console.log(data)
+
+    data.isProgress = this.object.getFlag('foundry-ironsworn', 'isProgress')
+
+    return data
+  }
+
+  activateListeners(html: JQuery<HTMLElement>): void {
+    super.activateListeners(html)
+
+    html.find('.ironsworn__is_progress').on('click', async (e) => {
+      console.log(e)
+      await this.object.setFlag(
+        'foundry-ironsworn',
+        'isProgress',
+        $(e.currentTarget).prop('checked')
+      )
+    })
+  }
+}

--- a/src/module/journalentry/sidebar.ts
+++ b/src/module/journalentry/sidebar.ts
@@ -32,7 +32,6 @@ export class JournalEntrySidebar extends VueApplication {
 
   getData(options?: Partial<FormApplicationOptions> | undefined) {
     const data = super.getData(options) as any
-    console.log(data)
 
     data.je = this.journalEntry.toObject(false)
 

--- a/src/module/journalentry/sidebar.ts
+++ b/src/module/journalentry/sidebar.ts
@@ -44,11 +44,30 @@ export class JournalEntrySidebar extends FormApplication<
 
     html.find('.ironsworn__is_progress').on('click', async (e) => {
       console.log(e)
-      await this.object.setFlag(
-        'foundry-ironsworn',
-        'isProgress',
-        $(e.currentTarget).prop('checked')
-      )
+      await this.setFlag('isProgress', $(e.currentTarget).prop('checked'))
+
+      if (this.getFlag('progressType') === undefined) {
+        await this._initFlags()
+      }
     })
+  }
+
+  private async _initFlags() {
+    await this.setFlag('progressType', 'progress')
+    await this.setFlag('complete', false)
+    await this.setFlag('hasTrack', true)
+    await this.setFlag('trackRank', 1)
+    await this.setFlag('trackTicks', 0)
+    await this.setFlag('hasClock', true)
+    await this.setFlag('clockTicks', 0)
+    await this.setFlag('clockMax', 6)
+  }
+
+  private setFlag(name: string, value: any) {
+    return this.object.setFlag('foundry-ironsworn', name, value)
+  }
+
+  private getFlag(name: string) {
+    return this.object.getFlag('foundry-ironsworn', name)
   }
 }

--- a/src/module/journalentry/sidebar.ts
+++ b/src/module/journalentry/sidebar.ts
@@ -1,12 +1,12 @@
+import { VueApplication } from '../applications/vueapp'
 import { IronswornSettings } from '../helpers/settings'
 
-export class JournalEntrySidebar extends FormApplication<
-  FormApplicationOptions,
-  any,
-  JournalEntry
-> {
-  constructor(object, options?: any) {
-    super(object, options)
+export class JournalEntrySidebar extends VueApplication {
+  constructor(
+    protected journalEntry: JournalEntry,
+    options?: Partial<ApplicationOptions>
+  ) {
+    super(options)
   }
 
   async _updateObject() {
@@ -24,50 +24,18 @@ export class JournalEntrySidebar extends FormApplication<
         'journalentry',
         `theme-${IronswornSettings.theme}`,
       ],
-      width: 200,
-      height: 400,
+      width: 250,
+      height: 450,
       left: 755,
     })
   }
 
   getData(options?: Partial<FormApplicationOptions> | undefined) {
-    const data = super.getData(options)
+    const data = super.getData(options) as any
     console.log(data)
 
-    data.isProgress = this.object.getFlag('foundry-ironsworn', 'isProgress')
+    data.je = this.journalEntry.toObject(false)
 
     return data
-  }
-
-  activateListeners(html: JQuery<HTMLElement>): void {
-    super.activateListeners(html)
-
-    html.find('.ironsworn__is_progress').on('click', async (e) => {
-      console.log(e)
-      await this.setFlag('isProgress', $(e.currentTarget).prop('checked'))
-
-      if (this.getFlag('progressType') === undefined) {
-        await this._initFlags()
-      }
-    })
-  }
-
-  private async _initFlags() {
-    await this.setFlag('progressType', 'progress')
-    await this.setFlag('complete', false)
-    await this.setFlag('hasTrack', true)
-    await this.setFlag('trackRank', 1)
-    await this.setFlag('trackTicks', 0)
-    await this.setFlag('hasClock', true)
-    await this.setFlag('clockTicks', 0)
-    await this.setFlag('clockMax', 6)
-  }
-
-  private setFlag(name: string, value: any) {
-    return this.object.setFlag('foundry-ironsworn', name, value)
-  }
-
-  private getFlag(name: string) {
-    return this.object.getFlag('foundry-ironsworn', name)
   }
 }

--- a/src/module/vue/journalentry-sidebar.vue
+++ b/src/module/vue/journalentry-sidebar.vue
@@ -3,24 +3,20 @@
     <h3>Progress Options</h3>
 
     <label class="checkbox">
-      <input
-        type="checkbox"
-        v-model="flags.isProgress"
-        @change="setIsProgress"
-      />
+      <input type="checkbox" v-model="flags.isProgress" @change="saveFlags" />
       Track Progress
     </label>
 
     <transition name="slide">
       <section v-if="flags.isProgress">
         <div class="flexrow">
-          <button>Actor</button>
+          <button type="button">Actor</button>
         </div>
 
         <select
           class="nogrow"
           v-model="flags.progressType"
-          @change="subtypeChange"
+          @change="saveFlags"
           style="margin: 0.5rem 0"
         >
           <option value="vow">{{ $t('IRONSWORN.Vow') }}</option>
@@ -32,7 +28,7 @@
           <input
             type="checkbox"
             v-model="flags.completed"
-            @change="updateComplete"
+            @change="saveFlags"
           />
           {{ $t('IRONSWORN.Completed') }}
         </label>
@@ -40,11 +36,7 @@
         <!-- Track -->
         <hr />
         <label class="checkbox">
-          <input
-            type="checkbox"
-            v-model="flags.hasTrack"
-            @change="updateHasTrack"
-          />
+          <input type="checkbox" v-model="flags.hasTrack" @change="saveFlags" />
           {{ $t('IRONSWORN.Track') }}
         </label>
 
@@ -76,11 +68,7 @@
         <hr />
 
         <label class="checkbox">
-          <input
-            type="checkbox"
-            v-model="flags.hasClock"
-            @change="saveChecks"
-          />
+          <input type="checkbox" v-model="flags.hasClock" @change="saveFlags" />
           {{ $t('IRONSWORN.Clock') }}
         </label>
 
@@ -98,7 +86,7 @@
               <select
                 class="nogrow"
                 v-model="flags.clockMax"
-                @change="clockMaxChange"
+                @change="saveFlags"
                 style="margin: 0.5rem 0"
               >
                 <option value="4">4</option>
@@ -124,6 +112,27 @@ export default {
   computed: {
     flags() {
       return this.je.flags['foundry-ironsworn']
+    },
+
+    $journalEntry() {
+      return game.journal.get(this.je._id)
+    },
+  },
+
+  methods: {
+    async setFlag(name, value) {
+      console.log(name, value)
+      return this.$journalEntry?.setFlag('foundry-ironsworn', name, value)
+    },
+
+    async saveFlags() {
+      for (const k of Object.keys(this.flags)) {
+        await this.setFlag(k, this.flags[k])
+      }
+    },
+
+    setClock(ticks) {
+      this.setFlag('clockTicks', ticks)
     },
   },
 }

--- a/src/module/vue/journalentry-sidebar.vue
+++ b/src/module/vue/journalentry-sidebar.vue
@@ -1,0 +1,126 @@
+<template>
+  <div>
+    <h3>Progress Options</h3>
+
+    <label class="checkbox">
+      <input
+        type="checkbox"
+        v-model="flags.isProgress"
+        @change="setIsProgress"
+      />
+      Track Progress
+    </label>
+
+    <transition name="slide">
+      <section v-if="flags.isProgress">
+        <select
+          class="nogrow"
+          v-model="flags.progressType"
+          @change="subtypeChange"
+          style="margin: 0.5rem 0"
+        >
+          <option value="vow">{{ $t('IRONSWORN.Vow') }}</option>
+          <option value="progress">{{ $t('IRONSWORN.Progress') }}</option>
+          <option value="bond">{{ $t('IRONSWORN.Connection') }}</option>
+        </select>
+
+        <label class="checkbox nogrow">
+          <input
+            type="checkbox"
+            v-model="flags.completed"
+            @change="updateComplete"
+          />
+          {{ $t('IRONSWORN.Completed') }}
+        </label>
+
+        <!-- Track -->
+        <hr />
+        <label class="checkbox">
+          <input
+            type="checkbox"
+            v-model="flags.hasTrack"
+            @change="updateHasTrack"
+          />
+          {{ $t('IRONSWORN.Track') }}
+        </label>
+
+        <transition name="slide">
+          <div class="nogrow" v-if="flags.hasTrack">
+            <!-- RANK -->
+            <div class="flexrow nogrow">
+              <rank-hexes
+                :current="flags.trackRank"
+                @click="setRank"
+                class="nogrow"
+                style="margin-right: 1em"
+              />
+              <h4>{{ rankText }}</h4>
+              <icon-button
+                v-if="editMode"
+                icon="trash"
+                @click="clearProgress"
+              />
+              <icon-button icon="play" @click="markProgress" />
+            </div>
+            <!-- PROGRESS -->
+            <div class="flexrow track nogrow" style="margin-bottom: 1em">
+              <progress-track :ticks="flags.trackTicks" />
+            </div>
+          </div>
+        </transition>
+
+        <hr />
+
+        <label class="checkbox">
+          <input
+            type="checkbox"
+            v-model="flags.hasClock"
+            @change="saveChecks"
+          />
+          {{ $t('IRONSWORN.Clock') }}
+        </label>
+
+        <transition name="slide">
+          <div class="flexrow nogrow" v-if="flags.hasClock">
+            <div class="nogrow" style="margin: 0 1rem">
+              <clock
+                :wedges="flags.clockMax"
+                :ticked="flags.clockTicks"
+                @click="setClock"
+              />
+            </div>
+            <div class="flexcol">
+              Segments:
+              <select
+                class="nogrow"
+                v-model="flags.clockMax"
+                @change="clockMaxChange"
+                style="margin: 0.5rem 0"
+              >
+                <option value="4">4</option>
+                <option value="6">6</option>
+                <option value="8">8</option>
+                <option value="10">10</option>
+                <option value="12">12</option>
+              </select>
+            </div>
+          </div>
+        </transition>
+      </section>
+    </transition>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    je: Object,
+  },
+
+  computed: {
+    flags() {
+      return this.je.flags['foundry-ironsworn']
+    },
+  },
+}
+</script>

--- a/src/module/vue/journalentry-sidebar.vue
+++ b/src/module/vue/journalentry-sidebar.vue
@@ -95,13 +95,13 @@
           </div>
         </transition>
 
-        <div v-if="connectedActor">
+        <div v-if="actorId">
           <a
             class="entity-link content-link"
             draggable="true"
             data-type="Actor"
             data-entity="Actor"
-            :data-id="connectedActor"
+            :data-id="actorId"
             ><i class="fas fa-user"></i> Actor (drag to map)</a
           >
         </div>
@@ -109,13 +109,13 @@
           <button type="button" @click="createActor">Generate actor</button>
         </div>
 
-        <div v-if="connectedItem">
+        <div v-if="itemId">
           <a
             class="entity-link content-link"
             draggable="true"
             data-type="Item"
             data-entity="Item"
-            :data-id="connectedItem"
+            :data-id="itemId"
             ><i class="fas fa-user"></i> Item (drag to sheet)</a
           >
         </div>
@@ -142,10 +142,16 @@ export default {
       return game.journal.get(this.je._id)
     },
 
-    connectedActor() {
+    actorId() {
       const { actorId } = this.flags
       const actor = game.actors.get(actorId)
       return actor ? actorId : undefined
+    },
+
+    itemId() {
+      const { itemId } = this.flags
+      const item = game.items.get(itemId)
+      return item ? itemId : undefined
     },
   },
 
@@ -174,7 +180,14 @@ export default {
       this.setFlag('actorId', actor.id)
     },
 
-    createItem() {},
+    async createItem() {
+      const item = await Item.create({
+        name: this.$journalEntry.name,
+        type: 'jeprogress',
+      })
+
+      this.setFlag('itemId', item.id)
+    },
   },
 }
 </script>

--- a/src/module/vue/journalentry-sidebar.vue
+++ b/src/module/vue/journalentry-sidebar.vue
@@ -9,10 +9,6 @@
 
     <transition name="slide">
       <section v-if="flags.isProgress">
-        <div class="flexrow">
-          <button type="button">Actor</button>
-        </div>
-
         <select
           class="nogrow"
           v-model="flags.progressType"
@@ -98,6 +94,34 @@
             </div>
           </div>
         </transition>
+
+        <div v-if="connectedActor">
+          <a
+            class="entity-link content-link"
+            draggable="true"
+            data-type="Actor"
+            data-entity="Actor"
+            :data-id="connectedActor"
+            ><i class="fas fa-user"></i> Actor (drag to map)</a
+          >
+        </div>
+        <div v-else>
+          <button type="button" @click="createActor">Generate actor</button>
+        </div>
+
+        <div v-if="connectedItem">
+          <a
+            class="entity-link content-link"
+            draggable="true"
+            data-type="Item"
+            data-entity="Item"
+            :data-id="connectedItem"
+            ><i class="fas fa-user"></i> Item (drag to sheet)</a
+          >
+        </div>
+        <div v-else>
+          <button type="button" @click="createItem">Generate item</button>
+        </div>
       </section>
     </transition>
   </div>
@@ -117,6 +141,12 @@ export default {
     $journalEntry() {
       return game.journal.get(this.je._id)
     },
+
+    connectedActor() {
+      const { actorId } = this.flags
+      const actor = game.actors.get(actorId)
+      return actor ? actorId : undefined
+    },
   },
 
   methods: {
@@ -134,6 +164,17 @@ export default {
     setClock(ticks) {
       this.setFlag('clockTicks', ticks)
     },
+
+    async createActor() {
+      const actor = await Actor.create({
+        name: this.$journalEntry.name,
+        type: 'jenpc',
+      })
+
+      this.setFlag('actorId', actor.id)
+    },
+
+    createItem() {},
   },
 }
 </script>

--- a/src/module/vue/journalentry-sidebar.vue
+++ b/src/module/vue/journalentry-sidebar.vue
@@ -13,6 +13,10 @@
 
     <transition name="slide">
       <section v-if="flags.isProgress">
+        <div class="flexrow">
+          <button>Actor</button>
+        </div>
+
         <select
           class="nogrow"
           v-model="flags.progressType"

--- a/system/template.json
+++ b/system/template.json
@@ -1,6 +1,14 @@
 {
   "Actor": {
-    "types": ["character", "shared", "foe", "site", "starship", "location"],
+    "types": [
+      "character",
+      "shared",
+      "foe",
+      "site",
+      "starship",
+      "location",
+      "jenpc"
+    ],
     "character": {
       "biography": "",
       "notes": "",
@@ -136,7 +144,8 @@
     "location": {
       "subtype": "planet",
       "klass": ""
-    }
+    },
+    "jenpc": {}
   },
   "Item": {
     "types": [
@@ -147,7 +156,8 @@
       "move",
       "sfmove",
       "delve-theme",
-      "delve-domain"
+      "delve-domain",
+      "jeprogress"
     ],
     "templates": {
       "progress": {
@@ -447,6 +457,7 @@
           "description": ""
         }
       ]
-    }
+    },
+    "jeprogress": {}
   }
 }

--- a/system/templates/journalentry/sidebar.hbs
+++ b/system/templates/journalentry/sidebar.hbs
@@ -1,11 +1,5 @@
 <form class='{{cssClass}} flexcol' autocomplete='off'>
-  <h3 class="nogrow">Progress Options</h3>
-  {{log this}}
-  {{log (checked isProgress)}}
-
-  <label class="checkbox nogrow">
-    <input type="checkbox" class="ironsworn__is_progress" {{checked isProgress}}>
-    Track Progress
-  </label>
-
+  <journalentry-sidebar class="ironsworn-vueport" dependencies="vue vuecomponents" :je="je">
+    Loading…
+  </journalentry-sidebar>
 </form>

--- a/system/templates/journalentry/sidebar.hbs
+++ b/system/templates/journalentry/sidebar.hbs
@@ -1,0 +1,11 @@
+<form class='{{cssClass}} flexcol' autocomplete='off'>
+  <h3 class="nogrow">Progress Options</h3>
+  {{log this}}
+  {{log (checked isProgress)}}
+
+  <label class="checkbox nogrow">
+    <input type="checkbox" class="ironsworn__is_progress" {{checked isProgress}}>
+    Track Progress
+  </label>
+
+</form>


### PR DESCRIPTION
This is a rough proof-of-concept for the idea outlined in https://github.com/ben/foundry-ironsworn/issues/386#issuecomment-1152949360. The idea is that all the data that's currently stored in progress item data is now stored in flags on a journal entry. There's a new Actor type (`jenpc`) and a new Item type (`jeprogress`) that only contain journal-entry IDs for reference.

- [x] Add new types to template.json
- [x] Hack together a journal-entry sidebar and a button to open it
    - [x] Some settings that work properly
    - [x] Buttons to generate actor/item
    - [x] If actor and/or item exist, links to drag them around
    - [ ] Image control which syncs to the linked actor/item
    - [ ] Sync name to actor/item
- [ ] `jenpc` actor
    - [ ] Trying to open its sheet instead opens the journal entry
- [ ] `jeprogress` item
    - [ ] Trying to open its sheet instead opens the journal entry
    - [ ] Support in character sheets for this type of item
- [ ] Update CHANGELOG.md
