### PR TITLE
Clock chat alerts

### DIFF
--- a/src/module/features/chat-alert.ts
+++ b/src/module/features/chat-alert.ts
@@ -27,7 +27,7 @@ export function registerChatAlertHooks() {
 
       let content: string | undefined
       if (data.name) {
-        content = game.i18n.format('IRONSWORN.ChangeLog.Renamed', {
+        content = game.i18n.format('IRONSWORN.ChatAlert.Renamed', {
           name: data.name,
         })
       } else {
@@ -47,7 +47,7 @@ export function registerChatAlertHooks() {
 
       let content: string | undefined
       if (data.name) {
-        content = game.i18n.format('IRONSWORN.ChangeLog.renamed', {
+        content = game.i18n.format('IRONSWORN.ChatAlert.renamed', {
           name: data.name,
         })
       } else {
@@ -70,7 +70,7 @@ export function registerChatAlertHooks() {
 
       sendToChat(
         item.parent,
-        game.i18n.format('IRONSWORN.ChangeLog.Added', { name: item.name })
+        game.i18n.format('IRONSWORN.ChatAlert.Added', { name: item.name })
       )
     }
   )
@@ -84,7 +84,7 @@ export function registerChatAlertHooks() {
 
       sendToChat(
         item.parent,
-        game.i18n.format('IRONSWORN.ChangeLog.Deleted', { name: item.name })
+        game.i18n.format('IRONSWORN.ChatAlert.Deleted', { name: item.name })
       )
     }
   )
@@ -99,11 +99,11 @@ const ACTOR_TYPE_HANDLERS: { [key: string]: ActorTypeHandler } = {
       const oldXp = characterData.data.xp
       const newXp = data.data.xp as number
       if (newXp > oldXp) {
-        return game.i18n.format('IRONSWORN.ChangeLog.MarkedXP', {
+        return game.i18n.format('IRONSWORN.ChatAlert.MarkedXP', {
           amt: newXp - oldXp,
         })
       } else {
-        return game.i18n.format('IRONSWORN.ChangeLog.UnmarkedXP', {
+        return game.i18n.format('IRONSWORN.ChatAlert.UnmarkedXP', {
           amt: oldXp - newXp,
         })
       }
@@ -115,11 +115,11 @@ const ACTOR_TYPE_HANDLERS: { [key: string]: ActorTypeHandler } = {
       const newXp = get(data.data, `legacies.${kind}XpSpent`)
       if (newXp !== undefined) {
         if (newXp > oldXp) {
-          return game.i18n.format('IRONSWORN.ChangeLog.MarkedXP', {
+          return game.i18n.format('IRONSWORN.ChatAlert.MarkedXP', {
             amt: newXp - oldXp,
           })
         } else {
-          return game.i18n.format('IRONSWORN.ChangeLog.UnmarkedXP', {
+          return game.i18n.format('IRONSWORN.ChatAlert.UnmarkedXP', {
             amt: oldXp - newXp,
           })
         }
@@ -132,7 +132,7 @@ const ACTOR_TYPE_HANDLERS: { [key: string]: ActorTypeHandler } = {
         const oldValue = get(characterData.data, stat)
         const signPrefix = newValue > oldValue ? '+' : ''
         const i18nStat = game.i18n.localize(`IRONSWORN.${capitalize(stat)}`)
-        return game.i18n.format('IRONSWORN.ChangeLog.AdjustedStat', {
+        return game.i18n.format('IRONSWORN.ChatAlert.AdjustedStat', {
           amt: `${signPrefix}${newValue - oldValue}`,
           stat: i18nStat,
           val: newValue,
@@ -166,8 +166,8 @@ const ACTOR_TYPE_HANDLERS: { [key: string]: ActorTypeHandler } = {
         const params = { condition: i18nDebility }
         // TODO: use "impact" if this is an SF character
         if (newValue)
-          return game.i18n.format('IRONSWORN.ChangeLog.SetCondition', params)
-        return game.i18n.format('IRONSWORN.ChangeLog.ClearedCondition', params)
+          return game.i18n.format('IRONSWORN.ChatAlert.SetCondition', params)
+        return game.i18n.format('IRONSWORN.ChatAlert.ClearedCondition', params)
       }
     }
 
@@ -182,7 +182,7 @@ const ACTOR_TYPE_HANDLERS: { [key: string]: ActorTypeHandler } = {
       const oldValue = sharedData.data.supply
       const signPrefix = newValue > oldValue ? '+' : ''
       const i18nStat = game.i18n.localize('IRONSWORN.Supply')
-      return game.i18n.format('IRONSWORN.ChangeLog.AdjustedStat', {
+      return game.i18n.format('IRONSWORN.ChatAlert.AdjustedStat', {
         amt: `${signPrefix}${newValue - oldValue}`,
         stat: i18nStat,
         val: newValue,
@@ -206,8 +206,8 @@ const ACTOR_TYPE_HANDLERS: { [key: string]: ActorTypeHandler } = {
         const params = { condition: i18nDebility }
         // TODO: use "impact" if this is an SF character
         if (newValue)
-          return game.i18n.format('IRONSWORN.ChangeLog.SetCondition', params)
-        return game.i18n.format('IRONSWORN.ChangeLog.ClearedCondition', params)
+          return game.i18n.format('IRONSWORN.ChatAlert.SetCondition', params)
+        return game.i18n.format('IRONSWORN.ChatAlert.ClearedCondition', params)
       }
     }
 
@@ -220,7 +220,7 @@ const ACTOR_TYPE_HANDLERS: { [key: string]: ActorTypeHandler } = {
     if (data.data?.rank) {
       const oldRank = game.i18n.localize(RANKS[siteData.data.rank])
       const newRank = game.i18n.localize(RANKS[data.data.rank])
-      return game.i18n.format('IRONSWORN.ChangeLog.RankChanged', {
+      return game.i18n.format('IRONSWORN.ChatAlert.RankChanged', {
         old: oldRank,
         new: newRank,
       })
@@ -228,7 +228,7 @@ const ACTOR_TYPE_HANDLERS: { [key: string]: ActorTypeHandler } = {
     if (data.data?.current !== undefined) {
       const advanced = data.data.current > siteData.data.current
       return game.i18n.localize(
-        `IRONSWORN.ChangeLog.Progress${advanced ? 'Advanced' : 'Reduced'}`
+        `IRONSWORN.ChatAlert.Progress${advanced ? 'Advanced' : 'Reduced'}`
       )
     }
     return undefined
@@ -242,7 +242,7 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
     if (data.data?.rank) {
       const oldRank = game.i18n.localize(RANKS[progressData.data.rank])
       const newRank = game.i18n.localize(RANKS[data.data.rank])
-      return game.i18n.format('IRONSWORN.ChangeLog.rankChanged', {
+      return game.i18n.format('IRONSWORN.ChatAlert.rankChanged', {
         old: oldRank,
         new: newRank,
       })
@@ -250,12 +250,12 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
     if (data.data?.current !== undefined) {
       const advanced = data.data.current > progressData.data.current
       return game.i18n.localize(
-        `IRONSWORN.ChangeLog.progress${advanced ? 'Advanced' : 'Reduced'}`
+        `IRONSWORN.ChatAlert.progress${advanced ? 'Advanced' : 'Reduced'}`
       )
     }
     if (data.data?.completed !== undefined) {
       return game.i18n.localize(
-        `IRONSWORN.ChangeLog.completed${
+        `IRONSWORN.ChatAlert.completed${
           data.data?.completed ? 'Marked' : 'Unmarked'
         }`
       )
@@ -274,10 +274,10 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
           const descriptors = ['First', 'Second', 'Third', 'Fourth', 'Fifth']
           const pos = game.i18n.localize(`IRONSWORN.${descriptors[i]}`)
           if (newEnables[i])
-            return game.i18n.format('IRONSWORN.ChangeLog.MarkedAbility', {
+            return game.i18n.format('IRONSWORN.ChatAlert.MarkedAbility', {
               pos,
             })
-          return game.i18n.format('IRONSWORN.ChangeLog.UnmarkedAbility', {
+          return game.i18n.format('IRONSWORN.ChatAlert.UnmarkedAbility', {
             pos,
           })
         }
@@ -288,7 +288,7 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
       const newValue = data.data.track.current
       const oldValue = assetData.data.track.current
       const signPrefix = newValue > oldValue ? '+' : ''
-      return game.i18n.format('IRONSWORN.ChangeLog.AdjustedStat', {
+      return game.i18n.format('IRONSWORN.ChatAlert.AdjustedStat', {
         amt: `${signPrefix}${newValue - oldValue}`,
         stat: assetData.data.track.name,
         val: newValue,
@@ -297,7 +297,7 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
 
     if (data.data?.exclusiveOptions !== undefined) {
       const selectedOption = data.data.exclusiveOptions.find((x) => x.selected)
-      return game.i18n.format('IRONSWORN.ChangeLog.MarkedOption', {
+      return game.i18n.format('IRONSWORN.ChatAlert.MarkedOption', {
         name: selectedOption.name,
       })
     }
@@ -307,7 +307,7 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
         const newField = data.data.fields[i]
         const oldField = assetData.data.fields[i]
         if (oldField && oldField?.value !== newField.value) {
-          return game.i18n.format('IRONSWORN.ChangeLog.SetField', {
+          return game.i18n.format('IRONSWORN.ChatAlert.SetField', {
             name: newField.name,
             val: newField.value,
           })
@@ -323,9 +323,9 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
       const oldLen = Object.values(bondsetData.data.bonds).length
       const newLen = Object.values(data.data.bonds).length
       if (oldLen < newLen) {
-        return game.i18n.localize('IRONSWORN.ChangeLog.AddBond')
+        return game.i18n.localize('IRONSWORN.ChatAlert.AddBond')
       } else if (newLen < oldLen) {
-        return game.i18n.localize('IRONSWORN.ChangeLog.LostBond')
+        return game.i18n.localize('IRONSWORN.ChatAlert.LostBond')
       }
     }
 

--- a/src/module/features/chat-alert.ts
+++ b/src/module/features/chat-alert.ts
@@ -273,7 +273,9 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
         }
       }
       if (change > 1) {
-        i18nKey += 'Multiple'
+        i18nKey += 'MultipleSegments'
+      } else if (change === 1) {
+        i18nKey += 'OneSegment'
       }
       return game.i18n.format(i18nKey, {
         change,

--- a/src/module/features/chat-alert.ts
+++ b/src/module/features/chat-alert.ts
@@ -273,7 +273,7 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
         }
       }
       if (change > 2) {
-        i18nKey += 'MultipleSegments'
+        i18nKey += 'ManySegments'
       } else if (change === 2) {
         i18nKey += 'TwoSegments'
       } else if (change === 1) {

--- a/src/module/features/chat-alert.ts
+++ b/src/module/features/chat-alert.ts
@@ -272,8 +272,10 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
           break
         }
       }
-      if (change > 1) {
+      if (change > 2) {
         i18nKey += 'MultipleSegments'
+      } else if (change === 2) {
+        i18nKey += 'TwoSegments'
       } else if (change === 1) {
         i18nKey += 'OneSegment'
       }

--- a/src/module/features/chat-alert.ts
+++ b/src/module/features/chat-alert.ts
@@ -256,11 +256,11 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
     if (data.data?.clockTicks !== undefined) {
       const change = data.data.clockTicks - progressData.data.clockTicks
       const advanced = data.data.clockTicks > progressData.data.clockTicks
-      const filled = data.data.clockTicks >= progressData.data.clockMax
+      const completed = data.data.clockTicks >= progressData.data.clockMax
       let i18nKey = 'IRONSWORN.ChatAlert.clock'
       switch (true) {
-        case filled: {
-          i18nKey += 'Filled'
+        case completed: {
+          i18nKey += 'Completed'
           break
         }
         case advanced: {

--- a/src/module/features/chat-alert.ts
+++ b/src/module/features/chat-alert.ts
@@ -253,6 +253,35 @@ const ITEM_TYPE_HANDLERS: { [key: string]: ItemTypeHandler } = {
         `IRONSWORN.ChatAlert.progress${advanced ? 'Advanced' : 'Reduced'}`
       )
     }
+    if (data.data?.clockTicks !== undefined) {
+      const change = data.data.clockTicks - progressData.data.clockTicks
+      const advanced = data.data.clockTicks > progressData.data.clockTicks
+      const filled = data.data.clockTicks >= progressData.data.clockMax
+      let i18nKey = 'IRONSWORN.ChatAlert.clock'
+      switch (true) {
+        case filled: {
+          i18nKey += 'Filled'
+          break
+        }
+        case advanced: {
+          i18nKey += 'Advanced'
+          break
+        }
+        default: {
+          i18nKey += 'Set'
+          break
+        }
+      }
+      if (change > 1) {
+        i18nKey += 'Multiple'
+      }
+      return game.i18n.format(i18nKey, {
+        change,
+        max: progressData.data.clockMax,
+        old: progressData.data.clockTicks,
+        new: data.data.clockTicks,
+      })
+    }
     if (data.data?.completed !== undefined) {
       return game.i18n.localize(
         `IRONSWORN.ChatAlert.completed${

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -188,7 +188,7 @@
     "Expanse": "Expanse",
     "RotateCCW": "Rotate counter-clockwise",
     "RotateCW": "Rotate clockwise",
-    "ChangeLog": {
+    "ChatAlert": {
       "Renamed": "Renamed to {name}",
       "renamed": "renamed to {name}",
       "Added": "Added {name}",

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -213,9 +213,11 @@
       "completedMarked": "marked completed",
       "completedUnmarked": "unmarked completed",
       "clockAdvancedOneSegment": "clock advanced to {new}⁄{max}",
-      "clockAdvancedMultipleSegments": "clock advanced by {change} segments to {new}⁄{max}",
+      "clockAdvancedTwoSegments": "clock advanced by {change} segments to {new}⁄{max}",
+      "clockAdvancedManySegments": "clock advanced by {change} segments to {new}⁄{max}",
       "clockFilledOneSegment": "clock advanced to {new}⁄{max}—clock filled!",
-      "clockFilledMultipleSegments": "clock advanced by {change} segments to {new}⁄{max}—clock filled!",
+      "clockFilledTwoSegments": "clock advanced by {change} segments to {new}⁄{max}—clock filled!",
+      "clockFilledManySegments": "clock advanced by {change} segments to {new}⁄{max}—clock filled!",
       "clockSet": "clock set to {new}⁄{max}"
     },
     "Settings": {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -211,7 +211,13 @@
       "AddBond": "Added a bond",
       "LostBond": "Lost a bond",
       "completedMarked": "marked completed",
-      "completedUnmarked": "unmarked completed"
+      "completedUnmarked": "unmarked completed",
+      "clockAdvanced": "clock advanced from {old} to {new} of {max}",
+      "clockSet": "clock set to {new} of {max}",
+      "clockFilled": "clock filled ({max} segments)",
+      "ClockAdvanced": "Clock advanced from {old} to {new} of {max}",
+      "ClockSet": "Clock set to {new} of {max}",
+      "ClockFilled": "Clock filled ({max} segments)"
     },
     "Settings": {
       "Theme": {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -215,9 +215,9 @@
       "clockAdvancedOneSegment": "clock advanced to {new}⁄{max}",
       "clockAdvancedTwoSegments": "clock advanced by {change} segments to {new}⁄{max}",
       "clockAdvancedManySegments": "clock advanced by {change} segments to {new}⁄{max}",
-      "clockFilledOneSegment": "clock advanced to {new}⁄{max}—clock filled!",
-      "clockFilledTwoSegments": "clock advanced by {change} segments to {new}⁄{max}—clock filled!",
-      "clockFilledManySegments": "clock advanced by {change} segments to {new}⁄{max}—clock filled!",
+      "clockCompletedOneSegment": "clock advanced to {new}⁄{max}—clock completed!",
+      "clockCompletedTwoSegments": "clock advanced by {change} segments to {new}⁄{max}—clock completed!",
+      "clockCompletedManySegments": "clock advanced by {change} segments to {new}⁄{max}—clock completed!",
       "clockSet": "clock set to {new}⁄{max}"
     },
     "Settings": {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -213,8 +213,8 @@
       "completedMarked": "marked completed",
       "completedUnmarked": "unmarked completed",
       "clockAdvancedOneSegment": "clock advanced to {new}⁄{max}",
-      "clockFilledOneSegment": "clock advanced to {new}⁄{max}—clock filled!",
       "clockAdvancedMultipleSegments": "clock advanced by {change} segments to {new}⁄{max}",
+      "clockFilledOneSegment": "clock advanced to {new}⁄{max}—clock filled!",
       "clockFilledMultipleSegments": "clock advanced by {change} segments to {new}⁄{max}—clock filled!",
       "clockSet": "clock set to {new}⁄{max}"
     },

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -212,10 +212,10 @@
       "LostBond": "Lost a bond",
       "completedMarked": "marked completed",
       "completedUnmarked": "unmarked completed",
-      "clockAdvanced": "clock advanced to {new}⁄{max}",
-      "clockFilled": "clock advanced to {new}⁄{max}—clock filled!",
-      "clockAdvancedMultiple": "clock advanced by {change} to {new}⁄{max}",
-      "clockFilledMultiple": "clock advanced by {change} to {new}⁄{max}—clock filled!",
+      "clockAdvancedOneSegment": "clock advanced to {new}⁄{max}",
+      "clockFilledOneSegment": "clock advanced to {new}⁄{max}—clock filled!",
+      "clockAdvancedMultipleSegments": "clock advanced by {change} segments to {new}⁄{max}",
+      "clockFilledMultipleSegments": "clock advanced by {change} segments to {new}⁄{max}—clock filled!",
       "clockSet": "clock set to {new}⁄{max}"
     },
     "Settings": {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -212,9 +212,11 @@
       "LostBond": "Lost a bond",
       "completedMarked": "marked completed",
       "completedUnmarked": "unmarked completed",
-      "clockAdvanced": "clock advanced from {old} to {new} of {max}",
-      "clockSet": "clock set to {new} of {max}",
-      "clockFilled": "clock filled ({max} segments)"
+      "clockAdvanced": "clock advanced to {new}⁄{max}",
+      "clockFilled": "clock advanced to {new}⁄{max}—clock filled!",
+      "clockAdvancedMultiple": "clock advanced by {change} to {new}⁄{max}",
+      "clockFilledMultiple": "clock advanced by {change} to {new}⁄{max}—clock filled!",
+      "clockSet": "clock set to {new}⁄{max}"
     },
     "Settings": {
       "Theme": {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -214,10 +214,7 @@
       "completedUnmarked": "unmarked completed",
       "clockAdvanced": "clock advanced from {old} to {new} of {max}",
       "clockSet": "clock set to {new} of {max}",
-      "clockFilled": "clock filled ({max} segments)",
-      "ClockAdvanced": "Clock advanced from {old} to {new} of {max}",
-      "ClockSet": "Clock set to {new} of {max}",
-      "ClockFilled": "Clock filled ({max} segments)"
+      "clockFilled": "clock filled ({max} segments)"
     },
     "Settings": {
       "Theme": {

--- a/system/lang/es.json
+++ b/system/lang/es.json
@@ -152,7 +152,7 @@
     "Expanse": "Expanse",
     "RotateCCW": "Rotate counter-clockwise",
     "RotateCW": "Rotate clockwise",
-    "ChangeLog": {
+    "ChatAlert": {
       "Renamed": "Renombrado a {name}",
       "renamed": "renombrado a {name}",
       "Added": "{name} añadido",

--- a/system/lang/fr.json
+++ b/system/lang/fr.json
@@ -114,7 +114,7 @@
     "Third": "troisième",
     "Fourth": "quatrième",
     "Fifth": "cinquième",
-    "ChangeLog": {
+    "ChatAlert": {
       "Renamed": "Renommé {name}",
       "renamed": "renommé {name}",
       "Added": "{name} ajouté",


### PR DESCRIPTION
addresses #400 by adding chat alerts for clock events, plus keys for the corresponding localizable strings. also adjusts the `ChangeLog` localization file key to match the new `ChatAlert` name.

the new localizable strings look like this:

```json
{
  "clockAdvancedOneSegment": "clock advanced to {new}⁄{max}",
  "clockAdvancedTwoSegments": "clock advanced by {change} segments to {new}⁄{max}",
  "clockAdvancedManySegments": "clock advanced by {change} segments to {new}⁄{max}",
  "clockCompletedOneSegment": "clock advanced to {new}⁄{max}—clock completed!",
  "clockCompletedTwoSegments": "clock advanced by {change} segments to {new}⁄{max}—clock completed!",
  "clockCompletedManySegments": "clock advanced by {change} segments to {new}⁄{max}—clock completed!",
  "clockSet": "clock set to {new}⁄{max}"
}
```

### Notes
* a rundown of the terminology, which i tried to be fairly strict about:
  * the wedge-shaped units that comprise clocks are called _'segments'_
  * incrementing a clock _'advances'_ it by _'filling'_ a segment ('fill' isn't used as a verb here, but i'm including it for the sake of completeness)
  * a _'completed'_ clock can also be described as _'filled'_ (i've preferred 'completed' here to make it less ambiguous)
* strings for one, two, and many segments are included to account for languages where dual and plural are grammatically distinct
  * strings for filling a single segment don't specify the number of segments filled; one segment is the default amount, and so is left unmarked
* `clockCompleted*` is for clock advancements that complete/fill the clock. `clockAdvanced*` is for clock advancements that don't
* `clockSet` is any clock change that isn't an advancement; it may have some use as a fallback. it's intentionally sparse to keep clutter down, because it's presumed to be a fix for user error--canonically, clocks only advance. note that "set" does not map to any specific game terminology.
* note that the slash between `{new}⁄{max}` is the specific one for vulgar fractions (HTML entity `&frasl;`)
