### PR TITLE
Asset browser

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ import {
   IronswornRollMessage,
   OracleRollMessage,
 } from './module/rolls'
+import { AssetCompendiumBrowser } from './module/item/asset-compendium-browser'
 
 export interface IronswornConfig {
   actorClass: typeof IronswornActor
@@ -27,8 +28,7 @@ export interface IronswornConfig {
   Dataforged: typeof starforged
   dataforgedHelpers: typeof dataforgedHelpers
 
-  _: typeof lodash
-  marked: typeof marked
+  beta: { [k: string]: any }
 }
 
 export const IRONSWORN: IronswornConfig = {
@@ -48,6 +48,7 @@ export const IRONSWORN: IronswornConfig = {
   Dataforged: starforged,
   dataforgedHelpers,
 
-  _: lodash,
-  marked,
+  beta: {
+    AssetCompendiumBrowser,
+  },
 }

--- a/src/module/item/asset-compendium-browser.ts
+++ b/src/module/item/asset-compendium-browser.ts
@@ -1,0 +1,28 @@
+import { VueSheetRenderHelperOptions } from '../vue/vue-render-helper'
+import { VueApplication } from '../vue/vueapp'
+import AssetCompendiumBrowserVue from '../vue/asset-compendium-browser.vue'
+
+export class AssetCompendiumBrowser extends VueApplication {
+  constructor(
+    protected compendium: string,
+    options?: Partial<ApplicationOptions>
+  ) {
+    super(options)
+  }
+
+  static get defaultOptions(): ApplicationOptions {
+    return mergeObject(super.defaultOptions, {
+      width: 400,
+      height: 600,
+      template:
+        'systems/foundry-ironsworn/templates/asset-compendium-browser.hbs',
+    })
+  }
+
+  get renderHelperOptions(): Partial<VueSheetRenderHelperOptions> {
+    return {
+      components: { 'asset-compendium-browser': AssetCompendiumBrowserVue },
+      vueData: async () => ({ compendium: this.compendium }),
+    }
+  }
+}

--- a/src/module/item/asset-compendium-browser.ts
+++ b/src/module/item/asset-compendium-browser.ts
@@ -4,7 +4,7 @@ import AssetCompendiumBrowserVue from '../vue/asset-compendium-browser.vue'
 
 export class AssetCompendiumBrowser extends VueApplication {
   constructor(
-    protected compendium: string,
+    protected toolset: 'starforged' | 'ironsworn',
     options?: Partial<ApplicationOptions>
   ) {
     super(options)
@@ -22,7 +22,7 @@ export class AssetCompendiumBrowser extends VueApplication {
   get renderHelperOptions(): Partial<VueSheetRenderHelperOptions> {
     return {
       components: { 'asset-compendium-browser': AssetCompendiumBrowserVue },
-      vueData: async () => ({ compendium: this.compendium }),
+      vueData: async () => ({ toolset: this.toolset }),
     }
   }
 }

--- a/src/module/item/asset-compendium-browser.ts
+++ b/src/module/item/asset-compendium-browser.ts
@@ -14,7 +14,7 @@ export class AssetCompendiumBrowser extends VueApplication {
     return mergeObject(super.defaultOptions, {
       title: game.i18n.localize('IRONSWORN.Assets'),
       width: 400,
-      height: 800,
+      height: 600,
       resizable: true,
       template:
         'systems/foundry-ironsworn/templates/asset-compendium-browser.hbs',

--- a/src/module/item/asset-compendium-browser.ts
+++ b/src/module/item/asset-compendium-browser.ts
@@ -12,8 +12,10 @@ export class AssetCompendiumBrowser extends VueApplication {
 
   static get defaultOptions(): ApplicationOptions {
     return mergeObject(super.defaultOptions, {
+      title: game.i18n.localize('IRONSWORN.Assets'),
       width: 400,
-      height: 600,
+      height: 800,
+      resizable: true,
       template:
         'systems/foundry-ironsworn/templates/asset-compendium-browser.hbs',
     })

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -4,7 +4,7 @@ import { EnhancedDataswornMove, moveDataByName } from '../helpers/data'
 import { IronswornPrerollDialog } from '../rolls'
 
 /**
- * Extend the base Iteem entity
+ * Extend the base Item entity
  * @extends {Item}
  */
 export class IronswornItem extends Item {

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -4,6 +4,7 @@
     <WithRolllisteners
       element="p"
       v-html="$enrichMarkdown(category.description)"
+      @moveclick="moveClick"
     />
 
     <AssetBrowserCard
@@ -18,7 +19,7 @@
 
 <script setup lang="ts">
 import { IAsset, IAssetType } from 'dataforged'
-import { reactive } from 'vue'
+import { provide, reactive } from 'vue'
 import { hashLookup, renderLinksInStr } from '../dataforged'
 import { ISAssetTypes, SFAssetTypes } from '../dataforged/data'
 import { IronswornItem } from '../item/item'
@@ -43,8 +44,10 @@ const data = reactive({
   categories: [] as DisplayCategory[],
 })
 
+provide('toolset', props.toolset)
+
 // Kick into async without requiring a <Suspense>
-Promise.resolve().then(async () => {
+async function resolveAssets() {
   const pack = game.packs.get(`foundry-ironsworn.${props.toolset}assets`)
   if (!pack)
     throw new Error(`can't load pack foundry-ironsworn.${props.toolset}assets`)
@@ -78,5 +81,10 @@ Promise.resolve().then(async () => {
   }
 
   data.categories = categories
-})
+}
+resolveAssets()
+
+function moveClick() {
+  // TODO:
+}
 </script>

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -1,6 +1,6 @@
 <template>
   <section
-    class="nogrow"
+    class="nogrow asset-category"
     v-for="category in data.categories"
     :key="category.df.$id"
     :style="`--transition-max-height: ${category.maxHeight}px`"
@@ -19,7 +19,7 @@
     <Transition name="slide">
       <div v-if="category.expanded">
         <section
-          class="asset-category"
+          class="asset-category-contents"
           :aria-expanded="category.expanded"
           :id="category.df.$id"
         >
@@ -61,9 +61,14 @@ h2 {
 }
 
 .asset-category {
-  border-left: 2px solid;
-  margin-left: 10px;
-  padding-left: 10px;
+  margin-bottom: 1em;
+  padding: 5px;
+  border: 1px solid;
+  border-radius: 5px;
+}
+
+.asset-category-contents {
+  margin: 5px 10px;
 }
 
 .category-description {

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -1,6 +1,82 @@
 <template>
-  <h1>Hey there</h1>
+  <section v-for="category in data.categories" :key="category.df.$id">
+    <h2>{{ category.title }}</h2>
+    <WithRolllisteners
+      element="p"
+      v-html="$enrichMarkdown(category.description)"
+    />
+
+    <AssetBrowserCard
+      :df="asset.df"
+      :foundry-item="asset.foundryItem"
+      v-for="asset in category.assets"
+      :key="asset.df.$id"
+      class="flexcol nogrow movesheet-row"
+    />
+  </section>
 </template>
 
 <script setup lang="ts">
+import { IAsset, IAssetType } from 'dataforged'
+import { reactive } from 'vue'
+import { hashLookup, renderLinksInStr } from '../dataforged'
+import { ISAssetTypes, SFAssetTypes } from '../dataforged/data'
+import { IronswornItem } from '../item/item'
+import { AssetDataProperties } from '../item/itemtypes'
+import WithRolllisteners from './components/with-rolllisteners.vue'
+import AssetBrowserCard from './components/asset/asset-browser-card.vue'
+
+const props = defineProps<{ toolset: 'starforged' | 'ironsworn' }>()
+
+interface DisplayAsset {
+  df: IAsset
+  foundryItem: Readonly<IronswornItem>
+}
+interface DisplayCategory {
+  df: IAssetType
+  title: string
+  description: string
+  expanded: boolean
+  assets: DisplayAsset[]
+}
+const data = reactive({
+  categories: [] as DisplayCategory[],
+})
+
+// Kick into async without requiring a <Suspense>
+Promise.resolve().then(async () => {
+  const pack = game.packs.get(`foundry-ironsworn.${props.toolset}assets`)
+  if (!pack)
+    throw new Error(`can't load pack foundry-ironsworn.${props.toolset}assets`)
+
+  const assetTypes =
+    props.toolset === 'starforged' ? SFAssetTypes : ISAssetTypes
+
+  const categories = [] as DisplayCategory[]
+  for (const dfAssetType of assetTypes) {
+    const i18nKeyBase = `IRONSWORN.Asset Categories.${dfAssetType.Name}.`
+    const i18nDescription = game.i18n.localize(i18nKeyBase + 'Description')
+    const cat: DisplayCategory = {
+      df: dfAssetType,
+      title: game.i18n.localize(i18nKeyBase + 'Title'),
+      description: renderLinksInStr(i18nDescription),
+      expanded: false,
+      assets: [],
+    }
+
+    for (const dfAsset of dfAssetType.Assets) {
+      const item = (await pack.getDocument(
+        hashLookup(dfAsset.$id)
+      )) as IronswornItem
+      cat.assets.push({
+        df: dfAsset,
+        foundryItem: Object.freeze(item),
+      })
+    }
+
+    categories.push(cat)
+  }
+
+  data.categories = categories
+})
 </script>

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -29,6 +29,7 @@
             v-html="$enrichMarkdown(category.description)"
             @moveclick="moveClick"
           />
+
           <AssetBrowserCard
             :df="asset.df"
             :foundry-item="(asset.foundryItem as any)"

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -1,0 +1,6 @@
+<template>
+  <h1>Hey there</h1>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -17,26 +17,27 @@
     </h2>
 
     <Transition name="slide">
-      <section
-        v-if="category.expanded"
-        class="asset-category"
-        :aria-expanded="category.expanded"
-        :id="category.df.$id"
-      >
-        <WithRolllisteners
-          element="div"
-          class="category-description"
-          v-html="$enrichMarkdown(category.description)"
-          @moveclick="moveClick"
-        />
-        <AssetBrowserCard
-          :df="asset.df"
-          :foundry-item="(asset.foundryItem as any)"
-          v-for="asset in category.assets"
-          :key="asset.df.$id"
-          class="flexcol nogrow movesheet-row"
-        />
-      </section>
+      <div v-if="category.expanded">
+        <section
+          class="asset-category"
+          :aria-expanded="category.expanded"
+          :id="category.df.$id"
+        >
+          <WithRolllisteners
+            element="div"
+            class="category-description"
+            v-html="$enrichMarkdown(category.description)"
+            @moveclick="moveClick"
+          />
+          <AssetBrowserCard
+            :df="asset.df"
+            :foundry-item="(asset.foundryItem as any)"
+            v-for="asset in category.assets"
+            :key="asset.df.$id"
+            class="flexcol nogrow movesheet-row"
+          />
+        </section>
+      </div>
     </Transition>
   </section>
 </template>
@@ -127,7 +128,7 @@ async function resolveAssets() {
       title: i18n(dfAssetType.Name, 'Title'),
       description: renderLinksInStr(i18nDescription),
       expanded: false,
-      maxHeight: 200 + dfAssetType.Assets.length * 25,
+      maxHeight: 200 + dfAssetType.Assets.length * 30,
       assets: [],
     }
 

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -5,25 +5,27 @@
     :key="category.df.$id"
     :style="`--transition-max-height: ${category.maxHeight}px`"
   >
-    <header class="nogrow flexrow">
-      <button
-        type="button"
-        @click="category.expanded = !category.expanded"
+    <h2 class="flexrow">
+      <BtnFaicon
+        :icon="category.expanded ? 'caret-down' : 'caret-right'"
         :aria-controls="category.df.$id"
-        class="clickable text asset-expand-toggle"
+        class="juicy text"
+        @click="category.expanded = !category.expanded"
       >
-        <h2>{{ category.title }}</h2>
-      </button>
-    </header>
+        {{ category.title }}
+      </BtnFaicon>
+    </h2>
 
     <Transition name="slide">
       <section
         v-if="category.expanded"
+        class="asset-category"
         :aria-expanded="category.expanded"
         :id="category.df.$id"
       >
         <WithRolllisteners
-          element="p"
+          element="div"
+          class="category-description"
           v-html="$enrichMarkdown(category.description)"
           @moveclick="moveClick"
         />
@@ -44,6 +46,28 @@
 .slide-leave-active {
   max-height: var(--transition-max-height);
 }
+
+h2 {
+  margin: 0;
+  line-height: 1.5;
+  border: none;
+  height: min-content;
+  button {
+    line-height: 1.5;
+    height: min-content;
+    text-transform: uppercase;
+  }
+}
+
+.asset-category {
+  border-left: 2px solid;
+  margin-left: 10px;
+  padding-left: 10px;
+}
+
+.category-description {
+  margin: 10px 0;
+}
 </style>
 
 <script setup lang="ts">
@@ -54,6 +78,7 @@ import { ISAssetTypes, SFAssetTypes } from '../dataforged/data'
 import { IronswornItem } from '../item/item'
 import WithRolllisteners from './components/with-rolllisteners.vue'
 import AssetBrowserCard from './components/asset/asset-browser-card.vue'
+import BtnFaicon from './components/buttons/btn-faicon.vue'
 
 const props = defineProps<{ toolset: 'starforged' | 'ironsworn' }>()
 

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -48,7 +48,7 @@
 
 <script setup lang="ts">
 import { IAsset, IAssetType } from 'dataforged'
-import { provide, reactive } from 'vue'
+import { capitalize, provide, reactive } from 'vue'
 import { hashLookup, renderLinksInStr } from '../dataforged'
 import { ISAssetTypes, SFAssetTypes } from '../dataforged/data'
 import { IronswornItem } from '../item/item'
@@ -86,13 +86,20 @@ async function resolveAssets() {
   const assetTypes =
     props.toolset === 'starforged' ? SFAssetTypes : ISAssetTypes
 
+  const i18n = (categoryName: string, extension: string) => {
+    const capCat = capitalize(categoryName)
+    const capToolset = capitalize(props.toolset)
+    return game.i18n.localize(
+      `IRONSWORN.Asset Categories.${capToolset}.${capCat}.${extension}`
+    )
+  }
+
   const categories = [] as DisplayCategory[]
   for (const dfAssetType of assetTypes) {
-    const i18nKeyBase = `IRONSWORN.Asset Categories.${dfAssetType.Name}.`
-    const i18nDescription = game.i18n.localize(i18nKeyBase + 'Description')
+    const i18nDescription = i18n(dfAssetType.Name, 'Description')
     const cat: DisplayCategory = {
       df: dfAssetType,
-      title: game.i18n.localize(i18nKeyBase + 'Title'),
+      title: i18n(dfAssetType.Name, 'Title'),
       description: renderLinksInStr(i18nDescription),
       expanded: false,
       maxHeight: 200 + dfAssetType.Assets.length * 25,

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -31,7 +31,7 @@
         />
         <AssetBrowserCard
           :df="asset.df"
-          :foundry-item="asset.foundryItem"
+          :foundry-item="(asset.foundryItem as any)"
           v-for="asset in category.assets"
           :key="asset.df.$id"
           class="flexcol nogrow movesheet-row"

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -47,7 +47,7 @@
           </div>
         </dl>
         <ul class="asset-abilities flexcol">
-          <with-rolllisteners
+          <WithRolllisteners
             v-for="(ability, i) in data.data.abilities"
             :key="'ability' + i"
             element="li"
@@ -64,7 +64,7 @@
               :wedges="ability.clockMax"
               :ticked="ability.clockTicks"
             />
-          </with-rolllisteners>
+          </WithRolllisteners>
         </ul>
 
         <article
@@ -89,6 +89,7 @@ import { IronswornItem } from '../../../item/item'
 import { AssetDataProperties } from '../../../item/itemtypes'
 import AssetTrack from './asset-track.vue'
 import Clock from '../clock.vue'
+import WithRolllisteners from '../with-rolllisteners.vue'
 
 const props = defineProps<{
   df: IAsset

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -88,6 +88,7 @@ import { inject, reactive } from 'vue'
 import { IronswornItem } from '../../../item/item'
 import { AssetDataProperties } from '../../../item/itemtypes'
 import AssetTrack from './asset-track.vue'
+import Clock from '../clock.vue'
 
 const props = defineProps<{
   df: IAsset

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -1,7 +1,7 @@
 
 <template>
   <article
-    class="item-row flexcol document item ironsworn__asset"
+    class="item-row item flexcol document ironsworn__asset"
     draggable="true"
     :data-pack="foundryItem.pack"
     :data-id="foundryItem.id"
@@ -12,6 +12,7 @@
         ? `--ironsworn-color-thematic: ${data.data.color}`
         : undefined
     "
+    @dragstart="dragStart"
   >
     <header class="asset-header nogrow flexrow">
       <i class="fa-solid fa-grip nogrow block draggable item"></i>
@@ -109,5 +110,17 @@ const toolset = inject('toolset')
 
 function moveClick() {
   // TODO:
+}
+
+function dragStart(ev) {
+  ev.dataTransfer.setData(
+    'text/plain',
+    JSON.stringify({
+      type: 'Item',
+      pack: props.foundryItem.pack,
+      id: props.foundryItem.id,
+      uuid: props.foundryItem.uuid,
+    })
+  )
 }
 </script>

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -10,6 +10,13 @@
     "
   >
     <header class="asset-header nogrow flexrow">
+      <i
+        class="fa-solid fa-grip nogrow block draggable"
+        draggable="true"
+        :data-pack="foundryItem.pack"
+        :data-id="foundryItem.id"
+      ></i>
+
       <button
         type="button"
         @click="state.expanded = !state.expanded"

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -1,7 +1,11 @@
 
 <template>
   <article
-    class="item-row flexcol ironsworn__asset"
+    class="item-row flexcol document item ironsworn__asset"
+    draggable="true"
+    :data-pack="foundryItem.pack"
+    :data-id="foundryItem.id"
+    :data-document-id="foundryItem.id"
     :class="{ [`asset-${toolset}`]: true }"
     :style="
       data.data.color
@@ -10,12 +14,7 @@
     "
   >
     <header class="asset-header nogrow flexrow">
-      <i
-        class="fa-solid fa-grip nogrow block draggable"
-        draggable="true"
-        :data-pack="foundryItem.pack"
-        :data-id="foundryItem.id"
-      ></i>
+      <i class="fa-solid fa-grip nogrow block draggable item"></i>
 
       <button
         type="button"

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -1,0 +1,16 @@
+
+<template>
+  <div class="draggable">
+    <h3>{{ foundryItem.name }}</h3>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { IAsset } from 'dataforged'
+import { IronswornItem } from '../../../item/item'
+
+const props = defineProps<{
+  df: IAsset
+  foundryItem: Readonly<IronswornItem>
+}>()
+</script>

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -79,6 +79,10 @@
 </template>
 
 <style lang="less" scoped>
+.ironsworn__asset {
+  margin: 10px 0;
+  padding: 5px;
+}
 </style>
 
 <script setup lang="ts">

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -1,16 +1,101 @@
 
 <template>
-  <div class="draggable">
-    <h3>{{ foundryItem.name }}</h3>
-  </div>
+  <article
+    class="item-row flexcol ironsworn__asset"
+    :class="{ [`asset-${toolset}`]: true }"
+    :style="
+      data.data.color
+        ? `--ironsworn-color-thematic: ${data.data.color}`
+        : undefined
+    "
+  >
+    <header class="asset-header nogrow flexrow">
+      <button
+        type="button"
+        @click="state.expanded = !state.expanded"
+        :aria-controls="bodyId"
+        class="clickable text asset-expand-toggle"
+      >
+        <h4 class="asset-title">
+          {{ foundryItem.name }}
+        </h4>
+      </button>
+    </header>
+
+    <transition name="slide">
+      <section
+        v-if="state.expanded"
+        class="asset-body flexcol"
+        :aria-expanded="state.expanded"
+        :id="bodyId"
+      >
+        <dl class="asset-fields" v-if="data.data.fields?.length">
+          <div
+            class="asset-field"
+            v-for="(field, i) in data.data.fields"
+            :key="'field' + i"
+          >
+            <dt class="asset-field-label">{{ field.name }}</dt>
+            <dd class="asset-field-value">{{ field.value }}</dd>
+          </div>
+        </dl>
+        <ul class="asset-abilities flexcol">
+          <with-rolllisteners
+            v-for="(ability, i) in data.data.abilities"
+            :key="'ability' + i"
+            element="li"
+            :class="`asset-ability bullet-${toolset}`"
+            @moveclick="moveClick"
+          >
+            <div
+              class="asset-ability-text flexcol"
+              v-html="$enrichHtml(ability.description)"
+            ></div>
+            <clock
+              v-if="ability.hasClock"
+              class="asset-ability-clock"
+              :wedges="ability.clockMax"
+              :ticked="ability.clockTicks"
+            />
+          </with-rolllisteners>
+        </ul>
+
+        <article
+          class="asset-condition-meter flexcol"
+          v-if="data.data.track.enabled"
+        >
+          <h4>{{ data.data.track.name }}</h4>
+          <asset-track :item="foundryItem.toObject(true)" />
+        </article>
+      </section>
+    </transition>
+  </article>
 </template>
+
+<style lang="less" scoped>
+</style>
 
 <script setup lang="ts">
 import { IAsset } from 'dataforged'
+import { inject, reactive } from 'vue'
 import { IronswornItem } from '../../../item/item'
+import { AssetDataProperties } from '../../../item/itemtypes'
+import AssetTrack from './asset-track.vue'
 
 const props = defineProps<{
   df: IAsset
   foundryItem: Readonly<IronswornItem>
 }>()
+const data = props.foundryItem.data as AssetDataProperties
+
+const state = reactive({
+  expanded: false,
+})
+
+const bodyId = `asset-body-${props.foundryItem.id}`
+const toolset = inject('toolset')
+
+function moveClick() {
+  // TODO:
+}
 </script>

--- a/src/module/vue/components/asset/asset-track.vue
+++ b/src/module/vue/components/asset/asset-track.vue
@@ -14,7 +14,7 @@ import Boxrow from '../boxrow/boxrow.vue'
 
 const props = defineProps<{ item: any }>()
 
-const $item = inject($ItemKey)
+const $item = inject($ItemKey, undefined)
 
 function click(value) {
   $item?.update({

--- a/src/module/vue/components/character-sheet-tabs/ironsworn-main.vue
+++ b/src/module/vue/components/character-sheet-tabs/ironsworn-main.vue
@@ -22,10 +22,13 @@
               <Asset :asset="asset" />
             </div>
           </transition-group>
-          <div class="flexcol nogrow" style="text-align: center">
-            <BtnCompendium class="block nogrow" compendium="ironswornassets">
+          <div class="flexrow nogrow" style="text-align: center">
+            <BtnCompendium class="block" compendium="ironswornassets">
               {{ $t('IRONSWORN.Assets') }}
             </BtnCompendium>
+            <btn-faicon icon="atlas" @click="assetBrowser">
+              Browser
+            </btn-faicon>
           </div>
         </div>
       </section>
@@ -68,6 +71,7 @@ import ProgressControls from '../progress-controls.vue'
 import { throttle } from 'lodash'
 import BtnFaicon from '../buttons/btn-faicon.vue'
 import ActiveCompletedProgresses from '../active-completed-progresses.vue'
+import { AssetCompendiumBrowser } from '../../../item/asset-compendium-browser'
 
 const actor = inject('actor') as Ref
 const $actor = inject($ActorKey)
@@ -145,5 +149,13 @@ function completedSortUp(i) {
 }
 function completedSortDown(i) {
   applySort(i, i + 1, false, (x) => x.data.data.completed)
+}
+
+let theAssetBrowser: AssetCompendiumBrowser | undefined
+function assetBrowser() {
+  if (!theAssetBrowser) {
+    theAssetBrowser = new AssetCompendiumBrowser('ironsworn')
+  }
+  theAssetBrowser.render(true)
 }
 </script>

--- a/src/module/vue/components/character-sheet-tabs/ironsworn-main.vue
+++ b/src/module/vue/components/character-sheet-tabs/ironsworn-main.vue
@@ -26,9 +26,6 @@
             <BtnCompendium class="block" compendium="ironswornassets">
               {{ $t('IRONSWORN.Assets') }}
             </BtnCompendium>
-            <btn-faicon icon="atlas" @click="assetBrowser">
-              Browser
-            </btn-faicon>
           </div>
         </div>
       </section>
@@ -71,7 +68,6 @@ import ProgressControls from '../progress-controls.vue'
 import { throttle } from 'lodash'
 import BtnFaicon from '../buttons/btn-faicon.vue'
 import ActiveCompletedProgresses from '../active-completed-progresses.vue'
-import { AssetCompendiumBrowser } from '../../../item/asset-compendium-browser'
 
 const actor = inject('actor') as Ref
 const $actor = inject($ActorKey)
@@ -149,13 +145,5 @@ function completedSortUp(i) {
 }
 function completedSortDown(i) {
   applySort(i, i + 1, false, (x) => x.data.data.completed)
-}
-
-let theAssetBrowser: AssetCompendiumBrowser | undefined
-function assetBrowser() {
-  if (!theAssetBrowser) {
-    theAssetBrowser = new AssetCompendiumBrowser('ironsworn')
-  }
-  theAssetBrowser.render(true)
 }
 </script>

--- a/src/module/vue/components/character-sheet-tabs/sf-assets.vue
+++ b/src/module/vue/components/character-sheet-tabs/sf-assets.vue
@@ -67,9 +67,7 @@ function sortDown(i) {
 let theAssetBrowser: AssetCompendiumBrowser | undefined
 function assetBrowser() {
   if (!theAssetBrowser) {
-    theAssetBrowser = new AssetCompendiumBrowser(
-      'foundry-ironsworn.starforgedassets'
-    )
+    theAssetBrowser = new AssetCompendiumBrowser('starforged')
   }
   theAssetBrowser.render(true)
 }

--- a/src/module/vue/components/character-sheet-tabs/sf-assets.vue
+++ b/src/module/vue/components/character-sheet-tabs/sf-assets.vue
@@ -16,7 +16,6 @@
       <btn-compendium class="block" compendium="starforgedassets">{{
         $t('IRONSWORN.Assets')
       }}</btn-compendium>
-      <btn-faicon icon="atlas" @click="assetBrowser"> Browser </btn-faicon>
     </div>
   </div>
 </template>
@@ -29,7 +28,6 @@ import Asset from '../asset/asset.vue'
 import BtnCompendium from '../buttons/btn-compendium.vue'
 import { $ActorKey } from '../../provisions'
 import BtnFaicon from '../buttons/btn-faicon.vue'
-import { AssetCompendiumBrowser } from '../../../item/asset-compendium-browser'
 
 const actor = inject('actor') as Ref
 const $actor = inject($ActorKey)
@@ -62,13 +60,5 @@ function sortUp(i) {
 }
 function sortDown(i) {
   applySort(i, i + 1, false)
-}
-
-let theAssetBrowser: AssetCompendiumBrowser | undefined
-function assetBrowser() {
-  if (!theAssetBrowser) {
-    theAssetBrowser = new AssetCompendiumBrowser('starforged')
-  }
-  theAssetBrowser.render(true)
 }
 </script>

--- a/src/module/vue/components/character-sheet-tabs/sf-assets.vue
+++ b/src/module/vue/components/character-sheet-tabs/sf-assets.vue
@@ -27,7 +27,6 @@ import OrderButtons from '../order-buttons.vue'
 import Asset from '../asset/asset.vue'
 import BtnCompendium from '../buttons/btn-compendium.vue'
 import { $ActorKey } from '../../provisions'
-import BtnFaicon from '../buttons/btn-faicon.vue'
 
 const actor = inject('actor') as Ref
 const $actor = inject($ActorKey)

--- a/src/module/vue/components/character-sheet-tabs/sf-assets.vue
+++ b/src/module/vue/components/character-sheet-tabs/sf-assets.vue
@@ -16,6 +16,7 @@
       <btn-compendium class="block" compendium="starforgedassets">{{
         $t('IRONSWORN.Assets')
       }}</btn-compendium>
+      <btn-faicon icon="atlas" @click="assetBrowser"> Browser </btn-faicon>
     </div>
   </div>
 </template>
@@ -27,6 +28,8 @@ import OrderButtons from '../order-buttons.vue'
 import Asset from '../asset/asset.vue'
 import BtnCompendium from '../buttons/btn-compendium.vue'
 import { $ActorKey } from '../../provisions'
+import BtnFaicon from '../buttons/btn-faicon.vue'
+import { AssetCompendiumBrowser } from '../../../item/asset-compendium-browser'
 
 const actor = inject('actor') as Ref
 const $actor = inject($ActorKey)
@@ -59,5 +62,15 @@ function sortUp(i) {
 }
 function sortDown(i) {
   applySort(i, i + 1, false)
+}
+
+let theAssetBrowser: AssetCompendiumBrowser | undefined
+function assetBrowser() {
+  if (!theAssetBrowser) {
+    theAssetBrowser = new AssetCompendiumBrowser(
+      'foundry-ironsworn.starforgedassets'
+    )
+  }
+  theAssetBrowser.render(true)
 }
 </script>

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -168,7 +168,7 @@ label {
 
 <script setup lang="ts">
 import SheetHeaderBasic from './sheet-header-basic.vue'
-import { capitalize, flatten, throttle } from 'lodash'
+import { capitalize, flatten, sample, throttle } from 'lodash'
 import { provide, computed, reactive, inject } from 'vue'
 import { IronswornActor } from '../actor/actor'
 import { $ActorKey } from './provisions'
@@ -606,7 +606,7 @@ async function randomizeName() {
     const json = await CONFIG.IRONSWORN.dataforgedHelpers.getDFOracleByDfId(
       `Starforged/Oracles/Planets/${kc}`
     )
-    name = CONFIG.IRONSWORN._.sample(json?.['Sample Names'] ?? [])
+    name = sample(json?.['Sample Names'] ?? [])
   } else if (subtype === 'settlement') {
     const table =
       await CONFIG.IRONSWORN.dataforgedHelpers.getFoundryTableByDfId(

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -1599,6 +1599,32 @@
       "Vaults": "Vaults",
       "Vital": "Vital",
       "Zones": "Zones"
+    },
+    "Asset Categories": {
+      "Command Vehicle": {
+        "Title": "Command Vehicle",
+        "Description": "The **command vehicle** is your interstellar STARSHIP. It is a default asset for your character, taken when you begin your campaign. If you are playing with others, this is a shared asset; each of you may use the STARSHIP's abilities while aboard the craft.\n\nThe command vehicle has an integrity meter and starts at 5 integrity. When your STARSHIP takes a hit, make the @Compendium[foundry-ironsworn.starforgedmoves.3782f1b3c8ca8b88]{Withstand Damage} move to see what happens."
+      },
+      "Module": {
+        "Title": "Module",
+        "Description": "**Modules** are linked to your STARSHIP and offer additional options and advantages when aboard that vehicle.\n\nThese assets are earned and managed by a single character. They can be shared with allies, but only if it's practical for them to make use of it (not everyone may know how to use a RESEARCH LAB).\n\nWhen you @Compendium[foundry-ironsworn.starforgedmoves.3782f1b3c8ca8b88]{Withstand Damage} and score a miss, you can mark a module as broken to offset further danger for your STARSHIP. Flip the card over to indicate its broken state. A broken module cannot be used until you successfully @Compendium[foundry-ironsworn.starforgedmoves.eece9a67d1961f70]{Repair} it."
+      },
+      "Support Vehicle": {
+        "Title": "Support Vehicle",
+        "Description": "**Support vehicles** complement your command vehicle for planetside or short-range operations. If you are playing with others, one of you might serve as the pilot or owner of a support vehicle, but anyone on board can use its abilities as appropriate to the situation.\n\nAs with the command vehicle, your support vehicles have integrity meters. The maximum integrity varies based on the type of vehicle. When a support vehicle faces a damaging situation or environment, you must @Compendium[foundry-ironsworn.starforgedmoves.3782f1b3c8ca8b88]{Withstand Damage} to see how it fares."
+      },
+      "Path": {
+        "Title": "Path",
+        "Description": "**Paths** are your background, interests, training, skills, powers, and key equipment. They provide mechanical and narrative advantages, but also reflect who you are and how you interact with the world. When you create your character in the next chapter, you'll select at least two paths to get started.\n\nSome paths represent your skill with a signature weapon style or piece of equipment. If you see a requirement at the top of the asset card, such as “If you wield a bladed weapon…,” the asset is only usable when taking action using that item."
+      },
+      "Companion": {
+        "Title": "Companion",
+        "Description": "**Companions** are NPC helpers. When you gain a companion, give them a name and envision their look and personality.\n\nCompanions utilize a health meter that can be reduced if an outcome puts them in harm's way. When your companion faces harm, make the @Compendium[foundry-ironsworn.starforgedmoves.d34cdf2408cd22b6]{Companion Takes a Hit} move. When their health is at 0, they are in danger of being killed or destroyed."
+      },
+      "Deed": {
+        "Title": "Deed",
+        "Description": "**Deeds** represent the notable achievement and situations of your story, and how those events change your character.\n\nDeeds have a requirement listed at the top of the card, phrased as “Once you \\[blank\\].” You may not spend experience to acquire a deed until you fulfill the requirement, and you cannot choose a deed when creating your character."
+      }
     }
   }
 }

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -1601,29 +1601,49 @@
       "Zones": "Zones"
     },
     "Asset Categories": {
-      "Command Vehicle": {
-        "Title": "Command Vehicle",
-        "Description": "The **command vehicle** is your interstellar STARSHIP. It is a default asset for your character, taken when you begin your campaign. If you are playing with others, this is a shared asset; each of you may use the STARSHIP's abilities while aboard the craft.\n\nThe command vehicle has an integrity meter and starts at 5 integrity. When your STARSHIP takes a hit, make the @Compendium[foundry-ironsworn.starforgedmoves.3782f1b3c8ca8b88]{Withstand Damage} move to see what happens."
+      "Ironsworn": {
+        "Companion": {
+          "Title": "Companion",
+          "Description": "Companions are your NPC helpers. When you acquire a companion, give them a name and envision their appearance and personality. If they don’t have a starting ability, choose one. Upgrading a companion enables additional abilities.\n\nCompanions utilize a health track and may suffer harm as a result of one of your moves. When your companion takes damage, make the [Companion Endure Harm](Ironsworn/Moves/Suffer/Companion_Endure_Harm) move (page 94) to determine the outcome. See page 43 to learn more."
+        },
+        "Path": {
+          "Title": "Path",
+          "Description": "Paths represent your background, interests, training, and skills. They provide mechanical and narrative advantages, but also reflect who you are and how you interact with the world. For example, a **Ritualist** would likely have a different outlook than a **Veteran**. Choosing both those paths can reflect an evolution of your character or an interesting background."
+        },
+        "Combat Talent": {
+          "Title": "Combat Talent",
+          "Description": "*Ironsworn* characters are assumed to be skilled fighters. Even without a combat talent, you can wield weapons and perform combat moves (page 78). A combat talent reflects a particular area of expertise, and gives you additional options and bonuses.\n\nCombat talent assets typically require you to wield a specific weapon, as noted in the asset text. For example, if you are a **Shield-Bearer** and don’t have a shield at the ready, you can’t use the asset’s abilities."
+        },
+        "Ritual": {
+          "Title": "Ritual",
+          "Description": "Magic in *Ironsworn* is cast through rituals which help support your actions or act as unique moves. Like all assets, rituals can be selected as you gain experience and can be upgraded over time to make them more flexible or powerful.\n\nAll rituals utilize a move as their default marked ability. You must make this move and the associated action roll to trigger the effect. Any secondary abilities you gain by upgrading the asset are dependent on performing the ritual described as the default ability."
+        }
       },
-      "Module": {
-        "Title": "Module",
-        "Description": "**Modules** are linked to your STARSHIP and offer additional options and advantages when aboard that vehicle.\n\nThese assets are earned and managed by a single character. They can be shared with allies, but only if it's practical for them to make use of it (not everyone may know how to use a RESEARCH LAB).\n\nWhen you @Compendium[foundry-ironsworn.starforgedmoves.3782f1b3c8ca8b88]{Withstand Damage} and score a miss, you can mark a module as broken to offset further danger for your STARSHIP. Flip the card over to indicate its broken state. A broken module cannot be used until you successfully @Compendium[foundry-ironsworn.starforgedmoves.eece9a67d1961f70]{Repair} it."
-      },
-      "Support Vehicle": {
-        "Title": "Support Vehicle",
-        "Description": "**Support vehicles** complement your command vehicle for planetside or short-range operations. If you are playing with others, one of you might serve as the pilot or owner of a support vehicle, but anyone on board can use its abilities as appropriate to the situation.\n\nAs with the command vehicle, your support vehicles have integrity meters. The maximum integrity varies based on the type of vehicle. When a support vehicle faces a damaging situation or environment, you must @Compendium[foundry-ironsworn.starforgedmoves.3782f1b3c8ca8b88]{Withstand Damage} to see how it fares."
-      },
-      "Path": {
-        "Title": "Path",
-        "Description": "**Paths** are your background, interests, training, skills, powers, and key equipment. They provide mechanical and narrative advantages, but also reflect who you are and how you interact with the world. When you create your character in the next chapter, you'll select at least two paths to get started.\n\nSome paths represent your skill with a signature weapon style or piece of equipment. If you see a requirement at the top of the asset card, such as “If you wield a bladed weapon…,” the asset is only usable when taking action using that item."
-      },
-      "Companion": {
-        "Title": "Companion",
-        "Description": "**Companions** are NPC helpers. When you gain a companion, give them a name and envision their look and personality.\n\nCompanions utilize a health meter that can be reduced if an outcome puts them in harm's way. When your companion faces harm, make the @Compendium[foundry-ironsworn.starforgedmoves.d34cdf2408cd22b6]{Companion Takes a Hit} move. When their health is at 0, they are in danger of being killed or destroyed."
-      },
-      "Deed": {
-        "Title": "Deed",
-        "Description": "**Deeds** represent the notable achievement and situations of your story, and how those events change your character.\n\nDeeds have a requirement listed at the top of the card, phrased as “Once you \\[blank\\].” You may not spend experience to acquire a deed until you fulfill the requirement, and you cannot choose a deed when creating your character."
+      "Starforged": {
+        "Command Vehicle": {
+          "Title": "Command Vehicle",
+          "Description": "The **command vehicle** is your interstellar STARSHIP. It is a default asset for your character, taken when you begin your campaign. If you are playing with others, this is a shared asset; each of you may use the STARSHIP's abilities while aboard the craft.\n\nThe command vehicle has an integrity meter and starts at 5 integrity. When your STARSHIP takes a hit, make the @Compendium[foundry-ironsworn.starforgedmoves.3782f1b3c8ca8b88]{Withstand Damage} move to see what happens."
+        },
+        "Module": {
+          "Title": "Module",
+          "Description": "**Modules** are linked to your STARSHIP and offer additional options and advantages when aboard that vehicle.\n\nThese assets are earned and managed by a single character. They can be shared with allies, but only if it's practical for them to make use of it (not everyone may know how to use a RESEARCH LAB).\n\nWhen you @Compendium[foundry-ironsworn.starforgedmoves.3782f1b3c8ca8b88]{Withstand Damage} and score a miss, you can mark a module as broken to offset further danger for your STARSHIP. Flip the card over to indicate its broken state. A broken module cannot be used until you successfully @Compendium[foundry-ironsworn.starforgedmoves.eece9a67d1961f70]{Repair} it."
+        },
+        "Support Vehicle": {
+          "Title": "Support Vehicle",
+          "Description": "**Support vehicles** complement your command vehicle for planetside or short-range operations. If you are playing with others, one of you might serve as the pilot or owner of a support vehicle, but anyone on board can use its abilities as appropriate to the situation.\n\nAs with the command vehicle, your support vehicles have integrity meters. The maximum integrity varies based on the type of vehicle. When a support vehicle faces a damaging situation or environment, you must @Compendium[foundry-ironsworn.starforgedmoves.3782f1b3c8ca8b88]{Withstand Damage} to see how it fares."
+        },
+        "Path": {
+          "Title": "Path",
+          "Description": "**Paths** are your background, interests, training, skills, powers, and key equipment. They provide mechanical and narrative advantages, but also reflect who you are and how you interact with the world. When you create your character in the next chapter, you'll select at least two paths to get started.\n\nSome paths represent your skill with a signature weapon style or piece of equipment. If you see a requirement at the top of the asset card, such as “If you wield a bladed weapon…,” the asset is only usable when taking action using that item."
+        },
+        "Companion": {
+          "Title": "Companion",
+          "Description": "**Companions** are NPC helpers. When you gain a companion, give them a name and envision their look and personality.\n\nCompanions utilize a health meter that can be reduced if an outcome puts them in harm's way. When your companion faces harm, make the @Compendium[foundry-ironsworn.starforgedmoves.d34cdf2408cd22b6]{Companion Takes a Hit} move. When their health is at 0, they are in danger of being killed or destroyed."
+        },
+        "Deed": {
+          "Title": "Deed",
+          "Description": "**Deeds** represent the notable achievement and situations of your story, and how those events change your character.\n\nDeeds have a requirement listed at the top of the card, phrased as “Once you \\[blank\\].” You may not spend experience to acquire a deed until you fulfill the requirement, and you cannot choose a deed when creating your character."
+        }
       }
     }
   }

--- a/system/templates/asset-compendium-browser.hbs
+++ b/system/templates/asset-compendium-browser.hbs
@@ -1,0 +1,5 @@
+<form class='{{cssClass}} flexcol vueroot' autocomplete='off'>
+  <asset-compendium-browser :compendium='data.compendium'>
+    Loading…
+  </asset-compendium-browser>
+</form>

--- a/system/templates/asset-compendium-browser.hbs
+++ b/system/templates/asset-compendium-browser.hbs
@@ -1,5 +1,5 @@
 <form class='{{cssClass}} flexcol vueroot' autocomplete='off'>
-  <asset-compendium-browser :compendium='data.compendium'>
+  <asset-compendium-browser :toolset='data.toolset'>
     Loading…
   </asset-compendium-browser>
 </form>


### PR DESCRIPTION
This adds an asset-compendium browser window.


- [x] Works for both Ironsworn and Starforged assets
- [x] Render category descriptions
  - [x] Visual polish
- [x] Render assets
- [x] Make drag-and-drop work
- [x] Remove the "browser" buttons from the sheets again
- [x] Update CHANGELOG.md (nothing user-visible just yet)

Move clicks do nothing for now, that'll have to wait for a global emitter in a separate PR.