### PR TITLE
`.content-link` works in v9 and v10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In progress
 
+- (v10) Fix a bug with move navigation ([#421](https://github.com/ben/foundry-ironsworn/pull/421))
+
 ## 1.16.4
 
 - Custom conditions with custom names ([#420](https://github.com/ben/foundry-ironsworn/pull/420))

--- a/src/module/vue/components/with-rolllisteners.vue
+++ b/src/module/vue/components/with-rolllisteners.vue
@@ -24,11 +24,10 @@ onMounted(() => {
     actor: $actor,
   })
 
-  $(el.value).find('.entity-link').on('click', click)
+  $(el.value).find('.content-link').on('click', click)
 })
 
 const $emit = defineEmits(['moveclick', 'oracleclick'])
-const $emitter = inject($EmitterKey)
 const $attrs = useAttrs()
 
 async function click(ev: JQuery.ClickEvent) {


### PR DESCRIPTION
Part of #385. This fixes clicking on moves to navigate around the move sheet.

- [x] Fix the bug
- [x] Update CHANGELOG.md
