### PR TITLE
Compact sheet updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Freshen up the compact PC sheet, and use the new rolling pipeline ([#448](https://github.com/ben/foundry-ironsworn/pull/448))
+
 ## 1.17.1
 
 - Make delve-site roll rendering a bit less ugly, until we can make it more pretty ([#446](https://github.com/ben/foundry-ironsworn/pull/446))

--- a/src/module/actor/sheets/compactsheet.ts
+++ b/src/module/actor/sheets/compactsheet.ts
@@ -2,16 +2,7 @@ import { IronswornSettings } from '../../helpers/settings'
 import { IronswornPrerollDialog } from '../../rolls'
 import { CharacterMoveSheet } from './charactermovesheet'
 
-interface CompactCharacterSheetOptions extends ActorSheet.Options {
-  statRollBonus: number
-}
-
-export class IronswornCompactCharacterSheet extends ActorSheet<CompactCharacterSheetOptions> {
-  constructor(actor, opts: CompactCharacterSheetOptions) {
-    opts.statRollBonus ||= 0
-    super(actor, opts)
-  }
-
+export class IronswornCompactCharacterSheet extends ActorSheet {
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
       classes: [
@@ -80,14 +71,11 @@ export class IronswornCompactCharacterSheet extends ActorSheet<CompactCharacterS
     const el = ev.currentTarget
     const stat = el.dataset.stat
     if (stat) {
-      const bonus = this.options.statRollBonus || 0
       IronswornPrerollDialog.showForStat(
         stat,
         this.actor.data.data[stat],
-        this.actor,
-        bonus
+        this.actor
       )
-      this.options.statRollBonus = 0
       this.render(true)
     }
   }

--- a/src/module/actor/sheets/compactsheet.ts
+++ b/src/module/actor/sheets/compactsheet.ts
@@ -77,18 +77,6 @@ export class IronswornCompactCharacterSheet extends ActorSheet<CompactCharacterS
     }
   }
 
-  _onBurnMomentum(ev: JQuery.ClickEvent) {
-    ev.preventDefault()
-
-    if (this.actor.data.type !== 'character') return
-    const { momentum, momentumReset } = this.actor.data.data
-    if (momentum > momentumReset) {
-      this.actor.update({
-        data: { momentum: momentumReset },
-      })
-    }
-  }
-
   _bonusAdjust(ev: JQuery.ClickEvent) {
     ev.preventDefault()
 

--- a/src/module/actor/sheets/compactsheet.ts
+++ b/src/module/actor/sheets/compactsheet.ts
@@ -1,5 +1,5 @@
-import { RollDialog } from '../../helpers/rolldialog'
 import { IronswornSettings } from '../../helpers/settings'
+import { IronswornPrerollDialog } from '../../rolls'
 import { CharacterMoveSheet } from './charactermovesheet'
 
 interface CompactCharacterSheetOptions extends ActorSheet.Options {
@@ -92,11 +92,12 @@ export class IronswornCompactCharacterSheet extends ActorSheet<CompactCharacterS
     const stat = el.dataset.stat
     if (stat) {
       const bonus = this.options.statRollBonus || 0
-      await RollDialog.show({
-        actor: this.actor,
+      IronswornPrerollDialog.showForStat(
         stat,
-        bonus,
-      })
+        this.actor.data.data[stat],
+        this.actor,
+        bonus
+      )
       this.options.statRollBonus = 0
       this.render(true)
     }

--- a/src/module/actor/sheets/compactsheet.ts
+++ b/src/module/actor/sheets/compactsheet.ts
@@ -123,12 +123,8 @@ export class IronswornCompactCharacterSheet extends ActorSheet<CompactCharacterS
   _momentumBurn(ev: JQuery.ClickEvent) {
     ev.preventDefault()
 
-    if (this.actor.data.type !== 'character') return
-    const { momentum, momentumReset } = this.actor.data.data
-    if (momentum > momentumReset) {
-      this.actor.update({
-        data: { momentum: momentumReset },
-      })
+    if (this.actor.data.type === 'character') {
+      this.actor.burnMomentum()
     }
   }
 }

--- a/src/module/actor/sheets/compactsheet.ts
+++ b/src/module/actor/sheets/compactsheet.ts
@@ -21,7 +21,7 @@ export class IronswornCompactCharacterSheet extends ActorSheet<CompactCharacterS
         `theme-${IronswornSettings.theme}`,
       ],
       width: 560,
-      height: 228,
+      height: 240,
       template: 'systems/foundry-ironsworn/templates/actor/compact.hbs',
       resizable: false,
     })

--- a/src/module/actor/sheets/compactsheet.ts
+++ b/src/module/actor/sheets/compactsheet.ts
@@ -21,7 +21,7 @@ export class IronswornCompactCharacterSheet extends ActorSheet<CompactCharacterS
         `theme-${IronswornSettings.theme}`,
       ],
       width: 560,
-      height: 240,
+      height: 210,
       template: 'systems/foundry-ironsworn/templates/actor/compact.hbs',
       resizable: false,
     })
@@ -33,9 +33,6 @@ export class IronswornCompactCharacterSheet extends ActorSheet<CompactCharacterS
     html
       .find('.ironsworn__stat__roll')
       .on('click', (e) => this._onStatRoll.call(this, e))
-    html
-      .find('.ironsworn__stat__bonusadajust')
-      .on('click', (e) => this._bonusAdjust.call(this, e))
     html
       .find('.ironsworn__resource__adjust')
       .on('click', (e) => this._resourceAdjust.call(this, e))
@@ -75,14 +72,6 @@ export class IronswornCompactCharacterSheet extends ActorSheet<CompactCharacterS
     } else {
       new CharacterMoveSheet(this.actor).render(true)
     }
-  }
-
-  _bonusAdjust(ev: JQuery.ClickEvent) {
-    ev.preventDefault()
-
-    const amt = parseInt(ev.currentTarget.dataset.amt || '0')
-    this.options.statRollBonus += amt
-    this.render(true)
   }
 
   async _onStatRoll(ev: JQuery.ClickEvent) {

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -347,10 +347,12 @@
   }
 
   .compact {
+    h2,
     h3,
     h4,
     h5 {
       margin: 3px 0;
+      border: none;
     }
   }
 

--- a/system/templates/actor/compact.hbs
+++ b/system/templates/actor/compact.hbs
@@ -22,7 +22,8 @@
     <div class="flexrow boxrow">
       {{#*inline "resource"}}
       <div class="box flexcol">
-        <div class="flexcol boxrow clickable block ironsworn__stat__roll" data-stat="{{stat}}">
+        <div class="flexcol boxrow {{#unless burn}}clickable block ironsworn__stat__roll{{/unless}}"
+          data-stat="{{stat}}">
           <h5>{{localize (concat 'IRONSWORN.' (capitalize stat))}}</h5>
           <h4>{{lookup data.data stat}}</h4>
         </div>

--- a/system/templates/actor/compact.hbs
+++ b/system/templates/actor/compact.hbs
@@ -5,7 +5,7 @@
       {{#*inline "stat"}}
       <div class="box flexcol clickable block ironsworn__stat__roll" data-stat="{{stat}}">
         <h4>{{localize (concat 'IRONSWORN.' (capitalize stat))}}</h4>
-        <h3>{{lookup data.data stat}}</h3>
+        <h2>{{lookup data.data stat}}</h2>
       </div>
       {{/inline}}
 

--- a/system/templates/actor/compact.hbs
+++ b/system/templates/actor/compact.hbs
@@ -15,13 +15,6 @@
       {{>stat stat="shadow"}}
       {{>stat stat="wits"}}
     </div>
-    <div class="flexrow boxrow small">
-      <div class="box clickable block ironsworn__stat__bonusadajust" data-amt="-1">&minus;</div>
-      <div class="box" title="{{localize 'IRONSWORN.StatBonusTooltip'}}">
-        {{options.statRollBonus}}
-      </div>
-      <div class="box clickable block ironsworn__stat__bonusadajust" data-amt="1">&plus;</div>
-    </div>
   </div>
 
   {{!-- Resources --}}

--- a/system/templates/rolls/preroll-dialog.hbs
+++ b/system/templates/rolls/preroll-dialog.hbs
@@ -1,48 +1,42 @@
 <form class='preroll-dialog{{#if action}} action-roll-dialog{{else}} progress-roll-dialog{{/if}}'>
   {{#if move}}
-    <section class='roll-trigger-text'>
-      {{{enrichMarkdown move.data.data.Trigger.Text}}}
-    </section>
-    {{#if move.data.data.Trigger.Options}}
-      <ul class='trigger-options'>
-        {{#each move.data.data.Trigger.Options}}
-          {{#if Text}}
-            <li class='trigger-option'>
-              {{Text}}:
-              <strong>{{formatRollMethod Method Using}}</strong>
-            </li>
-          {{/if}}
-        {{/each}}
-      </ul>
+  <section class='roll-trigger-text'>
+    {{{enrichMarkdown move.data.data.Trigger.Text}}}
+  </section>
+  {{#if move.data.data.Trigger.Options}}
+  <ul class='trigger-options'>
+    {{#each move.data.data.Trigger.Options}}
+    {{#if Text}}
+    <li class='trigger-option'>
+      {{Text}}:
+      <strong>{{formatRollMethod Method Using}}</strong>
+    </li>
     {{/if}}
+    {{/each}}
+  </ul>
+  {{/if}}
   {{/if}}
   <section class='dice-roll ironsworn-roll'>
     {{{graphic}}}
   </section>
   {{#if action}}
-    <fieldset class='form-group'>
-      <label for='roll-input-adds'>{{localize 'IRONSWORN.Adds'}}</label>
-      <input
-        id='roll-input-adds'
-        type='number'
-        step='1'
-        name='adds'
-        value='0'
-      />
-    </fieldset>
+  <fieldset class='form-group'>
+    <label for='roll-input-adds'>{{localize 'IRONSWORN.Adds'}}</label>
+    <input id='roll-input-adds' type='number' step='1' name='adds' value='0' />
+  </fieldset>
   {{/if}}
 
   {{#if showActorSelect}}
-    <fieldset class='form-group'>
-      <label for='char'>{{localize 'IRONSWORN.Character'}}</label>
-      <select name='char' id='char' class='select-character'>
-        {{#each allActors}}
-          <option value='{{id}}'>
-            {{name}}
-          </option>
-        {{/each}}
-      </select>
-    </fieldset>
+  <fieldset class='form-group'>
+    <label for='char'>{{localize 'IRONSWORN.Character'}}</label>
+    <select name='char' id='char' class='select-character'>
+      {{#each allActors}}
+      <option value='{{id}}'>
+        {{name}}
+      </option>
+      {{/each}}
+    </select>
+  </fieldset>
   {{/if}}
   {{! TODO: simple options from the move + actor assets }}
   <details class='advanced-roll-options'>
@@ -50,11 +44,7 @@
 
     <fieldset class='form-group'>
       <label class='checkbox'>
-        <input
-          type='checkbox'
-          class='advanced-roll-options-toggle'
-          name='automaticOutcome'
-        />
+        <input type='checkbox' class='advanced-roll-options-toggle' name='automaticOutcome' />
         {{localize 'IRONSWORN.RollDialog.PredeterminedOutcome'}}
       </label>
       <select name='automaticOutcomeValue'>
@@ -65,34 +55,20 @@
     </fieldset>
 
     {{#if action}}
-      <fieldset class='form-group'>
-        <label class='checkbox'>
-          <input
-            type='checkbox'
-            class='advanced-roll-options-toggle'
-            name='presetActionDie'
-          />
-          {{localize 'IRONSWORN.RollDialog.PresetActionDie'}}
-        </label>
-        <input type='number' step='1' name='presetActionDieValue' value='0' />
-      </fieldset>
+    <fieldset class='form-group'>
+      <label class='checkbox'>
+        <input type='checkbox' class='advanced-roll-options-toggle' name='presetActionDie' />
+        {{localize 'IRONSWORN.RollDialog.PresetActionDie'}}
+      </label>
+      <input type='number' step='1' name='presetActionDieValue' value='0' />
+    </fieldset>
     {{/if}}
     <fieldset class='form-group'>
       <label class='checkbox'>
-        <input
-          type='checkbox'
-          class='advanced-roll-options-toggle'
-          name='extraChallengeDice'
-        />
+        <input type='checkbox' class='advanced-roll-options-toggle' name='extraChallengeDice' />
         {{localize 'IRONSWORN.RollDialog.ExtraChallengeDice'}}
       </label>
-      <input
-        type='number'
-        step='1'
-        name='extraChallengeDiceValue'
-        value='0'
-        min='0'
-      />
+      <input type='number' step='1' name='extraChallengeDiceValue' value='0' min='0' />
     </fieldset>
 
   </details>


### PR DESCRIPTION
Updating the compact sheet to use the new rolling pipeline, and all the implications thereof.

- [x] Use IronswornPrerollDialog for rolls
- [x] Remove the "bonus" line of controls
- [x] Fix some layout issues
- [x] Clean up the code a bit
- [x] No more rolling +momentum
- [x] Update CHANGELOG.md

Before:

![CleanShot 2022-08-24 at 19 34 03](https://user-images.githubusercontent.com/39902/186562264-8cb9a6aa-b87f-48b0-b021-eda8545a0998.jpg)

After

![CleanShot 2022-08-24 at 19 44 03](https://user-images.githubusercontent.com/39902/186562389-ecf156b8-c4a6-4f1b-9a69-81a311467a85.jpg)

