### PR TITLE
Move oracles improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Release
 
+- Improvements to oracles ([#463](https://github.com/ben/foundry-ironsworn/pull/463)):
+  - Right-clicking on a move-result chat card will now display shortcuts for rolling oracles if any are mentioned
+  - The move sheet now uses the standard oracle control for in-move oracles, which makes them more compact, and saves a click and some chat space if you just want to roll the oracle
+
 ## 1.17.10
 
 - Fix momentum calculation

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -314,7 +314,13 @@ export class IronswornChatCard {
     const isPack = game.packs.get('foundry-ironsworn.ironswornoracles')
     const table = ((await sfPack?.getDocument(tableid)) ??
       (await isPack?.getDocument(tableid))) as RollTable | undefined
-    rollAndDisplayOracleResult(table, table?.pack || undefined)
+    if (!table?.id) return
+
+    const msg = await OracleRollMessage.fromTableId(
+      table.id,
+      table.pack || undefined
+    )
+    msg.createOrUpdate()
   }
 
   async _sfOracleReroll(ev: JQuery.ClickEvent) {
@@ -329,7 +335,13 @@ export class IronswornChatCard {
 
     const tableId = parent.data('table-id')
     const table = await pack?.getDocument(tableId)
-    rollAndDisplayOracleResult(table as RollTable, packName)
+    if (!table?.id) return
+
+    const msg = await OracleRollMessage.fromTableId(
+      table.id,
+      table.pack || undefined
+    )
+    msg.createOrUpdate()
   }
 
   async replaceSelectorWith(

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -90,7 +90,7 @@ async function walkOracleCategory(
   return node
 }
 
-async function walkOracle(oracle: IOracle): Promise<IOracleTreeNode> {
+export async function walkOracle(oracle: IOracle): Promise<IOracleTreeNode> {
   const table = await getFoundryTableByDfId(oracle.$id)
 
   const node: IOracleTreeNode = {
@@ -166,7 +166,7 @@ async function augmentWithFolderContents(node: IOracleTreeNode) {
   walkFolder(node, rootFolder)
 }
 
-function walkAndFreezeTables(node: IOracleTreeNode) {
+export function walkAndFreezeTables(node: IOracleTreeNode) {
   ;(node.tables as any) = Object.freeze(node.tables)
   for (const child of node.children) {
     walkAndFreezeTables(child)

--- a/src/module/vue/components/oracle-tree-node.vue
+++ b/src/module/vue/components/oracle-tree-node.vue
@@ -100,7 +100,6 @@ import BtnFaicon from './buttons/btn-faicon.vue'
 import BtnOracle from './buttons/btn-oracle.vue'
 import { $ActorKey, $EmitterKey, $EnrichMarkdownKey } from '../provisions'
 import { IronswornItem } from '../../item/item'
-import { rollAndDisplayOracleResult } from '../../chat/chatrollhelpers'
 
 const props = defineProps<{ node: IOracleTreeNode }>()
 

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -76,12 +76,6 @@ h4 {
 </style>
 
 <script setup lang="ts">
-import {
-  computed,
-  defineComponent,
-  inject,
-  nextTick,
-  reactive,
 import { computed, inject, nextTick, reactive, ref } from 'vue'
 import { getDFOracleByDfId } from '../../dataforged'
 import { Move } from '../../features/custommoves'

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -29,7 +29,14 @@
             {{ $t('IRONSWORN.Chat') }}
           </btn-sendmovetochat>
         </div>
-        <div v-html="$enrichMarkdown(fulltext)" />
+        <div v-html="fulltext" />
+
+        <oracle-tree-node
+          class="item-row"
+          v-for="node of data.oracles"
+          :key="node.displayName"
+          :node="node"
+        />
       </with-rolllisteners>
     </transition>
   </div>
@@ -75,19 +82,30 @@ import {
   inject,
   nextTick,
   reactive,
-  ref,
-  watch,
-} from 'vue'
+import { computed, inject, nextTick, reactive, ref } from 'vue'
+import { getDFOracleByDfId } from '../../dataforged'
 import { Move } from '../../features/custommoves'
+import {
+  IOracleTreeNode,
+  walkAndFreezeTables,
+  walkOracle,
+} from '../../features/customoracles'
+import { IronswornHandlebarsHelpers } from '../../helpers/handlebars'
 import { IronswornItem } from '../../item/item'
 import { moveHasRollableOptions } from '../../rolls/preroll-dialog'
 import { $EmitterKey } from '../provisions'
+import { enrichMarkdown } from '../vue-plugin'
 import BtnRollmove from './buttons/btn-rollmove.vue'
 import BtnSendmovetochat from './buttons/btn-sendmovetochat.vue'
 import WithRolllisteners from './with-rolllisteners.vue'
+import OracleTreeNode from './oracle-tree-node.vue'
 
 const props = defineProps<{ move: Move }>()
-const data = reactive({ expanded: false, highlighted: false })
+const data = reactive({
+  expanded: false,
+  highlighted: false,
+  oracles: [] as IOracleTreeNode[],
+})
 
 const tooltip = computed(() => {
   const { Title, Page } = props.move.dataforgedMove?.Source ?? {}
@@ -95,11 +113,24 @@ const tooltip = computed(() => {
   return `${Title} p${Page}`
 })
 const fulltext = computed(() => {
-  return props.move.moveItem?.data?.data?.Text
+  return IronswornHandlebarsHelpers.stripTables(
+    enrichMarkdown(props.move.moveItem?.data?.data?.Text)
+  )
 })
 const canRoll = computed(() => {
   return moveHasRollableOptions(props.move.moveItem)
 })
+
+if (props.move.dataforgedMove) {
+  const oracleIds = props.move.dataforgedMove.Oracles ?? []
+  Promise.all(oracleIds.map(getDFOracleByDfId)).then(async (dfOracles) => {
+    const nodes = await Promise.all(dfOracles.map(walkOracle))
+    for (const n of nodes) {
+      walkAndFreezeTables(n)
+    }
+    data.oracles.push(...nodes)
+  })
+}
 
 const $el = ref<HTMLElement>()
 const $emitter = inject($EmitterKey)

--- a/src/module/vue/components/sf-movesheetmoves.vue
+++ b/src/module/vue/components/sf-movesheetmoves.vue
@@ -61,7 +61,7 @@ h2 {
 
 <script setup lang="ts">
 import { flatten } from 'lodash'
-import { computed, inject, nextTick, reactive, ref, Ref } from 'vue'
+import { computed, inject, provide, reactive, ref, Ref } from 'vue'
 import {
   createIronswornMoveTree,
   createStarforgedMoveTree,
@@ -70,6 +70,7 @@ import { $EmitterKey } from '../provisions'
 import sfMoverow from './sf-moverow.vue'
 
 const props = defineProps<{ toolset: 'ironsworn' | 'starforged' }>()
+provide('toolset', props.toolset)
 
 const actor = inject('actor') as Ref
 


### PR DESCRIPTION
This adds two features: chat-card context menus and better move-sheet controls for rolling oracles.

## Chat cards
It's a little weird, but this now walks the content of chat cards, looking for links to moves, gathers any `Oracles` from those moves, and displays a context menu allowing the player to skip the move step and go straight to the oracles. This allows a player to shortcut the click through the move sheet if they know they want to just roll on the oracle.

![CleanShot 2022-09-13 at 06 29 37](https://user-images.githubusercontent.com/39902/189915548-f1877b05-2d62-4321-95a7-4e81740f4017.jpg)


## Move sheet oracles

We also now embed an oracle-rolling node in the move sheet area for each move. This allows rolling directly from this area (instead of having to dump the move to chat first), and collapses the table until asked for.

![CleanShot 2022-09-13 at 10 18 51](https://user-images.githubusercontent.com/39902/189966170-99b3fa56-a086-4cd2-8b99-d734dd460275.jpg)

## Misc.

I also replaced some references to the old oracle-rolling mechanism with the new one.

- [x] Chat card context menu
- [x] Move sheet oracle controls
- [x] Chat card button clicks -> new oracle pipeline
- [x] Update CHANGELOG.md
