### PR TITLE
Remove unnecessary `:actor="actor"`s

### DIFF
--- a/src/module/vue/character-sheet.vue
+++ b/src/module/vue/character-sheet.vue
@@ -10,7 +10,6 @@
         <div class="flexrow" style="flex-wrap: nowrap">
           <div class="flexcol stack momentum">
             <stack
-              :actor="actor"
               stat="momentum"
               :top="10"
               :bottom="-6"
@@ -35,11 +34,11 @@
       <div class="flexcol">
         <!-- Attributes -->
         <div class="flexrow stats">
-          <attr-box :actor="actor" attr="edge"></attr-box>
-          <attr-box :actor="actor" attr="heart"></attr-box>
-          <attr-box :actor="actor" attr="iron"></attr-box>
-          <attr-box :actor="actor" attr="shadow"></attr-box>
-          <attr-box :actor="actor" attr="wits"></attr-box>
+          <attr-box attr="edge"></attr-box>
+          <attr-box attr="heart"></attr-box>
+          <attr-box attr="iron"></attr-box>
+          <attr-box attr="shadow"></attr-box>
+          <attr-box attr="wits"></attr-box>
         </div>
 
         <tabs style="margin-top: 0.5rem">
@@ -57,15 +56,11 @@
       <div class="flexcol margin-right">
         <div class="flexrow nogrow" style="flex-wrap: nowrap">
           <!-- TODO: restyle as h4-like -->
-          <btn-rollstat
-            class="nogrow vertical-v2 text"
-            :actor="actor"
-            attr="health"
-          >
+          <btn-rollstat class="nogrow vertical-v2 text" attr="health">
             {{ $t('IRONSWORN.Health') }}
           </btn-rollstat>
           <div class="flexcol stack health">
-            <stack :actor="actor" stat="health" :top="5" :bottom="0"></stack>
+            <stack stat="health" :top="5" :bottom="0"></stack>
           </div>
         </div>
 
@@ -73,15 +68,11 @@
 
         <div class="flexrow nogrow" style="flex-wrap: nowrap">
           <!-- TODO: restyle as h4-like -->
-          <btn-rollstat
-            class="nogrow vertical-v2 text"
-            :actor="actor"
-            attr="spirit"
-          >
+          <btn-rollstat class="nogrow vertical-v2 text" attr="spirit">
             {{ $t('IRONSWORN.Spirit') }}
           </btn-rollstat>
           <div class="flexcol stack spirit">
-            <stack :actor="actor" stat="spirit" :top="5" :bottom="0"></stack>
+            <stack stat="spirit" :top="5" :bottom="0"></stack>
           </div>
         </div>
 
@@ -89,15 +80,11 @@
 
         <div class="flexrow nogrow" style="flex-wrap: nowrap">
           <!-- TODO: restyle as h4-like -->
-          <btn-rollstat
-            class="nogrow vertical-v2 text"
-            :actor="actor"
-            attr="supply"
-          >
+          <btn-rollstat class="nogrow vertical-v2 text" attr="supply">
             {{ $t('IRONSWORN.Supply') }}
           </btn-rollstat>
           <div class="flexcol stack supply">
-            <stack :actor="actor" stat="supply" :top="5" :bottom="0"></stack>
+            <stack stat="supply" :top="5" :bottom="0"></stack>
           </div>
         </div>
       </div>

--- a/src/module/vue/components/active-completed-progresses.vue
+++ b/src/module/vue/components/active-completed-progresses.vue
@@ -16,7 +16,6 @@
           />
           <progress-box
             :item="item"
-            :actor="actor"
             :showStar="true"
             @completed="progressCompleted"
           />
@@ -57,7 +56,7 @@
                 @sortUp="completedSortUp"
                 @sortDown="completedSortDown"
               />
-              <progress-box :item="item" :actor="actor" :showStar="true" />
+              <progress-box :item="item" :showStar="true" />
             </div>
           </transition-group>
         </div>

--- a/src/module/vue/components/asset/asset-track.vue
+++ b/src/module/vue/components/asset/asset-track.vue
@@ -12,7 +12,7 @@ import { inject } from 'vue'
 import { $ItemKey } from '../../provisions'
 import Boxrow from '../boxrow/boxrow.vue'
 
-const props = defineProps<{ item: any; actor?: any }>()
+const props = defineProps<{ item: any }>()
 
 const $item = inject($ItemKey)
 

--- a/src/module/vue/components/asset/asset-track.vue
+++ b/src/module/vue/components/asset/asset-track.vue
@@ -8,22 +8,16 @@
 </template>
 
 <script setup lang="ts">
+import { inject } from 'vue'
+import { $ItemKey } from '../../provisions'
 import Boxrow from '../boxrow/boxrow.vue'
 
 const props = defineProps<{ item: any; actor?: any }>()
 
-const $item = () => {
-  if (props.actor) {
-    // This is yucky, there's got to be a better way
-    const actor = game.actors?.get(props.actor._id ?? props.actor.id)
-    const item = actor?.items.get(props.item._id)
-    if (item) return item
-  }
-  return game.items?.get(props.item._id)
-}
+const $item = inject($ItemKey)
 
 function click(value) {
-  $item()?.update({
+  $item?.update({
     data: {
       track: {
         current: value,

--- a/src/module/vue/components/asset/asset-trackedit.vue
+++ b/src/module/vue/components/asset/asset-trackedit.vue
@@ -23,7 +23,7 @@
         v-model.number="item.data.track.max"
       />
     </div>
-    <asset-track style="margin-top: 5px" :actor="$item?.parent" :item="item" />
+    <asset-track style="margin-top: 5px" :item="item" />
   </div>
 </template>
 

--- a/src/module/vue/components/asset/asset.vue
+++ b/src/module/vue/components/asset/asset.vue
@@ -26,7 +26,6 @@
             :key="'ability' + i"
             element="li"
             class="flexrow"
-            :actor="actingActor"
             @moveclick="moveclick"
           >
             <!-- TODO: redo as list style -->

--- a/src/module/vue/components/asset/asset.vue
+++ b/src/module/vue/components/asset/asset.vue
@@ -46,7 +46,7 @@
           <btn-rollstat class="juicy text flexrow" :item="asset" attr="track">
             {{ asset.data.track.name }}
           </btn-rollstat>
-          <asset-track :actor="actor" :item="asset" />
+          <asset-track :item="asset" />
         </div>
 
         <div

--- a/src/module/vue/components/character-sheet-tabs/sf-assets.vue
+++ b/src/module/vue/components/character-sheet-tabs/sf-assets.vue
@@ -9,7 +9,7 @@
           @sortUp="sortUp"
           @sortDown="sortDown"
         />
-        <asset :actor="actor" :asset="asset" />
+        <asset :asset="asset" />
       </div>
     </transition-group>
     <div class="flexrow nogrow" style="text-align: center">

--- a/src/module/vue/components/character-sheet-tabs/sf-connections.vue
+++ b/src/module/vue/components/character-sheet-tabs/sf-connections.vue
@@ -13,7 +13,7 @@
           @sortUp="sortUp"
           @sortDown="sortDown"
         />
-        <progress-box :item="item" :actor="actor" :showStar="true" />
+        <progress-box :item="item" :showStar="true" />
       </div>
     </transition-group>
 

--- a/src/module/vue/sf-charactersheet.vue
+++ b/src/module/vue/sf-charactersheet.vue
@@ -61,11 +61,7 @@
       <div class="flexcol margin-right condition-meters">
         <div class="flexrow nogrow" style="flex-wrap: nowrap">
           <!-- TODO: restyle as h4-like -->
-          <btn-rollstat
-            class="vertical-v2 nogrow text"
-            :actor="actor"
-            attr="health"
-          >
+          <btn-rollstat class="vertical-v2 nogrow text" attr="health">
             {{ $t('IRONSWORN.Health') }}
           </btn-rollstat>
           <div class="flexcol stack health">
@@ -101,7 +97,7 @@
 
     <!-- Impacts -->
     <hr class="nogrow" />
-    <sf-impacts :actor="actor" class="nogrow" />
+    <sf-impacts class="nogrow" />
   </div>
 </template>
 

--- a/src/module/vue/shared-sheet.vue
+++ b/src/module/vue/shared-sheet.vue
@@ -20,7 +20,7 @@
     </section>
 
     <section v-if="hasBonds" class="sheet-area nogrow">
-      <bonds :actor="actor" />
+      <bonds />
     </section>
 
     <active-completed-progresses />

--- a/src/module/vue/site-sheet.vue
+++ b/src/module/vue/site-sheet.vue
@@ -106,66 +106,54 @@
     <div class="boxgroup nogrow" style="margin-bottom: 1em">
       <div class="flexrow boxrow">
         <site-denizenbox
-          :actor="actor"
           :idx="0"
           :ref="(e) => (denizenRefs[0] = e)"
         />
         <site-denizenbox
-          :actor="actor"
           :idx="1"
           :ref="(e) => (denizenRefs[1] = e)"
         />
         <site-denizenbox
-          :actor="actor"
           :idx="2"
           :ref="(e) => (denizenRefs[2] = e)"
         />
         <site-denizenbox
-          :actor="actor"
           :idx="3"
           :ref="(e) => (denizenRefs[3] = e)"
         />
       </div>
       <div class="flexrow boxrow">
         <site-denizenbox
-          :actor="actor"
           :idx="4"
           :ref="(e) => (denizenRefs[4] = e)"
         />
         <site-denizenbox
-          :actor="actor"
           :idx="5"
           :ref="(e) => (denizenRefs[5] = e)"
         />
         <site-denizenbox
-          :actor="actor"
           :idx="6"
           :ref="(e) => (denizenRefs[6] = e)"
         />
         <site-denizenbox
-          :actor="actor"
           :idx="7"
           :ref="(e) => (denizenRefs[7] = e)"
         />
       </div>
       <div class="flexrow boxrow">
         <site-denizenbox
-          :actor="actor"
           :idx="8"
           :ref="(e) => (denizenRefs[8] = e)"
         />
         <site-denizenbox
-          :actor="actor"
           :idx="9"
           :ref="(e) => (denizenRefs[9] = e)"
         />
         <site-denizenbox
-          :actor="actor"
           :idx="10"
           :ref="(e) => (denizenRefs[10] = e)"
         />
         <site-denizenbox
-          :actor="actor"
           :idx="11"
           :ref="(e) => (denizenRefs[11] = e)"
         />

--- a/src/module/vue/starship-sheet.vue
+++ b/src/module/vue/starship-sheet.vue
@@ -18,20 +18,10 @@
 
     <section class="flexrow nogrow">
       <div style="text-align: center">
-        <condition-checkbox
-          class="nogrow"
-          :actor="actor"
-          name="battered"
-          :global="true"
-        />
+        <condition-checkbox class="nogrow" name="battered" :global="true" />
       </div>
       <div style="text-align: center">
-        <condition-checkbox
-          class="nogrow"
-          :actor="actor"
-          name="cursed"
-          :global="true"
-        />
+        <condition-checkbox class="nogrow" name="cursed" :global="true" />
       </div>
     </section>
   </div>


### PR DESCRIPTION
We're using `provide` to give access to a Reactive `actor` object, as well as the Foundry-native `$actor` object, so anything inside a sheet can inject one whenever they want. Fixes #416.

- [x] Replace most uses
- [x] Do a provide/inject thing with the `asset` and `asset-track` components
- [x] ~~Update CHANGELOG.md~~ This isn't user-facing, so no
