### PR TITLE
V10 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- First release that fully loads under Foundry v10 ([#413](https://github.com/ben/foundry-ironsworn/pull/413))
+
 ## 1.16.1
 
 - A small fix that should allow DF Manual Rolls to work properly (fixes [#411](https://github.com/ben/foundry-ironsworn/issues/411))

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -184,7 +184,15 @@ export function activateSceneButtonListeners() {
   })
 }
 
-class IronswornCanvasLayer extends CanvasLayer {
+// In v9 we can inherit directly from CanvasLayer and it's fine
+// In v10 we have to use InteractionLayer
+
+let baseKlass = CanvasLayer
+if (typeof InteractionLayer !== 'undefined') {
+  baseKlass = InteractionLayer
+}
+
+class IronswornCanvasLayer extends baseKlass {
   static get layerOptions() {
     return foundry.utils.mergeObject(super.layerOptions, {
       zIndex: 180,

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -155,8 +155,12 @@ label {
 .box {
   padding: 7px;
 }
-.highlighted {
-  background: #33999933;
+.theme-starforged .highlighted {
+  background: #055;
+}
+
+.theme-ironsworn .highlighted {
+  background: #ccc;
 }
 </style>
 

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -31,7 +31,7 @@
     </div>
 
     <!-- Klass -->
-    <label class="flexrow" style="position: relative; gap: 10px">
+    <label class="flexrow nogrow" style="position: relative; gap: 10px">
       <!-- TODO: i18n and subtype text -->
       <span class="select-label">{{ subtypeSelectText }}:</span>
       <select

--- a/src/styles/themes/ironsworn.less
+++ b/src/styles/themes/ironsworn.less
@@ -196,7 +196,10 @@ body.theme-ironsworn {
 
       .entity-link,
       .content-link {
-        color: @text-color;
+        color: white;
+        padding: none;
+        border: none;
+        background: transparent;
       }
     }
   }

--- a/src/styles/themes/starforged.less
+++ b/src/styles/themes/starforged.less
@@ -258,7 +258,7 @@ body.theme-starforged {
 
         .entity-link,
         .content-link {
-          color: @text-dark-color;
+          color: @text-light-color;
         }
       }
     }

--- a/system/system.json
+++ b/system/system.json
@@ -9,10 +9,10 @@
   "manifest": "https://github.com/ben/foundry-ironsworn/releases/latest/download/system.json",
   "download": "https://github.com/ben/foundry-ironsworn/releases/download/1.16.1/ironsworn.zip",
   "minimumCoreVersion": "9",
-  "compatibleCoreVersion": "9",
+  "compatibleCoreVersion": "10",
   "compatibility": {
     "minimum": 9,
-    "verified": 9
+    "verified": 10
   },
   "authors": [
     {


### PR DESCRIPTION
This includes the final fixes to make the system work under Foundry v10. There are a few visual nits that we'll sweep up in time, but I think this makes most things work as well as they do in v9. 

- [x] Fix the scene buttons layer breaking scene loads in Starforged mode
- [ ] FontAwesome update broke the last two scene button icons; going to wait to see what @rsek's work can do for us here.
- [x] Entity links look different in v10, adjust styling for in-chat tables to accommodate 
- [x] Fix a few other visual glitches along the way
- [x] Update CHANGELOG.md
