### PR TITLE
Resolve extra challenge dice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Add a dialog for resolving a roll with extra challenge dice ([#458](https://github.com/ben/foundry-ironsworn/pull/458))
+
 ## 1.17.6
 
 - Prevent progress tracks from having negative values

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -201,7 +201,7 @@ export class IronswornChatCard {
     ev.preventDefault()
 
     const msgId = $(ev.target).parents('.chat-message').data('message-id')
-    new ChallengeResolutionDialog(msgId).render(true)
+    ChallengeResolutionDialog.showForMessage(msgId)
   }
 
   async _oracleReroll(ev: JQuery.ClickEvent) {

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -201,7 +201,7 @@ export class IronswornChatCard {
     ev.preventDefault()
 
     const msgId = $(ev.target).parents('.chat-message').data('message-id')
-    ChallengeResolutionDialog.showForMessage(msgId)
+    new ChallengeResolutionDialog(msgId).render(true)
   }
 
   async _oracleReroll(ev: JQuery.ClickEvent) {

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -15,6 +15,7 @@ import { IronswornHandlebarsHelpers } from '../helpers/handlebars'
 import { cachedDocumentsForPack } from '../features/pack-cache'
 import { DfRollOutcome, RollOutcome } from '../rolls/ironsworn-roll'
 import { IronswornRollMessage, OracleRollMessage } from '../rolls'
+import { ChallengeResolutionDialog } from '../rolls/challenge-resolution-dialog'
 
 export class IronswornChatCard {
   id?: string | null
@@ -52,6 +53,9 @@ export class IronswornChatCard {
     html
       .find('.oracle-roll .oracle-reroll')
       .on('click', (ev) => this._oracleReroll.call(this, ev))
+    html
+      .find('.ironsworn-roll-resolve')
+      .on('click', (ev) => this._resolveChallenge.call(this, ev))
     html
       .find('.ironsworn__delvedepths__roll')
       .on('click', (ev) => this._delveDepths.call(this, ev))
@@ -191,6 +195,13 @@ export class IronswornChatCard {
     const msgId = $(ev.target).parents('.chat-message').data('message-id')
     const irmsg = await IronswornRollMessage.fromMessage(msgId)
     return irmsg?.burnMomentum()
+  }
+
+  async _resolveChallenge(ev: JQuery.ClickEvent) {
+    ev.preventDefault()
+
+    const msgId = $(ev.target).parents('.chat-message').data('message-id')
+    ChallengeResolutionDialog.showForMessage(msgId)
   }
 
   async _oracleReroll(ev: JQuery.ClickEvent) {

--- a/src/module/rolls/challenge-resolution-dialog.ts
+++ b/src/module/rolls/challenge-resolution-dialog.ts
@@ -33,7 +33,13 @@ export class ChallengeResolutionDialog extends Dialog {
     // Render the dialog
     const template =
       'systems/foundry-ironsworn/templates/rolls/challenge-resolution-dialog.hbs'
-    const renderData = { msg }
+    const renderData = {
+      msg,
+      dice: msg.roll.rawChallengeDiceValues!.map((x) => ({
+        value: x,
+        minmax: x === 1 ? 'min' : x === 10 ? 'max' : undefined,
+      })),
+    }
     const content = await renderTemplate(template, renderData)
     const buttons = {
       save: { label: 'Commit' },
@@ -44,5 +50,11 @@ export class ChallengeResolutionDialog extends Dialog {
       buttons,
       default: 'save',
     }).render(true)
+  }
+
+  activateListeners(html: JQuery<HTMLElement>): void {
+    super.activateListeners(html)
+
+    html.find('input:radio').on('change', console.log)
   }
 }

--- a/src/module/rolls/challenge-resolution-dialog.ts
+++ b/src/module/rolls/challenge-resolution-dialog.ts
@@ -3,7 +3,7 @@ import { VueApplication } from '../vue/vueapp'
 import VueDialog from '../vue/challenge-resolution-dialog.vue'
 
 export class ChallengeResolutionDialog extends VueApplication {
-  constructor(
+  private constructor(
     protected messageId: string,
     options?: Partial<ApplicationOptions>
   ) {

--- a/src/module/rolls/challenge-resolution-dialog.ts
+++ b/src/module/rolls/challenge-resolution-dialog.ts
@@ -38,6 +38,7 @@ export class ChallengeResolutionDialog extends VueApplication {
     return mergeObject(super.defaultOptions, {
       template:
         'systems/foundry-ironsworn/templates/rolls/challenge-resolution-dialog.hbs',
+      title: 'IRONSWORN.ResolveChallenge',
       width: 300,
       height: 280,
     })

--- a/src/module/rolls/challenge-resolution-dialog.ts
+++ b/src/module/rolls/challenge-resolution-dialog.ts
@@ -17,7 +17,7 @@ export class ChallengeResolutionDialog extends VueApplication {
       template:
         'systems/foundry-ironsworn/templates/rolls/challenge-resolution-dialog.hbs',
       width: 300,
-      height: 250,
+      height: 280,
     })
   }
 

--- a/src/module/rolls/challenge-resolution-dialog.ts
+++ b/src/module/rolls/challenge-resolution-dialog.ts
@@ -1,5 +1,3 @@
-import { IronswornRollMessage } from '.'
-import { IronswornSettings } from '../helpers/settings'
 import { VueSheetRenderHelperOptions } from '../vue/vue-render-helper'
 import { VueApplication } from '../vue/vueapp'
 import VueDialog from '../vue/challenge-resolution-dialog.vue'
@@ -10,6 +8,21 @@ export class ChallengeResolutionDialog extends VueApplication {
     options?: Partial<ApplicationOptions>
   ) {
     super(options)
+  }
+
+  static async showForMessage(messageId: string) {
+    const foundryMessage = game.messages?.get(messageId)
+    const el = await foundryMessage?.getHTML()
+    if (!el) return
+
+    console.log({
+      left: window.innerWidth - 620,
+      top: Math.min(el[0].offsetTop, window.innerHeight - 300),
+    })
+    return new ChallengeResolutionDialog(messageId, {
+      left: window.innerWidth - 620,
+      top: Math.min(el[0].offsetTop, window.innerHeight - 300),
+    }).render(true)
   }
 
   static get defaultOptions() {

--- a/src/module/rolls/challenge-resolution-dialog.ts
+++ b/src/module/rolls/challenge-resolution-dialog.ts
@@ -1,60 +1,30 @@
 import { IronswornRollMessage } from '.'
 import { IronswornSettings } from '../helpers/settings'
+import { VueSheetRenderHelperOptions } from '../vue/vue-render-helper'
+import { VueApplication } from '../vue/vueapp'
+import VueDialog from '../vue/challenge-resolution-dialog.vue'
 
-export async function showChallengeResolutionDialog(messageId: string) {
-  const msg = await IronswornRollMessage.fromMessage(messageId)
-  if (!msg) return
+export class ChallengeResolutionDialog extends VueApplication {
+  constructor(
+    protected messageId: string,
+    options?: Partial<ApplicationOptions>
+  ) {
+    super(options)
+  }
 
-  // Bail if the roll is fully resolved
-  if (!msg.roll.preRollOptions.extraChallengeDice) return
-  const { replacedChallenge1, replacedChallenge2 } = msg.roll.postRollOptions
-  if (replacedChallenge1 && replacedChallenge2) return
-
-  // Render the dialog
-}
-
-export class ChallengeResolutionDialog extends Dialog {
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
-      classes: ['ironsworn', 'dialog', `theme-${IronswornSettings.theme}`],
+      template:
+        'systems/foundry-ironsworn/templates/rolls/challenge-resolution-dialog.hbs',
       width: 300,
+      height: 250,
     })
   }
 
-  static async showForMessage(messageId: string) {
-    const msg = await IronswornRollMessage.fromMessage(messageId)
-    if (!msg) return
-
-    // Bail if the roll is fully resolved
-    if (!msg.roll.preRollOptions.extraChallengeDice) return
-    const { replacedChallenge1, replacedChallenge2 } = msg.roll.postRollOptions
-    if (replacedChallenge1 && replacedChallenge2) return
-
-    // Render the dialog
-    const template =
-      'systems/foundry-ironsworn/templates/rolls/challenge-resolution-dialog.hbs'
-    const renderData = {
-      msg,
-      dice: msg.roll.rawChallengeDiceValues!.map((x) => ({
-        value: x,
-        minmax: x === 1 ? 'min' : x === 10 ? 'max' : undefined,
-      })),
+  get renderHelperOptions(): Partial<VueSheetRenderHelperOptions> {
+    return {
+      components: { 'challenge-resolution-dialog': VueDialog },
+      vueData: async () => ({ messageId: this.messageId }),
     }
-    const content = await renderTemplate(template, renderData)
-    const buttons = {
-      save: { label: 'Commit' },
-    }
-    return new ChallengeResolutionDialog({
-      title: 'Challenge Dice',
-      content,
-      buttons,
-      default: 'save',
-    }).render(true)
-  }
-
-  activateListeners(html: JQuery<HTMLElement>): void {
-    super.activateListeners(html)
-
-    html.find('input:radio').on('change', console.log)
   }
 }

--- a/src/module/rolls/challenge-resolution-dialog.ts
+++ b/src/module/rolls/challenge-resolution-dialog.ts
@@ -12,16 +12,12 @@ export class ChallengeResolutionDialog extends VueApplication {
 
   static async showForMessage(messageId: string) {
     const foundryMessage = game.messages?.get(messageId)
-    const el = await foundryMessage?.getHTML()
+    const el = $(`.chat-message[data-message-id="${messageId}"`)
     if (!el) return
 
-    console.log({
-      left: window.innerWidth - 620,
-      top: Math.min(el[0].offsetTop, window.innerHeight - 300),
-    })
     return new ChallengeResolutionDialog(messageId, {
       left: window.innerWidth - 620,
-      top: Math.min(el[0].offsetTop, window.innerHeight - 300),
+      top: Math.min(el[0].offsetTop - 50, window.innerHeight - 300),
     }).render(true)
   }
 

--- a/src/module/rolls/challenge-resolution-dialog.ts
+++ b/src/module/rolls/challenge-resolution-dialog.ts
@@ -1,0 +1,48 @@
+import { IronswornRollMessage } from '.'
+import { IronswornSettings } from '../helpers/settings'
+
+export async function showChallengeResolutionDialog(messageId: string) {
+  const msg = await IronswornRollMessage.fromMessage(messageId)
+  if (!msg) return
+
+  // Bail if the roll is fully resolved
+  if (!msg.roll.preRollOptions.extraChallengeDice) return
+  const { replacedChallenge1, replacedChallenge2 } = msg.roll.postRollOptions
+  if (replacedChallenge1 && replacedChallenge2) return
+
+  // Render the dialog
+}
+
+export class ChallengeResolutionDialog extends Dialog {
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      classes: ['ironsworn', 'dialog', `theme-${IronswornSettings.theme}`],
+      width: 300,
+    })
+  }
+
+  static async showForMessage(messageId: string) {
+    const msg = await IronswornRollMessage.fromMessage(messageId)
+    if (!msg) return
+
+    // Bail if the roll is fully resolved
+    if (!msg.roll.preRollOptions.extraChallengeDice) return
+    const { replacedChallenge1, replacedChallenge2 } = msg.roll.postRollOptions
+    if (replacedChallenge1 && replacedChallenge2) return
+
+    // Render the dialog
+    const template =
+      'systems/foundry-ironsworn/templates/rolls/challenge-resolution-dialog.hbs'
+    const renderData = { msg }
+    const content = await renderTemplate(template, renderData)
+    const buttons = {
+      save: { label: 'Commit' },
+    }
+    return new ChallengeResolutionDialog({
+      title: 'Challenge Dice',
+      content,
+      buttons,
+      default: 'save',
+    }).render(true)
+  }
+}

--- a/src/module/rolls/challenge-resolution-dialog.ts
+++ b/src/module/rolls/challenge-resolution-dialog.ts
@@ -10,15 +10,28 @@ export class ChallengeResolutionDialog extends VueApplication {
     super(options)
   }
 
+  static openDialogs = {} as { [k: string]: ChallengeResolutionDialog }
+
   static async showForMessage(messageId: string) {
-    const foundryMessage = game.messages?.get(messageId)
+    // Prevent duplicates
+    if (this.openDialogs[messageId]) {
+      return this.openDialogs[messageId].render(true)
+    }
+
     const el = $(`.chat-message[data-message-id="${messageId}"`)
     if (!el) return
 
-    return new ChallengeResolutionDialog(messageId, {
+    this.openDialogs[messageId] = new ChallengeResolutionDialog(messageId, {
       left: window.innerWidth - 620,
       top: Math.min(el[0].offsetTop - 50, window.innerHeight - 300),
     }).render(true)
+
+    return this.openDialogs[messageId]
+  }
+
+  close(options?: {}): Promise<void> {
+    delete ChallengeResolutionDialog.openDialogs[this.messageId]
+    return super.close(options)
   }
 
   static get defaultOptions() {

--- a/src/module/rolls/ironsworn-roll-message.ts
+++ b/src/module/rolls/ironsworn-roll-message.ts
@@ -172,10 +172,7 @@ export class IronswornRollMessage {
 
     // console.log('sent renderData', renderData)
     const renderData = {
-      graphic: await renderRollGraphic(
-        { ...this.roll.preRollOptions, showOutcome: false },
-        this.roll
-      ),
+      graphic: await renderRollGraphic({ roll: this.roll, hideOutcome: true }),
       ironswornroll: this.roll.serialize(),
       move: await this.roll.moveItem,
       ...(await this.titleData()),

--- a/src/module/rolls/ironsworn-roll-message.ts
+++ b/src/module/rolls/ironsworn-roll-message.ts
@@ -177,6 +177,7 @@ export class IronswornRollMessage {
       move: await this.roll.moveItem,
       ...(await this.titleData()),
       ...(await this.moveData()),
+      ...(await this.challengeDiceData()),
       ...(await this.momentumData()),
       ...(await this.oraclesData()),
     }
@@ -261,6 +262,17 @@ export class IronswornRollMessage {
       ret.moveOutcome = dfOutcome.Text
     }
     return ret
+  }
+
+  private challengeDiceData() {
+    // Only continue if this roll needs manual resolution
+    if (!this.roll.preRollOptions.extraChallengeDice) return {}
+    const { replacedChallenge1, replacedChallenge2 } = this.roll.postRollOptions
+    if (replacedChallenge1 && replacedChallenge2) return {}
+
+    return {
+      unresolved: true,
+    }
   }
 
   private momentumData() {

--- a/src/module/rolls/ironsworn-roll-message.ts
+++ b/src/module/rolls/ironsworn-roll-message.ts
@@ -161,7 +161,7 @@ export class IronswornRollMessage {
 
     await this.actor.burnMomentum()
     this.roll.postRollOptions.replacedOutcome = {
-      value: computeRollOutcome(momentum, c1, c2),
+      value: computeRollOutcome(momentum, c1.value, c2.value),
       source: game.i18n.localize('IRONSWORN.MomentumBurnt'),
     }
     return this.createOrUpdate()
@@ -295,7 +295,7 @@ export class IronswornRollMessage {
       return {
         possibleMomentumBurn: computeOutcomeText(
           momentumBurnOutcome,
-          c1 === c2
+          c1.value === c2.value
         ),
       }
     }

--- a/src/module/rolls/ironsworn-roll.ts
+++ b/src/module/rolls/ironsworn-roll.ts
@@ -134,10 +134,6 @@ export interface PreRollOptions {
    */
   moveDfId?: string
   actorId?: string
-  /**
-   * Whether to render the outcome info inside the roll graphic.
-   */
-  showOutcome?: boolean
 }
 
 // Input to rendering, can be updated after the fact

--- a/src/module/rolls/ironsworn-roll.ts
+++ b/src/module/rolls/ironsworn-roll.ts
@@ -5,7 +5,7 @@
 // - Rolling that plays nicer with DF Manual Rolls (all in one go, not {d6+N,d10,d10})
 // - Rerolls update chat message
 
-import { compact, pick, range, sum } from 'lodash'
+import { cloneDeep, compact, pick, range, sum } from 'lodash'
 import { getFoundryMoveByDfId } from '../dataforged'
 import { IronswornItem } from '../item/item'
 import { computeRollOutcome } from './ironsworn-roll-message'
@@ -405,5 +405,10 @@ export class IronswornRoll {
     const ir = new IronswornRoll()
     Object.assign(ir, json)
     return ir
+  }
+
+  clone(): IronswornRoll {
+    const json = this.serialize()
+    return IronswornRoll.fromJson(cloneDeep(json))
   }
 }

--- a/src/module/rolls/ironsworn-roll.ts
+++ b/src/module/rolls/ironsworn-roll.ts
@@ -353,16 +353,19 @@ export class IronswornRoll {
   }
 
   // Either [N,N] or undefined
-  get finalChallengeDice(): undefined | [number, number] {
+  get finalChallengeDice(): undefined | [SourcedValue, SourcedValue] {
     const replaced = compact([
       this.postRollOptions.replacedChallenge1,
       this.postRollOptions.replacedChallenge2,
     ])
     if (replaced.length === 2) {
-      return replaced.map((x) => x.value) as [number, number]
+      return replaced as [SourcedValue, SourcedValue]
     }
     if (this.rawChallengeDiceValues?.length === 2) {
-      return this.rawChallengeDiceValues as [number, number]
+      return this.rawChallengeDiceValues.map((d) => ({
+        source: 'd10',
+        value: d,
+      })) as [SourcedValue, SourcedValue]
     }
     return undefined
   }
@@ -370,7 +373,7 @@ export class IronswornRoll {
   get isMatch(): boolean {
     if (!this.finalChallengeDice) return false
     const [c1, c2] = this.finalChallengeDice ?? []
-    return typeof c1 === 'number' && c1 === c2
+    return c1 !== undefined && c1.value === c2.value
   }
 
   get rawOutcome(): SourcedValue<RollOutcome> | undefined {
@@ -380,7 +383,7 @@ export class IronswornRoll {
     if (!this.finalChallengeDice || this.score === undefined) return undefined
 
     const [c1, c2] = this.finalChallengeDice
-    const outcome = computeRollOutcome(this.score, c1, c2)
+    const outcome = computeRollOutcome(this.score, c1.value, c2.value)
     return {
       value: outcome,
       source: game.i18n.localize('IRONSWORN.Roll'),

--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -347,8 +347,9 @@ export class IronswornPrerollDialog extends Dialog<
     await msg.createOrUpdate()
 
     // Show resolution dialog if needed
-    if (r.preRollOptions.extraChallengeDice)
-      new ChallengeResolutionDialog(msg.roll.chatMessageId!).render(true)
+    if (r.preRollOptions.extraChallengeDice) {
+      ChallengeResolutionDialog.showForMessage(msg.roll.chatMessageId ?? '')
+    }
   }
 
   private static async renderContent(data: {

--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -348,7 +348,7 @@ export class IronswornPrerollDialog extends Dialog<
 
     // Show resolution dialog if needed
     if (r.preRollOptions.extraChallengeDice)
-      ChallengeResolutionDialog.showForMessage(msg.roll.chatMessageId)
+      new ChallengeResolutionDialog(msg.roll.chatMessageId!).render(true)
   }
 
   private static async renderContent(data: {

--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -16,6 +16,7 @@ import { renderRollGraphic } from './roll-graphic'
 import { CharacterDataProperties } from '../actor/actortypes'
 import { IronswornRollMessage } from '.'
 import { formatRollPlusStat } from './ironsworn-roll-message.js'
+import { ChallengeResolutionDialog } from './challenge-resolution-dialog'
 
 export function localeCapitalize(str: string) {
   const locale = game.i18n.lang
@@ -335,14 +336,19 @@ export class IronswornPrerollDialog extends Dialog<
     }).render(true)
   }
 
-  private static submitRoll(
+  private static async submitRoll(
     el: HTMLElement | JQuery<HTMLElement>,
     opts: PreRollOptions
   ) {
     const realOpts = prerollOptionsWithFormData($(el).find('form'), opts)
 
     const r = new IronswornRoll(realOpts)
-    return new IronswornRollMessage(r).createOrUpdate()
+    const msg = new IronswornRollMessage(r)
+    await msg.createOrUpdate()
+
+    // Show resolution dialog if needed
+    if (r.preRollOptions.extraChallengeDice)
+      ChallengeResolutionDialog.showForMessage(msg.roll.chatMessageId)
   }
 
   private static async renderContent(data: {

--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -353,15 +353,12 @@ export class IronswornPrerollDialog extends Dialog<
     showActorSelect?: boolean
     action?: boolean
   }): Promise<string> {
-    const newOptions = {
-      ...data.prerollOptions,
-      showOutcome: true,
-    }
-    console.log('preroll render options', newOptions)
-    const graphic = await renderRollGraphic(newOptions)
+    const graphic = await renderRollGraphic({
+      preRollOptions: data.prerollOptions,
+    })
     const template =
       'systems/foundry-ironsworn/templates/rolls/preroll-dialog.hbs'
-    return renderTemplate(template, { ...data, graphic, showOutcome: true })
+    return renderTemplate(template, { ...data, graphic })
   }
 
   activateListeners(html: JQuery<HTMLElement>): void {
@@ -380,7 +377,7 @@ export class IronswornPrerollDialog extends Dialog<
         this.element.find('form'),
         this.prerollOptions
       )
-      const graphic = await renderRollGraphic(pro)
+      const graphic = await renderRollGraphic({ preRollOptions: pro })
       this.element.find('.roll-graphic').replaceWith(graphic)
     }
     html.find('input').on('change', rerender)

--- a/src/module/rolls/roll-graphic.ts
+++ b/src/module/rolls/roll-graphic.ts
@@ -96,6 +96,5 @@ export async function renderRollGraphic(opts: RollGraphicRenderOpts) {
   }
   const graphicTemplate =
     'systems/foundry-ironsworn/templates/rolls/roll-graphic.hbs'
-  console.log('data to be passed to renderTemplate', renderData)
   return renderTemplate(graphicTemplate, renderData)
 }

--- a/src/module/rolls/roll-graphic.ts
+++ b/src/module/rolls/roll-graphic.ts
@@ -72,16 +72,7 @@ export async function renderRollGraphic(opts: RollGraphicRenderOpts) {
 
   renderData.challengeDice = opts.roll.challengeDice
   if (opts.roll.finalChallengeDice) {
-    renderData.challengeDice = [
-      {
-        source: opts.roll.challengeDice[0]?.source,
-        value: opts.roll.finalChallengeDice[0],
-      },
-      {
-        source: opts.roll.challengeDice[1]?.source,
-        value: opts.roll.finalChallengeDice[1],
-      },
-    ]
+    renderData.challengeDice = opts.roll.finalChallengeDice
   }
   for (const c of renderData.challengeDice ?? []) {
     if (c.value === 1) c.minmax = 'min'

--- a/src/module/vue/challenge-resolution-dialog.vue
+++ b/src/module/vue/challenge-resolution-dialog.vue
@@ -1,0 +1,92 @@
+<template>
+  <form class="challenge-resolution-dialog flexcol" style="flex-grow: 1">
+    <div class="grid" style="margin: 1em; justify-items: center; flex-grow: 1">
+      <div class="flexrow" v-for="(row, i) in state.rows" :key="`row${i}`">
+        <input
+          type="radio"
+          class="a"
+          :checked="row.choice === 'a'"
+          @change="update(i, 'a')"
+        />
+        <div class="ironsworn-roll roll-graphic dice-formula">
+          <span
+            class="roll die isiconbg-d10-blank d10 challenge challenge-die {{minmax}}"
+          >
+            {{ row.dieValue }}
+          </span>
+        </div>
+        <input
+          type="radio"
+          class="b"
+          :checked="row.choice === 'b'"
+          @change="update(i, 'b')"
+        />
+      </div>
+    </div>
+    <div
+      class="boxgroup"
+      style="margin-top: 1rem"
+      :data-tooltip="saveDisabled ? 'Make valid choices' : undefined"
+    >
+      <div class="boxrow flexrow">
+        <button
+          class="clickable block save"
+          :class="{ disabled: saveDisabled }"
+        >
+          <i class="fas fa-check"></i>
+          {{ $t('Save') }}
+        </button>
+      </div>
+    </div>
+  </form>
+</template>
+
+<style lang="less" scoped>
+input {
+  margin: 7px;
+  width: 30px;
+  &.a {
+    grid-column: 1;
+    justify-self: end;
+  }
+
+  &.b {
+    grid-column: 3;
+    justify-self: start;
+  }
+}
+</style>
+
+<script setup lang="ts">
+import { isArrayLikeObject } from 'lodash'
+import { computed, reactive } from 'vue'
+import { IronswornRollMessage } from '../rolls'
+
+const props = defineProps<{ messageId: string }>()
+const irm = await IronswornRollMessage.fromMessage(props.messageId)
+
+type AOrB = 'a' | '' | 'b'
+const state = reactive({
+  rows:
+    irm?.roll.rawChallengeDiceValues?.map((d) => ({
+      dieValue: d,
+      choice: '' as AOrB,
+    })) ?? [],
+})
+
+function update(i: number, value: AOrB) {
+  // Clear others of this choice
+  for (const row of state.rows) {
+    if (row.choice === value) row.choice = ''
+  }
+
+  // Set this choice
+  state.rows[i].choice = value
+}
+
+const saveDisabled = computed(() => {
+  const hasA = !!state.rows.find((x) => x.choice === 'a')
+  const hasB = !!state.rows.find((x) => x.choice === 'b')
+  return !(hasA && hasB)
+})
+</script>

--- a/src/module/vue/challenge-resolution-dialog.vue
+++ b/src/module/vue/challenge-resolution-dialog.vue
@@ -1,6 +1,6 @@
 <template>
   <form class="challenge-resolution-dialog flexcol" style="flex-grow: 1">
-    <div class="grid" style="margin: 1em; justify-items: center; flex-grow: 1">
+    <div class="grid">
       <div class="flexrow" v-for="(row, i) in state.rows" :key="`row${i}`">
         <input
           type="radio"
@@ -42,9 +42,16 @@
 </template>
 
 <style lang="less" scoped>
+div.grid {
+  margin: 1em;
+  justify-items: center;
+  flex-grow: 1;
+}
+
 input {
   margin: 7px;
   width: 30px;
+
   &.a {
     grid-column: 1;
     justify-self: end;

--- a/src/module/vue/challenge-resolution-dialog.vue
+++ b/src/module/vue/challenge-resolution-dialog.vue
@@ -32,7 +32,9 @@
     <div
       class="boxgroup"
       style="margin-top: 1rem"
-      :data-tooltip="saveDisabled ? 'Make valid choices' : undefined"
+      :data-tooltip="
+        saveDisabled ? $t('IRONSWORN.ResolveChallengeDisabled') : undefined
+      "
     >
       <div class="boxrow flexrow">
         <button

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -134,6 +134,7 @@
     "Burn": "Burn",
     "Focus": "Focus",
     "ResolveChallenge": "Resolve Challenge",
+    "ResolveChallengeDisabled": "Choose your final two challenge dice",
     "BurnForUpgrade": "Burn momentum: <strong>{type}</strong>",
     "MomentumBurnt": "Momentum Burn",
     "NegativeMomentumCancel": "Negative momentum canceled action die",

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -133,6 +133,7 @@
     "RandomName": "Random name",
     "Burn": "Burn",
     "Focus": "Focus",
+    "ResolveChallenge": "Resolve Challenge",
     "BurnForUpgrade": "Burn momentum: <strong>{type}</strong>",
     "MomentumBurnt": "Momentum Burn",
     "NegativeMomentumCancel": "Negative momentum canceled action die",

--- a/system/templates/rolls/challenge-resolution-dialog.hbs
+++ b/system/templates/rolls/challenge-resolution-dialog.hbs
@@ -1,3 +1,17 @@
 <form class="challenge-resolution-dialog">
-  <h1>resolve it</h1>
+  {{log this}}
+
+  <div class="grid" style="margin: 1em; justify-items: center">
+    {{#each dice}}
+    <input style="grid-column:1; margin: 7px; width: 30px; justify-self: end" type="radio" name="die1"
+      id="{{@index}}" />
+    <div class="ironsworn-roll roll-graphic dice-formula">
+      <span class="roll die isiconbg-d10-blank d10 challenge challenge-die {{minmax}}">
+        {{value}}
+      </span>
+    </div>
+    <input style="grid-column:3; margin: 7px; width: 30px; justify-self: start" type="radio" name="die2"
+      id="{{@index}}" />
+    {{/each}}
+  </div>
 </form>

--- a/system/templates/rolls/challenge-resolution-dialog.hbs
+++ b/system/templates/rolls/challenge-resolution-dialog.hbs
@@ -1,0 +1,3 @@
+<form class="challenge-resolution-dialog">
+  <h1>resolve it</h1>
+</form>

--- a/system/templates/rolls/challenge-resolution-dialog.hbs
+++ b/system/templates/rolls/challenge-resolution-dialog.hbs
@@ -1,17 +1,7 @@
-<form class="challenge-resolution-dialog">
-  {{log this}}
-
-  <div class="grid" style="margin: 1em; justify-items: center">
-    {{#each dice}}
-    <input style="grid-column:1; margin: 7px; width: 30px; justify-self: end" type="radio" name="die1"
-      id="{{@index}}" />
-    <div class="ironsworn-roll roll-graphic dice-formula">
-      <span class="roll die isiconbg-d10-blank d10 challenge challenge-die {{minmax}}">
-        {{value}}
-      </span>
-    </div>
-    <input style="grid-column:3; margin: 7px; width: 30px; justify-self: start" type="radio" name="die2"
-      id="{{@index}}" />
-    {{/each}}
-  </div>
+<form class="challenge-resolution-dialog vueroot" style="height: 100%" autocomplete="off">
+  <Suspense>
+    <challenge-resolution-dialog :message-id="data.messageId">
+      Whoops, an error occurred.
+    </challenge-resolution-dialog>
+  </Suspense>
 </form>

--- a/system/templates/rolls/ironsworn-roll-message.hbs
+++ b/system/templates/rolls/ironsworn-roll-message.hbs
@@ -1,7 +1,4 @@
-<article
-  class='ironsworn-roll flexcol'
-  data-ironswornroll='{{json ironswornroll}}'
->
+<article class='ironsworn-roll flexcol' data-ironswornroll='{{json ironswornroll}}'>
   <h3 class='ironsworn-roll-title'>
     {{title}}
   </h3>
@@ -13,9 +10,9 @@
   <section class='roll-outcome {{outcomeClass}}'>
     <h4 class='outcome-label' title='{{outcome.source}}'>
       {{#if outcomeReplacementReason}}
-        <span class='outcome-replacement-reason'>
-          {{outcomeReplacementReason}}:&nbsp;<wbr />
-        </span>
+      <span class='outcome-replacement-reason'>
+        {{outcomeReplacementReason}}:&nbsp;<wbr />
+      </span>
       {{/if}}
       <span class='outcome-text'>
         {{outcomeText}}
@@ -23,37 +20,39 @@
     </h4>
 
     {{#if moveOutcome}}
-      <section class='move-outcome'>
-        {{{enrichMarkdown moveOutcome}}}
-      </section>
+    <section class='move-outcome'>
+      {{{enrichMarkdown moveOutcome}}}
+    </section>
     {{/if}}
   </section>
 
   <section class='outcome-shortcuts'>
+    {{#if unresolved}}
+    <section class="resolve">
+      <button class='icon-button isicon-d10-tilt ironsworn-roll-resolve' type='button'>
+        <span class='button-text'>
+          {{localize 'IRONSWORN.ResolveChallenge'}}
+        </span>
+      </button>
+    </section>
+    {{/if}}
     {{#if possibleMomentumBurn}}
-      <section class='momentum-burn'>
-        <button
-          class='icon-button fas fa-fire ironsworn-roll-burn-momentum'
-          type='button'
-        >
-          <span class='button-text'>
-            {{{localize 'IRONSWORN.BurnForUpgrade' type=possibleMomentumBurn}}}
-          </span>
-        </button>
-      </section>
+    <section class='momentum-burn'>
+      <button class='icon-button fas fa-fire ironsworn-roll-burn-momentum' type='button'>
+        <span class='button-text'>
+          {{{localize 'IRONSWORN.BurnForUpgrade' type=possibleMomentumBurn}}}
+        </span>
+      </button>
+    </section>
     {{/if}}
     {{#if nextOracles}}
-      <section class='move-oracle-buttons'>
-        {{#each nextOracles}}
-          <button
-            class='starforged__oracle__roll icon-button isicon-d10-tilt'
-            type='button'
-            data-tableid='{{id}}'
-          >
-            <span class='button-text'>{{name}}</span>
-          </button>
-        {{/each}}
-      </section>
+    <section class='move-oracle-buttons'>
+      {{#each nextOracles}}
+      <button class='starforged__oracle__roll icon-button isicon-d10-tilt' type='button' data-tableid='{{id}}'>
+        <span class='button-text'>{{name}}</span>
+      </button>
+      {{/each}}
+    </section>
     {{/if}}
   </section>
 </article>

--- a/system/templates/rolls/roll-graphic.hbs
+++ b/system/templates/rolls/roll-graphic.hbs
@@ -1,11 +1,14 @@
-<article class="roll-graphic dice-formula{{#unless isProgress}} action-roll-formula{{else}} progress-roll-formula{{/unless}}">
+<article
+  class="roll-graphic dice-formula{{#unless isProgress}} action-roll-formula{{else}} progress-roll-formula{{/unless}}">
   {{!-- The action die or progress score --}}
 
   {{#unless isProgress}}
-    {{#if actionDieCanceledByNegativeMomentum}}
-    <del class="roll-term-cancelled">
+  {{#if actionDieCanceledByNegativeMomentum}}
+  <del class="roll-term-cancelled">
     {{/if}}
-    <span class="action-die die action roll d6 isiconbg-d6-blank {{actionMinMax}}{{#unless computedActionDie.value}}indeterminate-value{{/unless}}" title="{{computedActionDie.source}}">
+    <span
+      class="action-die die action roll d6 isiconbg-d6-blank {{actionMinMax}}{{#unless computedActionDie.value}}indeterminate-value{{/unless}}"
+      title="{{computedActionDie.source}}">
       {{#if computedActionDie.value}}
       {{computedActionDie.value}}
       {{else}}
@@ -13,28 +16,28 @@
       {{/if}}
     </span>
     {{#if actionDieCanceledByNegativeMomentum}}
-    </del>
-    {{/if}}
+  </del>
+  {{/if}}
 
-    {{#each adds}}
-      <span class="math-symbol">&plus;</span>
-      <span title="{{source}}" class="action-roll-add">{{value}}</span>
-    {{/each}}
+  {{#each adds}}
+  <span class="math-symbol">&plus;</span>
+  <span title="{{source}}" class="action-roll-add">{{value}}</span>
+  {{/each}}
 
-    {{#unless adds.[1]}}
-      <span class="math-symbol">&plus;</span>
-      <span title="{{source}}" class="action-roll-add">0</span>
-    {{/unless}}
-    <span class="math-symbol">&equals;</span>
+  {{#unless adds.[1]}}
+  <span class="math-symbol">&plus;</span>
+  <span title="{{source}}" class="action-roll-add">0</span>
+  {{/unless}}
+  <span class="math-symbol">&equals;</span>
   {{/unless}}
 
-  <span class="score{{#if actionScoreCapped}} action-score-capped{{/if}}{{#unless score}} indeterminate-value{{/unless}}"
-  title="{{#if actionScoreCapped}}{{localize 'IRONSWORN.CappedAt10'}}{{/if}}"
-  >
+  <span
+    class="score{{#if actionScoreCapped}} action-score-capped{{/if}}{{#unless score}} indeterminate-value{{/unless}}"
+    title="{{#if actionScoreCapped}}{{localize 'IRONSWORN.CappedAt10'}}{{/if}}">
     {{#if score}}
-      {{score}}
-      {{else}}
-      ?
+    {{score}}
+    {{else}}
+    ?
     {{/if}}
   </span>
 
@@ -44,7 +47,9 @@
 
   <div class="challenge-dice{{#if isMatch}} match{{/if}}">
     {{#each challengeDice}}
-    <span class="roll die isiconbg-d10-blank d10 challenge challenge-die {{minmax}}{{#unless value}}indeterminate-value{{/unless}}" title="{{source}}">
+    <span
+      class="roll die isiconbg-d10-blank d10 challenge challenge-die {{minmax}}{{#unless value}}indeterminate-value{{/unless}}"
+      title="{{source}}">
       {{#if value}}
       {{value}}
       {{else}}
@@ -54,17 +59,14 @@
     {{/each}}
   </div>
 
-  {{#if showOutcome}}
-    {{#if outcome}}
-      <div class="outcome-label">
-        <i class="fa fa-arrow-right"></i>
-        <span class="outcome-text">
-          {{{computeOutcomeText outcome.value false}}}
-        </span>
-      </div>
-    {{/if}}
+  {{#unless hideOutcome}}
+  {{#if outcome}}
+  <div class="outcome-label">
+    <i class="fa fa-arrow-right"></i>
+    <span class="outcome-text">
+      {{{computeOutcomeText outcome.value false}}}
+    </span>
+  </div>
   {{/if}}
-{{!-- <pre><code>{{json this}}</code></pre> --}}
+  {{/unless}}
 </article>
-
-

--- a/system/templates/rolls/roll-graphic.hbs
+++ b/system/templates/rolls/roll-graphic.hbs
@@ -1,5 +1,5 @@
 <article
-  class="roll-graphic dice-formula{{#unless isProgress}} action-roll-formula{{else}} progress-roll-formula{{/unless}}">
+  class="roll-graphic dice-formula {{#unless isProgress}}action-roll-formula{{else}}progress-roll-formula{{/unless}}">
   {{!-- The action die or progress score --}}
 
   {{#unless isProgress}}
@@ -7,7 +7,7 @@
   <del class="roll-term-cancelled">
     {{/if}}
     <span
-      class="action-die die action roll d6 isiconbg-d6-blank {{actionMinMax}}{{#unless computedActionDie.value}}indeterminate-value{{/unless}}"
+      class="action-die die action roll d6 isiconbg-d6-blank {{actionMinMax}} {{#unless computedActionDie.value}}indeterminate-value{{/unless}}"
       title="{{computedActionDie.source}}">
       {{#if computedActionDie.value}}
       {{computedActionDie.value}}
@@ -32,7 +32,7 @@
   {{/unless}}
 
   <span
-    class="score{{#if actionScoreCapped}} action-score-capped{{/if}}{{#unless score}} indeterminate-value{{/unless}}"
+    class="score {{#if actionScoreCapped}}action-score-capped{{/if}} {{#unless score}}indeterminate-value{{/unless}}"
     title="{{#if actionScoreCapped}}{{localize 'IRONSWORN.CappedAt10'}}{{/if}}">
     {{#if score}}
     {{score}}
@@ -45,10 +45,10 @@
     {{localize 'IRONSWORN.Versus'}}
   </span>
 
-  <div class="challenge-dice{{#if isMatch}} match{{/if}}">
+  <div class="challenge-dice {{#if isMatch}}match{{/if}}">
     {{#each challengeDice}}
     <span
-      class="roll die isiconbg-d10-blank d10 challenge challenge-die {{minmax}}{{#unless value}}indeterminate-value{{/unless}}"
+      class="roll die isiconbg-d10-blank d10 challenge challenge-die {{minmax}} {{#unless value}}indeterminate-value{{/unless}}"
       title="{{source}}">
       {{#if value}}
       {{value}}


### PR DESCRIPTION
In #422 we added the capability of adding extra challenge dice. This adds the capability for the player to resolve and finalize that after the roll. Fixes #444.

- [x] Refactor the graphic-rendering code a bit
- [x] Make a dialog for choosing the final challenge dice
- [x] Add a button to unresolved roll messages that opens the dialog
- [x] Open the dialog automatically when finishing a roll that needs it
- [x] Update CHANGELOG.md
