### PR TITLE
Encapsulate sheet header styles in wrapper component

### DIFF
--- a/src/module/vue/asset-sheet.vue
+++ b/src/module/vue/asset-sheet.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <header class="sheet-header">
+    <SheetHeader>
       <document-name :document="item" />
-    </header>
+    </SheetHeader>
 
     <p>
       <input
@@ -51,6 +51,7 @@ h3 {
 </style>
 
 <script setup lang="ts">
+import SheetHeader from './sheet-header.vue'
 import { computed, inject, provide, Ref } from 'vue'
 import DocumentName from './components/document-name.vue'
 import AssetFieldsedit from './components/asset/asset-fieldsedit.vue'

--- a/src/module/vue/asset-sheet.vue
+++ b/src/module/vue/asset-sheet.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <SheetHeader>
+    <SheetHeader class="nogrow">
       <document-name :document="item" />
     </SheetHeader>
 

--- a/src/module/vue/character-sheet.vue
+++ b/src/module/vue/character-sheet.vue
@@ -1,107 +1,111 @@
 <template>
-  <article class="flexcol character-sheet-classic">
+  <SheetBasic
+    :document="actor"
+    class="character-sheet-classic"
+    bodyClass="flexrow"
+  >
     <!-- Header row -->
-    <character-header />
+    <template #header>
+      <CharacterHeader />
+    </template>
 
     <!-- Main body row -->
-    <div class="flexrow">
-      <!-- Momentum on left -->
-      <div class="flexcol margin-left">
-        <div class="flexrow" style="flex-wrap: nowrap">
-          <div class="flexcol stack momentum">
-            <stack
-              stat="momentum"
-              :top="10"
-              :bottom="-6"
-              :softMax="actorData.data.momentumMax"
-            ></stack>
-            <hr class="nogrow" />
-            <div>
-              <btn-momentumburn class="nogrow block stack-row">
-                {{ $t('IRONSWORN.Burn') }}
-              </btn-momentumburn>
+    <!-- Momentum on left -->
+    <div class="flexcol margin-left">
+      <div class="flexrow" style="flex-wrap: nowrap">
+        <div class="flexcol stack momentum">
+          <stack
+            stat="momentum"
+            :top="10"
+            :bottom="-6"
+            :softMax="actorData.data.momentumMax"
+          ></stack>
+          <hr class="nogrow" />
+          <div>
+            <btn-momentumburn class="nogrow block stack-row">
+              {{ $t('IRONSWORN.Burn') }}
+            </btn-momentumburn>
 
-              {{ $t('IRONSWORN.Reset') }}: {{ actorData.data.momentumReset }}
-              {{ $t('IRONSWORN.Max') }}:
-              {{ actorData.data.momentumMax }}
-            </div>
+            {{ $t('IRONSWORN.Reset') }}: {{ actorData.data.momentumReset }}
+            {{ $t('IRONSWORN.Max') }}:
+            {{ actorData.data.momentumMax }}
           </div>
-          <h4 class="vertical">{{ $t('IRONSWORN.Momentum') }}</h4>
+        </div>
+        <h4 class="vertical">{{ $t('IRONSWORN.Momentum') }}</h4>
+      </div>
+    </div>
+
+    <!-- Center area -->
+    <div class="flexcol">
+      <!-- Attributes -->
+      <div class="flexrow stats" data-tooltip-direction="UP">
+        <attr-box attr="edge"></attr-box>
+        <attr-box attr="heart"></attr-box>
+        <attr-box attr="iron"></attr-box>
+        <attr-box attr="shadow"></attr-box>
+        <attr-box attr="wits"></attr-box>
+      </div>
+
+      <tabs style="margin-top: 0.5rem">
+        <tab :title="$t('IRONSWORN.Character')"><ironsworn-main /></tab>
+        <tab :title="$t('IRONSWORN.Notes')"><ironsworn-notes /></tab>
+      </tabs>
+
+      <!-- Conditions & Banes & Burdens -->
+      <section class="sheet-area nogrow">
+        <conditions />
+      </section>
+    </div>
+
+    <!-- Stats on right -->
+    <div class="flexcol margin-right" data-tooltip-direction="UP">
+      <div class="flexrow nogrow" style="flex-wrap: nowrap">
+        <!-- TODO: restyle as h4-like -->
+        <btn-rollstat
+          class="nogrow vertical text"
+          attr="health"
+          :statLabel="$t('IRONSWORN.Health')"
+        >
+          {{ $t('IRONSWORN.Health') }}
+        </btn-rollstat>
+        <div class="flexcol stack health">
+          <stack stat="health" :top="5" :bottom="0"></stack>
         </div>
       </div>
 
-      <!-- Center area -->
-      <div class="flexcol">
-        <!-- Attributes -->
-        <div class="flexrow stats" data-tooltip-direction="UP">
-          <attr-box attr="edge"></attr-box>
-          <attr-box attr="heart"></attr-box>
-          <attr-box attr="iron"></attr-box>
-          <attr-box attr="shadow"></attr-box>
-          <attr-box attr="wits"></attr-box>
+      <hr class="nogrow" />
+
+      <div class="flexrow nogrow" style="flex-wrap: nowrap">
+        <!-- TODO: restyle as h4-like -->
+        <btn-rollstat
+          class="nogrow vertical text"
+          attr="spirit"
+          :statLabel="$t('IRONSWORN.Spirit')"
+        >
+          {{ $t('IRONSWORN.Spirit') }}
+        </btn-rollstat>
+        <div class="flexcol stack spirit">
+          <stack stat="spirit" :top="5" :bottom="0"></stack>
         </div>
-
-        <tabs style="margin-top: 0.5rem">
-          <tab :title="$t('IRONSWORN.Character')"><ironsworn-main /></tab>
-          <tab :title="$t('IRONSWORN.Notes')"><ironsworn-notes /></tab>
-        </tabs>
-
-        <!-- Conditions & Banes & Burdens -->
-        <section class="sheet-area nogrow">
-          <conditions />
-        </section>
       </div>
 
-      <!-- Stats on right -->
-      <div class="flexcol margin-right" data-tooltip-direction="UP">
-        <div class="flexrow nogrow" style="flex-wrap: nowrap">
-          <!-- TODO: restyle as h4-like -->
-          <btn-rollstat
-            class="nogrow vertical text"
-            attr="health"
-            :statLabel="$t('IRONSWORN.Health')"
-          >
-            {{ $t('IRONSWORN.Health') }}
-          </btn-rollstat>
-          <div class="flexcol stack health">
-            <stack stat="health" :top="5" :bottom="0"></stack>
-          </div>
-        </div>
+      <hr class="nogrow" />
 
-        <hr class="nogrow" />
-
-        <div class="flexrow nogrow" style="flex-wrap: nowrap">
-          <!-- TODO: restyle as h4-like -->
-          <btn-rollstat
-            class="nogrow vertical text"
-            attr="spirit"
-            :statLabel="$t('IRONSWORN.Spirit')"
-          >
-            {{ $t('IRONSWORN.Spirit') }}
-          </btn-rollstat>
-          <div class="flexcol stack spirit">
-            <stack stat="spirit" :top="5" :bottom="0"></stack>
-          </div>
-        </div>
-
-        <hr class="nogrow" />
-
-        <div class="flexrow nogrow" style="flex-wrap: nowrap">
-          <!-- TODO: restyle as h4-like -->
-          <btn-rollstat
-            class="nogrow vertical text"
-            attr="supply"
-            :statLabel="$t('IRONSWORN.Supply')"
-          >
-            {{ $t('IRONSWORN.Supply') }}
-          </btn-rollstat>
-          <div class="flexcol stack supply">
-            <stack stat="supply" :top="5" :bottom="0"></stack>
-          </div>
+      <div class="flexrow nogrow" style="flex-wrap: nowrap">
+        <!-- TODO: restyle as h4-like -->
+        <btn-rollstat
+          class="nogrow vertical text"
+          attr="supply"
+          :statLabel="$t('IRONSWORN.Supply')"
+        >
+          {{ $t('IRONSWORN.Supply') }}
+        </btn-rollstat>
+        <div class="flexcol stack supply">
+          <stack stat="supply" :top="5" :bottom="0"></stack>
         </div>
       </div>
     </div>
-  </article>
+  </SheetBasic>
 </template>
 
 <style lang="less" scoped>
@@ -133,6 +137,7 @@ import Tab from './components/tabs/tab.vue'
 import IronswornMain from './components/character-sheet-tabs/ironsworn-main.vue'
 import IronswornNotes from './components/character-sheet-tabs/ironsworn-notes.vue'
 import { CharacterDataProperties } from '../actor/actortypes'
+import SheetBasic from './sheet-basic.vue'
 
 const props = defineProps<{
   actor: ReturnType<typeof IronswornActor.prototype.toObject>

--- a/src/module/vue/character-sheet.vue
+++ b/src/module/vue/character-sheet.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flexcol">
+  <article class="flexcol character-sheet-classic">
     <!-- Header row -->
     <character-header />
 
@@ -101,10 +101,13 @@
         </div>
       </div>
     </div>
-  </div>
+  </article>
 </template>
 
 <style lang="less" scoped>
+.character-sheet-classic {
+  gap: 10px;
+}
 .stat-roll {
   text-transform: uppercase;
 }

--- a/src/module/vue/components/character-header.vue
+++ b/src/module/vue/components/character-header.vue
@@ -1,8 +1,6 @@
 <template>
-  <SheetHeader style="gap: 5px">
-    <document-img :document="actor" />
-    <document-name :document="actor" />
-    <div class="flexrow xp" style="gap: 5px">
+  <SheetHeaderBasic class="nogrow" :document="actor">
+    <section class="flexrow xp" style="gap: 5px">
       <h4 class="nogrow" style="margin: 0">{{ $t('IRONSWORN.XP') }}</h4>
       <div class="flexrow">
         <xp-box :key="0" :current="-1" :value="0" @click="setXp(0)"> × </xp-box>
@@ -14,12 +12,12 @@
           @click="setXp(n)"
         />
       </div>
-    </div>
-  </SheetHeader>
+    </section>
+  </SheetHeaderBasic>
 </template>
 
 <script setup lang="ts">
-import SheetHeader from '../sheet-header.vue'
+import SheetHeaderBasic from '../sheet-header-basic.vue'
 import { Ref, inject } from 'vue'
 import { $ActorKey } from '../provisions'
 import XpBox from './xp-box.vue'

--- a/src/module/vue/components/character-header.vue
+++ b/src/module/vue/components/character-header.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="sheet-header" style="gap: 5px">
+  <SheetHeader style="gap: 5px">
     <document-img :document="actor" />
     <document-name :document="actor" />
     <div class="flexrow xp" style="gap: 5px">
@@ -15,10 +15,11 @@
         />
       </div>
     </div>
-  </header>
+  </SheetHeader>
 </template>
 
 <script setup lang="ts">
+import SheetHeader from '../sheet-header.vue'
 import { Ref, inject } from 'vue'
 import { $ActorKey } from '../provisions'
 import XpBox from './xp-box.vue'

--- a/src/module/vue/components/character-header.vue
+++ b/src/module/vue/components/character-header.vue
@@ -21,8 +21,6 @@ import SheetHeaderBasic from '../sheet-header-basic.vue'
 import { Ref, inject } from 'vue'
 import { $ActorKey } from '../provisions'
 import XpBox from './xp-box.vue'
-import DocumentImg from './document-img.vue'
-import DocumentName from './document-name.vue'
 
 const actor = inject('actor') as Ref
 const xpArray = [1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/src/module/vue/components/document-img.vue
+++ b/src/module/vue/components/document-img.vue
@@ -5,23 +5,26 @@
     :style="style"
     :height="size"
     :width="size"
-    class="nogrow"
     @click="click"
   />
 </template>
 
+<style lang="less" scoped></style>
+
 <script setup lang="ts">
 import { computed, inject } from '@vue/runtime-core'
 import { $ActorKey, $ItemKey } from '../provisions'
-const props = defineProps<{
-  document: any
-  size?: string
-}>()
+const props = withDefaults(
+  defineProps<{
+    document: any
+    size: string
+  }>(),
+  { size: '50px' }
+)
 
 const style = computed(() => ({
-  width: props.size ?? '50px',
-  height: props.size ?? '50px',
-  'flex-basis': 0,
+  width: props.size,
+  height: props.size,
 }))
 
 const $actor = inject($ActorKey, undefined)

--- a/src/module/vue/components/document-img.vue
+++ b/src/module/vue/components/document-img.vue
@@ -13,10 +13,11 @@
 <style lang="less">
 .document-img {
   cursor: pointer;
-  .theme-ironsworn & {
-    // tint so that the default fill of included vector icons (white) is at least nominally visible on a white ground.
-    background-color: rgba(0, 0, 0, 0.2);
-  }
+}
+
+.theme-ironsworn .document-img[src$='.svg'] {
+  // tint so that the default fill of included vector icons (white) is at least nominally visible on a white ground.
+  background-color: rgba(0, 0, 0, 0.2);
 }
 </style>
 

--- a/src/module/vue/components/document-img.vue
+++ b/src/module/vue/components/document-img.vue
@@ -9,8 +9,6 @@
   />
 </template>
 
-<style lang="less" scoped></style>
-
 <script setup lang="ts">
 import { computed, inject } from '@vue/runtime-core'
 import { $ActorKey, $ItemKey } from '../provisions'

--- a/src/module/vue/components/document-img.vue
+++ b/src/module/vue/components/document-img.vue
@@ -15,7 +15,7 @@
   cursor: pointer;
   .theme-ironsworn & {
     // tint so that the default fill of included vector icons (white) is at least nominally visible on a white ground.
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: rgba(0, 0, 0, 0.2);
   }
 }
 </style>

--- a/src/module/vue/components/document-img.vue
+++ b/src/module/vue/components/document-img.vue
@@ -1,5 +1,6 @@
 <template>
   <img
+    class="document-img"
     :src="document.img"
     :title="document.name"
     :style="style"
@@ -8,6 +9,16 @@
     @click="click"
   />
 </template>
+
+<style lang="less">
+.document-img {
+  cursor: pointer;
+  .theme-ironsworn & {
+    // tint so that the default fill of included vector icons (white) is at least nominally visible on a white ground.
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+}
+</style>
 
 <script setup lang="ts">
 import { computed, inject } from '@vue/runtime-core'

--- a/src/module/vue/components/document-name.vue
+++ b/src/module/vue/components/document-name.vue
@@ -13,7 +13,10 @@
 import { IronswornItem } from '../../item/item'
 import { inject } from 'vue'
 import { $ActorKey, $ItemKey } from '../provisions'
-const props = defineProps<{ document: any; tag?: string }>()
+const props = defineProps<{
+  document: any
+  tag?: string
+}>()
 
 const $item = inject($ItemKey, undefined)
 const $actor = inject($ActorKey, undefined)

--- a/src/module/vue/components/foe-sheet.vue
+++ b/src/module/vue/components/foe-sheet.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="flexcol">
-    <SheetHeader class="flexrow nogrow" style="gap: 5px">
-      <DocumentImg :document="actor" />
-      <DocumentName :document="actor" />
-    </SheetHeader>
-
+    <SheetHeaderBasic :document="actor" class="nogrow" />
     <div v-if="foe">
       <div class="flexrow nogrow">
         <RankPips
@@ -64,7 +60,7 @@
 </style>
 
 <script setup lang="ts">
-import SheetHeader from '../sheet-header.vue'
+import SheetHeaderBasic from '../sheet-header-basic.vue'
 import { computed, inject, provide } from 'vue'
 import { IronswornActor } from '../../actor/actor'
 import { $ActorKey } from '../provisions'

--- a/src/module/vue/components/foe-sheet.vue
+++ b/src/module/vue/components/foe-sheet.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="flexcol">
-    <header class="sheet-header flexrow nogrow" style="gap: 5px">
+    <SheetHeader class="flexrow nogrow" style="gap: 5px">
       <DocumentImg :document="actor" />
       <DocumentName :document="actor" />
-    </header>
+    </SheetHeader>
 
     <div v-if="foe">
       <div class="flexrow nogrow">
@@ -64,6 +64,7 @@
 </style>
 
 <script setup lang="ts">
+import SheetHeader from '../sheet-header.vue'
 import { computed, inject, provide } from 'vue'
 import { IronswornActor } from '../../actor/actor'
 import { $ActorKey } from '../provisions'

--- a/src/module/vue/components/sf-characterheader.vue
+++ b/src/module/vue/components/sf-characterheader.vue
@@ -1,11 +1,9 @@
 <template>
-  <SheetHeader class="flexrow">
+  <SheetHeader class="sf-character-header">
     <document-img :document="actor" size="75px" />
-
-    <div class="flexcol" style="flex-basis: 100px; margin-left: 6px">
+    <section class="header-pc-vitals flexcol">
       <input
         type="text"
-        style="margin-bottom: 7px"
         :placeholder="$t('IRONSWORN.Name')"
         v-model="actor.name"
         ref="name"
@@ -13,7 +11,6 @@
       />
       <input
         type="text"
-        style="margin-bottom: 7px"
         :placeholder="$t('IRONSWORN.Pronouns')"
         :value="actor.data.pronouns"
         ref="pronouns"
@@ -26,13 +23,11 @@
         ref="callsign"
         @keyup="save"
       />
-    </div>
+    </section>
 
     <textarea
-      rows="4"
       :value="actor.data.biography"
       ref="characteristics"
-      style="flex-basis: 300px; margin-left: 6px"
       :placeholder="$t('IRONSWORN.Characteristics')"
       @keyup="save"
     />
@@ -46,6 +41,19 @@ textarea {
   border-radius: 1px;
   font-family: var(--font-primary);
   resize: none;
+  font-size: inherit;
+}
+textarea {
+  flex-basis: 300px;
+  margin: 0;
+  flex-grow: 2;
+}
+.header-pc-vitals {
+  flex-basis: 100px;
+  min-width: 20ch;
+  max-width: 30ch;
+  gap: 5px;
+  flex-grow: 1;
 }
 </style>
 

--- a/src/module/vue/components/sf-characterheader.vue
+++ b/src/module/vue/components/sf-characterheader.vue
@@ -1,6 +1,6 @@
 <template>
   <SheetHeader class="sf-character-header">
-    <document-img :document="actor" size="75px" />
+    <DocumentImg :document="actor" size="75px" />
     <section class="header-pc-vitals flexcol">
       <input
         type="text"
@@ -62,7 +62,7 @@ import SheetHeader from '../sheet-header.vue'
 import { debounce } from 'lodash'
 import { inject, ref, Ref } from 'vue'
 import { $ActorKey } from '../provisions'
-import documentImg from './document-img.vue'
+import DocumentImg from './document-img.vue'
 
 const actor = inject('actor') as Ref
 const $actor = inject($ActorKey)

--- a/src/module/vue/components/sf-characterheader.vue
+++ b/src/module/vue/components/sf-characterheader.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="sheet-header flexrow">
+  <SheetHeader class="flexrow">
     <document-img :document="actor" size="75px" />
 
     <div class="flexcol" style="flex-basis: 100px; margin-left: 6px">
@@ -36,7 +36,7 @@
       :placeholder="$t('IRONSWORN.Characteristics')"
       @keyup="save"
     />
-  </header>
+  </SheetHeader>
 </template>
 
 <style lang="less" scoped>
@@ -50,6 +50,7 @@ textarea {
 </style>
 
 <script lang="ts" setup>
+import SheetHeader from '../sheet-header.vue'
 import { debounce } from 'lodash'
 import { inject, ref, Ref } from 'vue'
 import { $ActorKey } from '../provisions'

--- a/src/module/vue/progress-sheet.vue
+++ b/src/module/vue/progress-sheet.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="flexcol">
     <!-- HEADER -->
-    <SheetHeader class="flexrow nogrow" style="gap: 5px">
-      <DocumentImg :document="item" />
-      <DocumentName :document="item" />
-    </SheetHeader>
+    <SheetHeaderBasic class="nogrow" :document="item" />
 
     <select
       class="nogrow"
@@ -139,6 +136,7 @@ import ProgressTrack from './components/progress/progress-track.vue'
 import Clock from './components/clock.vue'
 import MceEditor from './components/mce-editor.vue'
 import { throttle } from 'lodash'
+import SheetHeaderBasic from './sheet-header-basic.vue'
 
 const $item = inject($ItemKey)
 

--- a/src/module/vue/progress-sheet.vue
+++ b/src/module/vue/progress-sheet.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="flexcol">
     <!-- HEADER -->
-    <header class="sheet-header flexrow nogrow" style="gap: 5px">
+    <SheetHeader class="flexrow nogrow" style="gap: 5px">
       <DocumentImg :document="item" />
       <DocumentName :document="item" />
-    </header>
+    </SheetHeader>
 
     <select
       class="nogrow"
@@ -127,6 +127,7 @@
 </style>
 
 <script setup lang="ts">
+import SheetHeader from './sheet-header.vue'
 import { computed, inject, provide } from 'vue'
 import { RANKS, RANK_INCREMENTS } from '../constants'
 import { $ItemKey } from './provisions'

--- a/src/module/vue/sf-charactersheet.vue
+++ b/src/module/vue/sf-charactersheet.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flexcol sf-character-sheet">
+  <article class="flexcol sf-character-sheet">
     <!-- TODO: rm inline styles added to maintain consistent styling (required largely because of other inline styles) -->
     <!-- Header row -->
     <sf-characterheader />
@@ -117,11 +117,12 @@
     <!-- Impacts -->
     <hr class="nogrow" />
     <sf-impacts class="nogrow" />
-  </div>
+  </article>
 </template>
 
 <style lang="less">
 .sf-character-sheet {
+  gap: 7px;
   .stat-roll {
     text-transform: uppercase;
   }

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -59,7 +59,7 @@
       />
     </label>
 
-    <header
+    <SheetHeader
       class="sheet-header flexrow nogrow"
       style="position: relative; gap: 5px"
     >
@@ -91,7 +91,7 @@
           />
         </div>
       </div>
-    </header>
+    </SheetHeader>
 
     <section
       class="boxgroup flexcol nogrow"
@@ -165,6 +165,7 @@ label {
 </style>
 
 <script setup lang="ts">
+import SheetHeader from '../sheet-header.vue'
 import { capitalize, flatten, throttle } from 'lodash'
 import { provide, computed, reactive, inject } from 'vue'
 import { IronswornActor } from '../actor/actor'

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -165,7 +165,7 @@ label {
 </style>
 
 <script setup lang="ts">
-import SheetHeader from '../sheet-header.vue'
+import SheetHeader from './sheet-header.vue'
 import { capitalize, flatten, throttle } from 'lodash'
 import { provide, computed, reactive, inject } from 'vue'
 import { IronswornActor } from '../actor/actor'

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -58,41 +58,21 @@
         :tooltip="randomKlassTooltip"
       />
     </label>
-
-    <SheetHeader
-      class="sheet-header flexrow nogrow"
-      style="position: relative; gap: 5px"
+    <SheetHeaderBasic
+      :document="actor"
+      class="sf-location-header nogrow"
+      :nameClass="{
+        highlighted: data.firstLookHighlight && canRandomizeName,
+      }"
     >
-      <document-img :document="actor" size="50px" />
-      <div class="flexcol">
-        <div class="flexrow nogrow">
-          <document-name
-            :document="actor"
-            :class="{
-              highlighted: data.firstLookHighlight && canRandomizeName,
-            }"
-          />
-
-          <btn-isicon
-            v-if="canRandomizeName"
-            icon="d10-tilt juicy"
-            class="block nogrow"
-            style="
-              position: absolute;
-              padding: 0px 10px;
-              line-height: 53px;
-              right: 1px;
-              top: 6px;
-              height: 48px;
-              border-radius: 0 3px 3px 0;
-            "
-            :tooltip="$t('IRONSWORN.RandomName')"
-            @click="randomizeName"
-          />
-        </div>
-      </div>
-    </SheetHeader>
-
+      <btn-isicon
+        v-if="canRandomizeName"
+        icon="d10-tilt"
+        class="btn-randomize-name juicy block nogrow"
+        :tooltip="$t('IRONSWORN.RandomName')"
+        @click="randomizeName"
+      />
+    </SheetHeaderBasic>
     <section
       class="boxgroup flexcol nogrow"
       style="margin-bottom: 1rem"
@@ -143,6 +123,25 @@
   </div>
 </template>
 
+<style lang="less">
+.sf-location-header {
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-columns: max-content 1fr max-content;
+  > * {
+    grid-row: 1;
+  }
+  .charname {
+    grid-column: 2 / span 2;
+  }
+  .btn-randomize-name {
+    grid-column: 3;
+    height: 50px;
+    aspect-ratio: 1;
+    border-radius: 0 3px 3px 0;
+  }
+}
+</style>
 <style lang="less" scoped>
 label {
   line-height: 27px;
@@ -165,7 +164,7 @@ label {
 </style>
 
 <script setup lang="ts">
-import SheetHeader from './sheet-header.vue'
+import SheetHeaderBasic from './sheet-header-basic.vue'
 import { capitalize, flatten, throttle } from 'lodash'
 import { provide, computed, reactive, inject } from 'vue'
 import { IronswornActor } from '../actor/actor'

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -1,83 +1,87 @@
 <template>
-  <div class="flexcol" style="gap: 5px">
-    <div class="flexrow nogrow" style="gap: 5px">
-      <!-- Region -->
-      <label class="flexrow" style="flex-basis: 150px; gap: 10px">
-        <span class="select-label">{{ $t('IRONSWORN.Region') }}</span>
-        <select v-model="region" @change="regionChanged">
-          <option value="terminus">
-            {{ $t('IRONSWORN.Terminus') }}
-          </option>
-          <option value="outlands">
-            {{ $t('IRONSWORN.Outlands') }}
-          </option>
-          <option value="expanse">
-            {{ $t('IRONSWORN.Expanse') }}
+  <SheetBasic :document="actor">
+    <template #before-header>
+      <div class="flexrow nogrow" style="gap: 5px">
+        <!-- Region -->
+        <label class="flexrow" style="flex-basis: 150px; gap: 10px">
+          <span class="select-label">{{ $t('IRONSWORN.Region') }}</span>
+          <select v-model="region" @change="regionChanged">
+            <option value="terminus">
+              {{ $t('IRONSWORN.Terminus') }}
+            </option>
+            <option value="outlands">
+              {{ $t('IRONSWORN.Outlands') }}
+            </option>
+            <option value="expanse">
+              {{ $t('IRONSWORN.Expanse') }}
+            </option>
+          </select>
+        </label>
+
+        <!-- Subtype -->
+        <label class="flexrow" style="flex-basis: 200px; gap: 10px">
+          {{ $t('IRONSWORN.LocationType') }}
+          <select v-model="actor.data.subtype" @change="subtypeChanged">
+            <option value="planet">Planet</option>
+            <option value="settlement">Settlement</option>
+            <option value="star">Stellar Object</option>
+            <option value="derelict">Derelict</option>
+            <option value="vault">Precursor Vault</option>
+          </select>
+        </label>
+      </div>
+
+      <!-- Klass -->
+      <label class="flexrow nogrow" style="position: relative; gap: 10px">
+        <!-- TODO: i18n and subtype text -->
+        <span class="select-label">{{ subtypeSelectText }}:</span>
+        <select
+          v-model="actor.data.klass"
+          @change="klassChanged"
+          :class="{ highlighted: data.firstLookHighlight }"
+        >
+          <option
+            v-for="opt in klassOptions"
+            :key="opt.value"
+            :value="opt.value"
+          >
+            {{ opt.label }}
           </option>
         </select>
+        <btn-isicon
+          icon="d10-tilt juicy"
+          class="block nogrow"
+          style="
+            padding: 0px 5px;
+            position: absolute;
+            right: 15px;
+            height: 25px;
+            line-height: 30px;
+            top: 1px;
+          "
+          @click="randomizeKlass"
+          :tooltip="randomKlassTooltip"
+        />
       </label>
-
-      <!-- Subtype -->
-      <label class="flexrow" style="flex-basis: 200px; gap: 10px">
-        {{ $t('IRONSWORN.LocationType') }}
-        <select v-model="actor.data.subtype" @change="subtypeChanged">
-          <option value="planet">Planet</option>
-          <option value="settlement">Settlement</option>
-          <option value="star">Stellar Object</option>
-          <option value="derelict">Derelict</option>
-          <option value="vault">Precursor Vault</option>
-        </select>
-      </label>
-    </div>
-
-    <!-- Klass -->
-    <label class="flexrow nogrow" style="position: relative; gap: 10px">
-      <!-- TODO: i18n and subtype text -->
-      <span class="select-label">{{ subtypeSelectText }}:</span>
-      <select
-        v-model="actor.data.klass"
-        @change="klassChanged"
-        :class="{ highlighted: data.firstLookHighlight }"
+    </template>
+    <template #header>
+      <SheetHeaderBasic
+        :document="actor"
+        class="sf-location-header nogrow"
+        :nameClass="{
+          highlighted: data.firstLookHighlight && canRandomizeName,
+        }"
       >
-        <option v-for="opt in klassOptions" :key="opt.value" :value="opt.value">
-          {{ opt.label }}
-        </option>
-      </select>
-      <btn-isicon
-        icon="d10-tilt juicy"
-        class="block nogrow"
-        style="
-          padding: 0px 5px;
-          position: absolute;
-          right: 15px;
-          height: 25px;
-          line-height: 30px;
-          top: 1px;
-        "
-        @click="randomizeKlass"
-        :tooltip="randomKlassTooltip"
-      />
-    </label>
-    <SheetHeaderBasic
-      :document="actor"
-      class="sf-location-header nogrow"
-      :nameClass="{
-        highlighted: data.firstLookHighlight && canRandomizeName,
-      }"
-    >
-      <btn-isicon
-        v-if="canRandomizeName"
-        icon="d10-tilt"
-        class="btn-randomize-name juicy block nogrow"
-        :tooltip="$t('IRONSWORN.RandomName')"
-        @click="randomizeName"
-      />
-    </SheetHeaderBasic>
-    <section
-      class="boxgroup flexcol nogrow"
-      style="margin-bottom: 1rem"
-      v-if="oracles.length > 0"
-    >
+        <btn-isicon
+          v-if="canRandomizeName"
+          icon="d10-tilt"
+          class="btn-randomize-name juicy block nogrow"
+          :tooltip="$t('IRONSWORN.RandomName')"
+          @click="randomizeName"
+        />
+      </SheetHeaderBasic>
+    </template>
+    <section class="boxgroup flexcol nogrow" v-if="oracles.length > 0">
       <div class="flexrow boxrow">
         <btn-isicon
           icon="d10-tilt"
@@ -112,7 +116,6 @@
         </btn-icon>
       </div>
     </section>
-
     <section class="flexcol">
       <MceEditor
         v-model="actor.data.description"
@@ -120,7 +123,7 @@
         @change="throttledSaveDescription"
       />
     </section>
-  </div>
+  </SheetBasic>
 </template>
 
 <style lang="less">
@@ -176,6 +179,7 @@ import BtnIcon from './components/buttons/btn-icon.vue'
 import MceEditor from './components/mce-editor.vue'
 import { OracleRollMessage } from '../rolls'
 import { LocationDataProperties } from '../actor/actortypes'
+import SheetBasic from './sheet-basic.vue'
 
 const props = defineProps<{
   actor: any

--- a/src/module/vue/sfmove-sheet.vue
+++ b/src/module/vue/sfmove-sheet.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="move-sheet flexcol">
-    <SheetHeader>
+    <SheetHeader class="nogrow">
       <document-name :document="item" />
     </SheetHeader>
 

--- a/src/module/vue/sfmove-sheet.vue
+++ b/src/module/vue/sfmove-sheet.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="move-sheet flexcol">
-    <header class="sheet-header">
+    <SheetHeader>
       <document-name :document="item" />
-    </header>
+    </SheetHeader>
 
     <div class="flexrow">
       <!-- Tab selection on left -->
@@ -128,6 +128,7 @@
 </style>
 
 <script setup lang="ts">
+import SheetHeader from './sheet-header.vue'
 import { provide, computed, reactive, inject } from 'vue'
 import { get, set } from 'lodash'
 import { $ItemKey } from './provisions'

--- a/src/module/vue/shared-sheet.vue
+++ b/src/module/vue/shared-sheet.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="flexcol">
-    <SheetHeaderBasic class="nogrow" :document="actor" />
-
+  <SheetBasic :document="actor">
     <section class="sheet-area nogrow">
       <btn-rollstat
         class="text"
@@ -34,7 +32,7 @@
         @change="throttledSaveNotes"
       />
     </section>
-  </div>
+  </SheetBasic>
 </template>
 
 <style lang="less" scoped>
@@ -63,14 +61,10 @@ textarea.notes {
 </style>
 
 <script setup lang="ts">
-import SheetHeaderBasic from './sheet-header-basic.vue'
 import { provide, computed, inject } from 'vue'
-import { IronswornActor } from '../actor/actor'
 import { RollDialog } from '../helpers/rolldialog'
 import { IronswornSettings } from '../helpers/settings'
 import { $ActorKey } from './provisions'
-import DocumentImg from './components/document-img.vue'
-import DocumentName from './components/document-name.vue'
 import Boxrow from './components/boxrow/boxrow.vue'
 import Bonds from './components/bonds.vue'
 import MceEditor from './components/mce-editor.vue'
@@ -78,6 +72,7 @@ import { throttle } from 'lodash'
 import BtnRollstat from './components/buttons/btn-rollstat.vue'
 import ActiveCompletedProgresses from './components/active-completed-progresses.vue'
 import { BondsetDataProperties } from '../item/itemtypes'
+import SheetBasic from './sheet-basic.vue'
 
 const props = defineProps<{
   actor: any

--- a/src/module/vue/shared-sheet.vue
+++ b/src/module/vue/shared-sheet.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="flexcol">
-    <SheetHeader style="gap: 5px">
-      <document-img :document="actor" />
-      <document-name :document="actor" />
-    </SheetHeader>
+    <SheetHeaderBasic class="nogrow" :document="actor" />
 
     <section class="sheet-area nogrow">
       <btn-rollstat
@@ -66,7 +63,7 @@ textarea.notes {
 </style>
 
 <script setup lang="ts">
-import SheetHeader from './sheet-header.vue'
+import SheetHeaderBasic from './sheet-header-basic.vue'
 import { provide, computed, inject } from 'vue'
 import { IronswornActor } from '../actor/actor'
 import { RollDialog } from '../helpers/rolldialog'

--- a/src/module/vue/shared-sheet.vue
+++ b/src/module/vue/shared-sheet.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="flexcol">
-    <header class="sheet-header flexrow nogrow" style="gap: 5px">
+    <SheetHeader class="flexrow nogrow" style="gap: 5px">
       <document-img :document="actor" />
       <document-name :document="actor" />
-    </header>
+    </SheetHeader>
 
     <section class="sheet-area nogrow">
       <btn-rollstat
@@ -66,6 +66,7 @@ textarea.notes {
 </style>
 
 <script setup lang="ts">
+import SheetHeader from './sheet-header.vue'
 import { provide, computed, inject } from 'vue'
 import { IronswornActor } from '../actor/actor'
 import { RollDialog } from '../helpers/rolldialog'

--- a/src/module/vue/shared-sheet.vue
+++ b/src/module/vue/shared-sheet.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flexcol">
-    <SheetHeader class="flexrow nogrow" style="gap: 5px">
+    <SheetHeader style="gap: 5px">
       <document-img :document="actor" />
       <document-name :document="actor" />
     </SheetHeader>

--- a/src/module/vue/sheet-basic.vue
+++ b/src/module/vue/sheet-basic.vue
@@ -1,0 +1,28 @@
+<template>
+  <article class="ironsworn-sheet flexcol">
+    <slot name="before-header"></slot>
+    <slot name="header">
+      <SheetHeaderBasic class="nogrow" :document="props.document" />
+    </slot>
+    <section class="ironsworn-sheet-body" :class="bodyClass">
+      <slot name="default"></slot>
+    </section>
+  </article>
+</template>
+
+<style lang="less" scoped>
+.ironsworn-sheet {
+  gap: 10px;
+}
+</style>
+
+<script setup lang="ts">
+import SheetHeaderBasic from './sheet-header-basic.vue'
+const props = withDefaults(
+  defineProps<{
+    document: any
+    bodyClass: any
+  }>(),
+  { bodyClass: { flexcol: true } }
+)
+</script>

--- a/src/module/vue/sheet-header-basic.vue
+++ b/src/module/vue/sheet-header-basic.vue
@@ -1,0 +1,24 @@
+<template>
+  <SheetHeader>
+    <DocumentImg
+      class="nogrow"
+      :class="imgClass"
+      :document="props.document"
+      :size="props.imgSize"
+    />
+    <DocumentName :document="props.document" :class="nameClass" />
+    <slot></slot>
+  </SheetHeader>
+</template>
+
+<script setup lang="ts">
+import DocumentName from './components/document-name.vue'
+import DocumentImg from './components/document-img.vue'
+import SheetHeader from './sheet-header.vue'
+const props = defineProps<{
+  document: any
+  imgSize?: string
+  nameClass?: any
+  imgClass?: any
+}>()
+</script>

--- a/src/module/vue/sheet-header.vue
+++ b/src/module/vue/sheet-header.vue
@@ -11,20 +11,20 @@
 <style lang="less">
 // not scoped, so it also applies to handlebars templates with the appropriate class
 .sheet-header {
-  overflow: hidden;
+  // overflow: hidden;
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  margin-bottom: 10px;
-  flex: 0 0 auto;
+  // flex-wrap: wrap;
+  // justify-content: flex-start;
+  // margin-bottom: 10px;
+  // flex: 0 0 auto;
+  gap: 6px;
 
   .profile-img {
     flex: 0 0 50px;
     height: 50px;
     margin-right: 10px;
   }
-
   .header-fields {
     flex: 1;
     height: 100px;

--- a/src/module/vue/sheet-header.vue
+++ b/src/module/vue/sheet-header.vue
@@ -1,0 +1,47 @@
+<template>
+  <header class="sheet-header">
+    <slot></slot>
+  </header>
+</template>
+<script lang="ts" setup>
+/**
+ * Wrapper to standardize + encapsulate sheet header styles.
+ */
+</script>
+<style lang="less">
+// not scoped, so it also applies to handlebars templates with the appropriate class
+.sheet-header {
+  overflow: hidden;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  margin-bottom: 10px;
+  flex: 0 0 auto;
+
+  .profile-img {
+    flex: 0 0 50px;
+    height: 50px;
+    margin-right: 10px;
+  }
+
+  .header-fields {
+    flex: 1;
+    height: 100px;
+  }
+
+  h1.charname {
+    flex-grow: 1;
+    height: 50px;
+    padding: 0px;
+    border-bottom: 0;
+    margin: 0;
+
+    input {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+    }
+  }
+}
+</style>

--- a/src/module/vue/sheet-header.vue
+++ b/src/module/vue/sheet-header.vue
@@ -11,13 +11,8 @@
 <style lang="less">
 // not scoped, so it also applies to handlebars templates with the appropriate class
 .sheet-header {
-  // overflow: hidden;
   display: flex;
   flex-direction: row;
-  // flex-wrap: wrap;
-  // justify-content: flex-start;
-  // margin-bottom: 10px;
-  // flex: 0 0 auto;
   gap: 6px;
 
   .profile-img {

--- a/src/module/vue/site-sheet.vue
+++ b/src/module/vue/site-sheet.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="flexcol">
     <!-- HEADER -->
-    <header class="sheet-header" style="gap: 5px">
+    <SheetHeader style="gap: 5px">
       <DocumentImg :document="actor" />
       <DocumentName :document="actor" />
-    </header>
+    </SheetHeader>
 
     <!-- RANK -->
     <div class="flexrow nogrow">
@@ -155,6 +155,7 @@ textarea {
 </style>
 
 <script setup lang="ts">
+import SheetHeader from './sheet-header.vue'
 import { provide, computed, inject, nextTick, ref, Component } from 'vue'
 import { IronswornActor } from '../actor/actor'
 import { $ActorKey } from './provisions'

--- a/src/module/vue/site-sheet.vue
+++ b/src/module/vue/site-sheet.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="flexcol">
     <!-- HEADER -->
-    <SheetHeader style="gap: 5px">
-      <DocumentImg :document="actor" />
-      <DocumentName :document="actor" />
-    </SheetHeader>
+    <SheetHeaderBasic class="nogrow" :document="actor" />
 
     <!-- RANK -->
     <div class="flexrow nogrow">
@@ -155,7 +152,7 @@ textarea {
 </style>
 
 <script setup lang="ts">
-import SheetHeader from './sheet-header.vue'
+import SheetHeaderBasic from './sheet-header-basic.vue'
 import { provide, computed, inject, nextTick, ref, Component } from 'vue'
 import { IronswornActor } from '../actor/actor'
 import { $ActorKey } from './provisions'

--- a/src/module/vue/starship-sheet.vue
+++ b/src/module/vue/starship-sheet.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="flexcol">
-    <SheetHeader class="nogrow" style="gap: 5px">
-      <document-img :document="actor" />
-      <document-name :document="actor" />
-    </SheetHeader>
-
+    <SheetHeaderBasic :document="actor" />
     <Tabs>
       <Tab :title="$t('IRONSWORN.Assets')">
         <SfAssets />
@@ -50,6 +46,7 @@ import SfNotes from './components/character-sheet-tabs/sf-notes.vue'
 import documentImg from './components/document-img.vue'
 import ConditionCheckbox from './components/conditions/condition-checkbox.vue'
 import DocumentName from './components/document-name.vue'
+import SheetHeaderBasic from './sheet-header-basic.vue'
 
 const props = defineProps<{
   actor: ReturnType<typeof IronswornActor.prototype.toObject>

--- a/src/module/vue/starship-sheet.vue
+++ b/src/module/vue/starship-sheet.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="flexcol">
-    <header class="sheet-header nogrow" style="gap: 5px">
+    <SheetHeader class="nogrow" style="gap: 5px">
       <document-img :document="actor" />
       <document-name :document="actor" />
-    </header>
+    </SheetHeader>
 
     <Tabs>
       <Tab :title="$t('IRONSWORN.Assets')">
@@ -40,6 +40,7 @@
 </style>
 
 <script setup lang="ts">
+import SheetHeader from './sheet-header.vue'
 import { provide, computed } from 'vue'
 import { IronswornActor } from '../actor/actor'
 import Tabs from './components/tabs/tabs.vue'

--- a/src/module/vue/starship-sheet.vue
+++ b/src/module/vue/starship-sheet.vue
@@ -1,6 +1,5 @@
 <template>
-  <div class="flexcol">
-    <SheetHeaderBasic :document="actor" />
+  <SheetBasic :document="actor">
     <Tabs>
       <Tab :title="$t('IRONSWORN.Assets')">
         <SfAssets />
@@ -20,7 +19,7 @@
         <condition-checkbox class="nogrow" name="cursed" :global="true" />
       </div>
     </section>
-  </div>
+  </SheetBasic>
 </template>
 
 <style lang="less" scoped>
@@ -36,17 +35,14 @@
 </style>
 
 <script setup lang="ts">
-import SheetHeader from './sheet-header.vue'
 import { provide, computed } from 'vue'
 import { IronswornActor } from '../actor/actor'
 import Tabs from './components/tabs/tabs.vue'
 import Tab from './components/tabs/tab.vue'
 import SfAssets from './components/character-sheet-tabs/sf-assets.vue'
 import SfNotes from './components/character-sheet-tabs/sf-notes.vue'
-import documentImg from './components/document-img.vue'
 import ConditionCheckbox from './components/conditions/condition-checkbox.vue'
-import DocumentName from './components/document-name.vue'
-import SheetHeaderBasic from './sheet-header-basic.vue'
+import SheetBasic from './sheet-basic.vue'
 
 const props = defineProps<{
   actor: ReturnType<typeof IronswornActor.prototype.toObject>

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -87,41 +87,6 @@
     }
   }
 
-  .sheet-header {
-    overflow: hidden;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    margin-bottom: 10px;
-    flex: 0 0 auto;
-
-    .profile-img {
-      flex: 0 0 50px;
-      height: 50px;
-      margin-right: 10px;
-    }
-
-    .header-fields {
-      flex: 1;
-      height: 100px;
-    }
-
-    h1.charname {
-      flex-grow: 1;
-      height: 50px;
-      padding: 0px;
-      border-bottom: 0;
-      margin: 0;
-
-      input {
-        width: 100%;
-        height: 100%;
-        margin: 0;
-      }
-    }
-  }
-
   .xp {
     flex-grow: 0;
     flex-direction: row;


### PR DESCRIPTION
a simple, slotted `SheetHeader` component so that the `.sheet-header` styles are encapsulated in an SFC, rather than them living in `styles.less`