### PR TITLE
Custom conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- Custom conditions with custom names ([#420](https://github.com/ben/foundry-ironsworn/pull/420))
+
 ## 1.16.3
 
 - Ironsworn sheet: completed area, and move notes to a tab ([#417](https://github.com/ben/foundry-ironsworn/pull/417))

--- a/src/module/actor/actortypes.ts
+++ b/src/module/actor/actortypes.ts
@@ -25,6 +25,10 @@ interface CharacterDataSourceData {
     doomed: boolean
     indebted: boolean
     battered: boolean
+    custom1: boolean
+    custom1name: string
+    custom2: boolean
+    custom2name: string
   }
   legacies: {
     quests: number

--- a/src/module/vue/character-sheet.vue
+++ b/src/module/vue/character-sheet.vue
@@ -49,7 +49,7 @@
 
         <!-- Conditions & Banes & Burdens -->
         <section class="sheet-area nogrow">
-          <conditions :actor="actor" />
+          <conditions />
         </section>
       </div>
 
@@ -114,7 +114,6 @@ import { provide, computed, inject } from 'vue'
 import { RollDialog } from '../helpers/rolldialog'
 import CharacterHeader from './components/character-header.vue'
 import Conditions from './components/conditions/conditions.vue'
-import { throttle } from 'lodash'
 import Tabs from './components/tabs/tabs.vue'
 import Tab from './components/tabs/tab.vue'
 import IronswornMain from './components/character-sheet-tabs/ironsworn-main.vue'

--- a/src/module/vue/components/conditions/condition-checkbox.vue
+++ b/src/module/vue/components/conditions/condition-checkbox.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts" setup>
-import { inject, Ref } from 'vue'
+import { inject, nextTick, Ref } from 'vue'
 import { IronswornSettings } from '../../../helpers/settings'
 import { $ActorKey } from '../../provisions'
 
@@ -24,18 +24,24 @@ const props = defineProps<{
 
 async function input(ev) {
   const value = ev.currentTarget.checked
-  let numDebilitiesMarked =
-    Object.values(actor.value.data.debility).filter((x) => x).length +
-    (value ? 1 : -1)
   await $actor?.update({
     data: {
       debility: {
         [props.name]: value,
       },
+    },
+  })
+  await nextTick()
+  const numDebilitiesMarked = Object.values(actor.value.data.debility).filter(
+    (x) => x === true
+  ).length
+  await $actor?.update({
+    data: {
       momentumMax: 10 - numDebilitiesMarked,
       momentumReset: Math.max(0, 2 - numDebilitiesMarked),
     },
   })
+
   if (props.global) {
     await IronswornSettings.maybeSetGlobalCondition(props.name, value)
   }

--- a/src/module/vue/components/conditions/conditions.vue
+++ b/src/module/vue/components/conditions/conditions.vue
@@ -13,6 +13,14 @@
     <condition-checkbox name="encumbered" />
     <condition-checkbox name="corrupted" />
     <condition-checkbox name="tormented" />
+
+    <custom-condition-checkbox
+      style="grid-column: 1 / 3"
+      debilitykey="custom1"
+    />
+    <custom-condition-checkbox
+      style="grid-column: 3 / 5"
+      debilitykey="custom2"
     />
   </div>
 </template>
@@ -25,4 +33,5 @@
 
 <script setup lang="ts" >
 import ConditionCheckbox from './condition-checkbox.vue'
+import CustomConditionCheckbox from './custom-condition-checkbox.vue'
 </script>

--- a/src/module/vue/components/conditions/conditions.vue
+++ b/src/module/vue/components/conditions/conditions.vue
@@ -1,30 +1,27 @@
 <template>
-  <div class="flexrow">
-    <div class="flexcol" style="flex: 2">
-      <h4>{{ $t('IRONSWORN.Conditions') }}</h4>
-      <div class="flexrow">
-        <div class="flexcol">
-          <condition-checkbox name="wounded" />
-          <condition-checkbox name="unprepared" />
-        </div>
-        <div class="flexcol">
-          <condition-checkbox name="shaken" />
-          <condition-checkbox name="encumbered" />
-        </div>
-      </div>
-    </div>
-    <div class="flexcol">
-      <h4>{{ $t('IRONSWORN.Banes') }}</h4>
-      <condition-checkbox name="maimed" />
-      <condition-checkbox name="corrupted" />
-    </div>
-    <div class="flexcol">
-      <h4>{{ $t('IRONSWORN.Burdens') }}</h4>
-      <condition-checkbox name="cursed" />
-      <condition-checkbox name="tormented" />
-    </div>
+  <div class="grid">
+    <h4 style="grid-column: 1 / 3">{{ $t('IRONSWORN.Conditions') }}</h4>
+    <h4 style="grid-column: 3">{{ $t('IRONSWORN.Banes') }}</h4>
+    <h4 style="grid-column: 4">{{ $t('IRONSWORN.Burdens') }}</h4>
+
+    <condition-checkbox name="wounded" />
+    <condition-checkbox name="shaken" />
+    <condition-checkbox name="maimed" />
+    <condition-checkbox name="cursed" />
+
+    <condition-checkbox name="unprepared" />
+    <condition-checkbox name="encumbered" />
+    <condition-checkbox name="corrupted" />
+    <condition-checkbox name="tormented" />
+    />
   </div>
 </template>
+
+<style lang="less" scoped>
+.grid {
+  grid-template-columns: repeat(4, 1fr);
+}
+</style>
 
 <script setup lang="ts" >
 import ConditionCheckbox from './condition-checkbox.vue'

--- a/src/module/vue/components/conditions/custom-condition-checkbox.vue
+++ b/src/module/vue/components/conditions/custom-condition-checkbox.vue
@@ -1,0 +1,69 @@
+<template>
+  <label class="checkbox flexrow">
+    <input
+      type="checkbox"
+      :checked="actor.data.debility[debilitykey]"
+      @input="toggled"
+    />
+    <input
+      type="text"
+      v-model="actor.data.debility[nameKey]"
+      @input="nameUpdate"
+    />
+  </label>
+</template>
+
+<style lang="less" scoped>
+label {
+  margin-left: -2px;
+  margin-right: 5px;
+}
+input[type='text'] {
+  border: 0;
+  outline: 0;
+  border-bottom: 1px solid;
+}
+</style>
+
+<script lang="ts" setup>
+import { throttle } from 'lodash'
+import { computed, inject, nextTick, Ref } from 'vue'
+import { $ActorKey } from '../../provisions'
+
+const props = defineProps<{ debilitykey: string }>()
+
+const actor = inject('actor') as Ref
+const $actor = inject($ActorKey)
+
+const nameKey = computed(() => `${props.debilitykey}name`)
+
+async function toggled(ev) {
+  const value = ev.target.checked
+  await $actor?.update({
+    data: {
+      debility: {
+        [props.debilitykey]: value,
+      },
+    },
+  })
+  await nextTick()
+  const numDebilitiesMarked = Object.values(actor.value.data.debility).filter(
+    (x) => x === true
+  ).length
+  await $actor?.update({
+    data: {
+      momentumMax: 10 - numDebilitiesMarked,
+      momentumReset: Math.max(0, 2 - numDebilitiesMarked),
+    },
+  })
+}
+
+async function immediateNameUpdate() {
+  const nk = nameKey.value
+  console.log(`data.debility.${nk}`, actor.value.data.debility[nk])
+  await $actor?.update({
+    [`data.debility.${nk}`]: actor.value.data.debility[nk],
+  })
+}
+const nameUpdate = throttle(immediateNameUpdate, 1000)
+</script>

--- a/src/module/vue/components/conditions/custom-condition-checkbox.vue
+++ b/src/module/vue/components/conditions/custom-condition-checkbox.vue
@@ -60,7 +60,6 @@ async function toggled(ev) {
 
 async function immediateNameUpdate() {
   const nk = nameKey.value
-  console.log(`data.debility.${nk}`, actor.value.data.debility[nk])
   await $actor?.update({
     [`data.debility.${nk}`]: actor.value.data.debility[nk],
   })

--- a/src/module/vue/components/sf-impacts.vue
+++ b/src/module/vue/components/sf-impacts.vue
@@ -1,31 +1,42 @@
 <template>
-  <div class="flexrow">
-    <div class="flexcol">
-      <h5>{{ $t('IRONSWORN.Misfortunes') }}</h5>
-      <condition-checkbox class="nogrow" name="wounded" />
-      <condition-checkbox class="nogrow" name="shaken" />
-      <condition-checkbox class="nogrow" name="unprepared" />
-    </div>
-    <div class="flexcol">
-      <h5>{{ $t('IRONSWORN.LastingEffects') }}</h5>
-      <condition-checkbox class="nogrow" name="permanentlyharmed" />
-      <condition-checkbox class="nogrow" name="traumatized" />
-    </div>
-    <div class="flexcol">
-      <h5>{{ $t('IRONSWORN.Burdens') }}</h5>
-      <condition-checkbox class="nogrow" name="doomed" />
-      <condition-checkbox class="nogrow" name="tormented" />
-      <condition-checkbox class="nogrow" name="indebted" />
-    </div>
-    <div class="flexcol">
-      <h5>{{ $t('IRONSWORN.Vehicle') }}</h5>
-      <condition-checkbox class="nogrow" name="battered" :global="true" />
-      <condition-checkbox class="nogrow" name="cursed" :global="true" />
-    </div>
+  <div class="grid">
+    <h5>{{ $t('IRONSWORN.Misfortunes') }}</h5>
+    <h5>{{ $t('IRONSWORN.LastingEffects') }}</h5>
+    <h5>{{ $t('IRONSWORN.Burdens') }}</h5>
+    <h5>{{ $t('IRONSWORN.Vehicle') }}</h5>
+
+    <condition-checkbox class="nogrow" name="wounded" />
+    <condition-checkbox class="nogrow" name="permanentlyharmed" />
+    <condition-checkbox class="nogrow" name="doomed" />
+    <condition-checkbox class="nogrow" name="battered" :global="true" />
+
+    <condition-checkbox class="nogrow" name="shaken" />
+    <condition-checkbox class="nogrow" name="traumatized" />
+    <condition-checkbox class="nogrow" name="tormented" />
+    <condition-checkbox class="nogrow" name="cursed" :global="true" />
+
+    <condition-checkbox class="nogrow" name="unprepared" />
+    <condition-checkbox
+      class="nogrow"
+      name="indebted"
+      style="grid-column: 3/4"
+    />
+
+    <custom-condition-checkbox
+      style="grid-column: 1 / 3"
+      debilitykey="custom1"
+    />
+    <custom-condition-checkbox
+      style="grid-column: 3 / 5"
+      debilitykey="custom2"
+    />
   </div>
 </template>
 
 <style lang="less" scoped>
+.grid {
+  grid-template-columns: repeat(4, 1fr);
+}
 h5 {
   flex-grow: 0;
   margin: 0.2rem 0;
@@ -34,4 +45,5 @@ h5 {
 
 <script setup lang="ts">
 import conditionCheckbox from './conditions/condition-checkbox.vue'
+import CustomConditionCheckbox from './conditions/custom-condition-checkbox.vue'
 </script>

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -15,6 +15,10 @@
   scrollbar-color: #444 rgba(0, 0, 0, 0.1);
 }
 
+.grid {
+  display: grid;
+}
+
 .ironsworn {
   font-family: var(--font-primary);
   h1,

--- a/system/template.json
+++ b/system/template.json
@@ -37,7 +37,11 @@
         "traumatized": false,
         "doomed": false,
         "indebted": false,
-        "battered": false
+        "battered": false,
+        "custom1": false,
+        "custom1name": "",
+        "custom2": false,
+        "custom2name": ""
       },
       "xp": 0
     },


### PR DESCRIPTION
This adds two custom-entry checkboxes to each character sheet, to enable the use of custom conditions for things like the Leech ritual. I also took the opportunity to switch the condition layouts to use CSS grid, which makes it _much_ clearer what's happening.

- [x] Add fields to template and TS types
- [x] New custom-condition component
- [x] Add custom conditions to IS and SF sheets
- [x] Update CHANGELOG.md
