### PR TITLE
Open the right(er) foe compendium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Don't open editors for non-editable items when clicking a move link and no character move sheet is open.
 - Add a start for Polish translations (see [#428](https://github.com/ben/foundry-ironsworn/issues/428))
 - Retire the "Classic" character ([#438](https://github.com/ben/foundry-ironsworn/pull/438)) and shared ([#440](https://github.com/ben/foundry-ironsworn/pull/440)) sheets
+- Improve choice of foe compendium in the "shared" sheet ([#442](https://github.com/ben/foundry-ironsworn/pull/442))
 
 ## 1.16.9
 

--- a/src/module/vue/components/active-completed-progresses.vue
+++ b/src/module/vue/components/active-completed-progresses.vue
@@ -21,7 +21,7 @@
           />
         </div>
       </transition-group>
-      <progress-controls foeCompendium="starforgedencounters" />
+      <progress-controls :foeCompendium="foeCompendium" />
     </div>
 
     <div class="item-row nogrow progress-completed" style="margin-top: 1rem">
@@ -111,6 +111,7 @@ import OrderButtons from './order-buttons.vue'
 import ProgressBox from './progress/progress-box.vue'
 import ProgressControls from './progress-controls.vue'
 import BtnFaicon from './buttons/btn-faicon.vue'
+import { IronswornSettings } from '../../helpers/settings'
 
 const data = reactive({
   expandCompleted: false,
@@ -150,6 +151,12 @@ function progressCompleted() {
     data.highlightCompleted = false
   }, 2000)
 }
+
+const foeCompendium = computed(() => {
+  return IronswornSettings.starforgedToolsEnabled
+    ? 'starforgedencounters'
+    : 'ironswornfoes'
+})
 
 async function applySort(oldI, newI, sortBefore, filterFn) {
   const foundryItems = $actor?.items


### PR DESCRIPTION
Fixes #441. This now pays attention to the "toolbox" setting when opening a foe compendium.

- [x] Fix the bug
- [x] Update CHANGELOG.md
