### PR TITLE
Fix folder-reuse code to work in v10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- Fix a bug with creating duplicate folders with scene buttons in v10 ([#454](https://github.com/ben/foundry-ironsworn/pull/454))
 ## 1.17.3
 
 - Remove "Oracle NN:" from Ironsworn oracle names ([#453](https://github.com/ben/foundry-ironsworn/pull/453))

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -9,7 +9,9 @@ function warn() {
 // Make sure a folder exists, e.g. ['Locations', 'Sector 05']
 async function ensureFolder(...path: string[]): Promise<Folder | undefined> {
   let parentFolder: Folder | undefined
-  let directory: Folder[] | undefined = game.folders?.contents
+  let directory: Folder[] | undefined = game.folders?.filter(
+    (x) => x.type === 'Actor'
+  )
 
   for (const name of path) {
     if (directory === undefined) {
@@ -19,7 +21,7 @@ async function ensureFolder(...path: string[]): Promise<Folder | undefined> {
     const existing = directory.find((x) => x.name === name)
     if (existing) {
       parentFolder = existing
-      directory = (existing as any).children
+      directory = (existing as any).children.map((x) => x.folder)
       continue
     }
     parentFolder = await Folder.create({

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -21,7 +21,9 @@ async function ensureFolder(...path: string[]): Promise<Folder | undefined> {
     const existing = directory.find((x) => x.name === name)
     if (existing) {
       parentFolder = existing
-      directory = (existing as any).children.map((x) => x.folder)
+      directory = (existing as any).children.map((child) => {
+        return child.folder /* v10 */ || child /* v9 */
+      })
       continue
     }
     parentFolder = await Folder.create({


### PR DESCRIPTION
This fixes the scene button logic to, when creating new actors, actually place them in the named folder that's expected. The current code works in v9, but in v10 produces a new "Sector 01" folder every time something new is placed.

- [x] Fix the bug
- [x] Make it work in v9 again
- [x] Update CHANGELOG.md
