### PR TITLE
patch: standardize ActorKey + ItemKey to fix nonreactive progress

### DIFF
--- a/src/module/vue/asset-sheet.vue
+++ b/src/module/vue/asset-sheet.vue
@@ -75,15 +75,12 @@ import AssetFieldsedit from './components/asset/asset-fieldsedit.vue'
 import AssetAbilitiesedit from './components/asset/asset-abilitiesedit.vue'
 import AssetOptionsedit from './components/asset/asset-optionsedit.vue'
 import AssetTrackedit from './components/asset/asset-trackedit.vue'
-import { $ItemKey } from './provisions'
+import { $ItemKey, ItemKey } from './provisions'
 
 const $item = inject($ItemKey)
 
 const props = defineProps<{ item: any }>()
-provide(
-  'item',
-  computed(() => props.item)
-)
+provide(ItemKey, computed(() => props.item) as any)
 
 const editMode = computed(() => {
   return props.item.flags['foundry-ironsworn']?.['edit-mode']

--- a/src/module/vue/bondset-sheet.vue
+++ b/src/module/vue/bondset-sheet.vue
@@ -28,15 +28,12 @@
 
 <script setup lang="ts">
 import { computed, inject, provide } from 'vue'
-import { $ItemKey } from './provisions'
+import { $ItemKey, ItemKey } from './provisions'
 import BtnFaicon from '../vue/components/buttons/btn-faicon.vue'
 import { BondsetDataPropertiesData } from '../item/itemtypes'
 
 const props = defineProps<{ item: any }>()
-provide(
-  'item',
-  computed(() => props.item)
-)
+provide(ItemKey, computed(() => props.item) as any)
 
 const $item = inject($ItemKey)
 

--- a/src/module/vue/character-sheet.vue
+++ b/src/module/vue/character-sheet.vue
@@ -122,7 +122,7 @@
 </style>
 
 <script setup lang="ts">
-import { $ActorKey } from './provisions'
+import { $ActorKey, ActorKey } from './provisions'
 import AttrBox from './components/attr-box.vue'
 import BtnMomentumburn from './components/buttons/btn-momentumburn.vue'
 import Stack from './components/stack/stack.vue'
@@ -144,10 +144,7 @@ const props = defineProps<{
 }>()
 const actorData = props.actor as CharacterDataProperties
 
-provide(
-  'actor',
-  computed(() => props.actor)
-)
+provide(ActorKey, computed(() => props.actor) as any)
 
 const $actor = inject($ActorKey)
 

--- a/src/module/vue/components/active-completed-progresses.vue
+++ b/src/module/vue/components/active-completed-progresses.vue
@@ -111,7 +111,7 @@ h3 {
 
 <script setup lang="ts">
 import { computed, inject, reactive, Ref } from 'vue'
-import { $ActorKey } from '../provisions'
+import { $ActorKey, ActorKey } from '../provisions'
 import OrderButtons from './order-buttons.vue'
 import ProgressListItem from './progress/progress-list-item.vue'
 import ProgressControls from './progress-controls.vue'
@@ -135,7 +135,7 @@ const data = reactive({
   highlightCompleted: false,
 })
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 const $actor = inject($ActorKey)
 
 const excludedSubtypes = compact([props.exclude])

--- a/src/module/vue/components/asset/asset-abilitiesedit.vue
+++ b/src/module/vue/components/asset/asset-abilitiesedit.vue
@@ -58,10 +58,10 @@
 <script setup lang="ts">
 import { computed, Ref, inject } from 'vue'
 import { AssetDataPropertiesData } from '../../../item/itemtypes'
-import { $ItemKey } from '../../provisions'
+import { $ItemKey, ItemKey } from '../../provisions'
 import Clock from '../clock.vue'
 
-const item = inject('item') as Ref
+const item = inject(ItemKey) as Ref
 const $item = inject($ItemKey)
 
 const editMode = computed(

--- a/src/module/vue/components/asset/asset-fieldsedit.vue
+++ b/src/module/vue/components/asset/asset-fieldsedit.vue
@@ -51,10 +51,10 @@
 
 <script setup lang="ts">
 import { computed, inject, Ref } from 'vue'
-import { $ItemKey } from '../../provisions'
+import { $ItemKey, ItemKey } from '../../provisions'
 import BtnFaicon from '../buttons/btn-faicon.vue'
 
-const item = inject('item') as Ref
+const item = inject(ItemKey) as Ref
 const $item = inject($ItemKey)
 
 const editMode = computed(() => {

--- a/src/module/vue/components/asset/asset-optionsedit.vue
+++ b/src/module/vue/components/asset/asset-optionsedit.vue
@@ -49,11 +49,11 @@
 
 <script setup lang="ts">
 import { computed, inject, nextTick, Ref } from 'vue'
-import { $ItemKey } from '../../provisions'
+import { $ItemKey, ItemKey } from '../../provisions'
 import BtnFaicon from '../buttons/btn-faicon.vue'
 import AssetExclusiveoption from './asset-exclusiveoption.vue'
 
-const item = inject('item') as Ref
+const item = inject(ItemKey) as Ref
 const $item = inject($ItemKey)
 
 const editMode = computed(() => {

--- a/src/module/vue/components/asset/asset-trackedit.vue
+++ b/src/module/vue/components/asset/asset-trackedit.vue
@@ -29,10 +29,10 @@
 
 <script setup lang="ts">
 import { computed, inject, Ref } from 'vue'
-import { $ItemKey } from '../../provisions'
+import { $ItemKey, ItemKey } from '../../provisions'
 import AssetTrack from './asset-track.vue'
 
-const item = inject('item') as Ref
+const item = inject(ItemKey) as Ref
 const editMode = computed(() => {
   return item.value.flags['foundry-ironsworn']?.['edit-mode']
 })

--- a/src/module/vue/components/asset/asset.vue
+++ b/src/module/vue/components/asset/asset.vue
@@ -303,11 +303,11 @@ import AssetTrack from './asset-track.vue'
 import AssetExclusiveoption from './asset-exclusiveoption.vue'
 import Clock from '../clock.vue'
 import WithRolllisteners from '../with-rolllisteners.vue'
-import { $ActorKey, $ItemKey } from '../../provisions'
+import { $ActorKey, $ItemKey, ActorKey } from '../../provisions'
 import { defaultActor } from '../../../helpers/actors'
 
 const props = defineProps<{ asset: any }>()
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 
 const $actor = inject($ActorKey)
 const foundryItem = $actor

--- a/src/module/vue/components/attr-box.vue
+++ b/src/module/vue/components/attr-box.vue
@@ -43,11 +43,11 @@
 import { inject, computed, capitalize, Ref } from 'vue'
 import { IronswornActor } from '../../actor/actor'
 import { IronswornPrerollDialog } from '../../rolls'
-import { $ActorKey } from '../provisions'
+import { $ActorKey, ActorKey } from '../provisions'
 
 const props = defineProps<{ attr: string }>()
 const $actor = inject($ActorKey)
-const actor = inject('actor') as Ref<
+const actor = inject(ActorKey) as Ref<
   ReturnType<typeof IronswornActor.prototype.toObject>
 >
 

--- a/src/module/vue/components/bonds.vue
+++ b/src/module/vue/components/bonds.vue
@@ -14,7 +14,9 @@
 </template>
 
 <script setup lang="ts">
+import { ActorDataBaseSource } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/actorData.js'
 import { inject, computed, Ref } from 'vue'
+import { BondsetDataSource } from '../../item/itemtypes.js'
 import { $ActorKey, ActorKey } from '../provisions'
 import btnFaicon from './buttons/btn-faicon.vue'
 import ProgressTrack from './progress/progress-track.vue'
@@ -25,7 +27,9 @@ const actor = inject(ActorKey)
 const $actor = inject($ActorKey)
 
 const bonds = computed(() => {
-  return actor?.value?.items.find((x) => x.type === 'bondset')
+  return actor?.value?.items.find(
+    (x) => x.type === 'bondset'
+  ) as unknown as ActorDataBaseSource & BondsetDataSource
 })
 const bondcount = computed(() => {
   if (!bonds.value?.data?.bonds) return 0
@@ -33,11 +37,11 @@ const bondcount = computed(() => {
 })
 
 function editBonds() {
-  const item = $actor?.items.get(bonds.value._id)
+  const item = $actor?.items.get(bonds?.value?._id as string)
   item?.sheet?.render(true)
 }
 function rollBonds() {
-  const item = $actor?.items.get(bonds.value._id)
+  const item = $actor?.items.get(bonds?.value?._id as string)
   item?.writeEpilogue()
 }
 </script>

--- a/src/module/vue/components/bonds.vue
+++ b/src/module/vue/components/bonds.vue
@@ -8,24 +8,24 @@
     <ProgressTrack
       :ticks="bondcount"
       :rank="null"
-      :compact-progress="compactProgress"
+      :compact-progress="props.compactProgress"
     />
   </div>
 </template>
 
 <script setup lang="ts">
 import { inject, computed, Ref } from 'vue'
-import { $ActorKey } from '../provisions'
+import { $ActorKey, ActorKey } from '../provisions'
 import btnFaicon from './buttons/btn-faicon.vue'
 import ProgressTrack from './progress/progress-track.vue'
 
 const props = defineProps<{ compactProgress?: boolean }>()
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey)
 const $actor = inject($ActorKey)
 
 const bonds = computed(() => {
-  return actor.value?.items.find((x) => x.type === 'bondset')
+  return actor?.value?.items.find((x) => x.type === 'bondset')
 })
 const bondcount = computed(() => {
   if (!bonds.value?.data?.bonds) return 0

--- a/src/module/vue/components/character-header.vue
+++ b/src/module/vue/components/character-header.vue
@@ -43,10 +43,10 @@
 <script setup lang="ts">
 import SheetHeaderBasic from '../sheet-header-basic.vue'
 import { Ref, inject } from 'vue'
-import { $ActorKey } from '../provisions'
+import { $ActorKey, ActorKey } from '../provisions'
 import XpBox from './xp-box.vue'
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 const xpArray = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 const $actor = inject($ActorKey)

--- a/src/module/vue/components/character-sheet-tabs/ironsworn-main.vue
+++ b/src/module/vue/components/character-sheet-tabs/ironsworn-main.vue
@@ -62,7 +62,7 @@ h3 {
 
 <script lang="ts" setup>
 import { computed, inject, reactive, Ref } from 'vue'
-import { $ActorKey } from '../../provisions'
+import { $ActorKey, ActorKey } from '../../provisions'
 import Bonds from '../bonds.vue'
 import OrderButtons from '../order-buttons.vue'
 import Asset from '../asset/asset.vue'
@@ -74,7 +74,7 @@ import BtnFaicon from '../buttons/btn-faicon.vue'
 import ActiveCompletedProgresses from '../active-completed-progresses.vue'
 import { AssetCompendiumBrowser } from '../../../item/asset-compendium-browser'
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 const $actor = inject($ActorKey)
 
 const progressItems = computed(() => {

--- a/src/module/vue/components/character-sheet-tabs/ironsworn-notes.vue
+++ b/src/module/vue/components/character-sheet-tabs/ironsworn-notes.vue
@@ -11,10 +11,10 @@
 <script setup lang="ts">
 import { debounce } from 'lodash'
 import { inject, Ref } from 'vue'
-import { $ActorKey } from '../../provisions'
+import { $ActorKey, ActorKey } from '../../provisions'
 import MceEditor from '../mce-editor.vue'
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 const $actor = inject($ActorKey)
 
 const immediateSave = () => {

--- a/src/module/vue/components/character-sheet-tabs/sf-assets.vue
+++ b/src/module/vue/components/character-sheet-tabs/sf-assets.vue
@@ -26,10 +26,10 @@ import { computed, inject, Ref } from 'vue'
 import OrderButtons from '../order-buttons.vue'
 import Asset from '../asset/asset.vue'
 import BtnFaicon from '../buttons/btn-faicon.vue'
-import { $ActorKey } from '../../provisions'
+import { $ActorKey, ActorKey } from '../../provisions'
 import { AssetCompendiumBrowser } from '../../../item/asset-compendium-browser'
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 const $actor = inject($ActorKey)
 
 const editMode = computed(() => {

--- a/src/module/vue/components/character-sheet-tabs/sf-connections.vue
+++ b/src/module/vue/components/character-sheet-tabs/sf-connections.vue
@@ -33,16 +33,15 @@
 </style>
 
 <script setup lang="ts">
-import { computed, inject, provide, Ref } from 'vue'
-import { $ActorKey } from '../../provisions'
+import { computed, inject, Ref } from 'vue'
+import { $ActorKey, ActorKey } from '../../provisions'
 import OrderButtons from '../order-buttons.vue'
 import ProgressListItem from '../progress/progress-list-item.vue'
 import BtnFaicon from '../buttons/btn-faicon.vue'
 import { ProgressDataProperties } from '../../../item/itemtypes'
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 const $actor = inject($ActorKey)
-provide($ActorKey, $actor)
 
 const connections = computed(() => {
   return actor.value.items

--- a/src/module/vue/components/character-sheet-tabs/sf-legacies.vue
+++ b/src/module/vue/components/character-sheet-tabs/sf-legacies.vue
@@ -34,21 +34,16 @@
 </style>
 
 <script lang="ts" setup>
-import { computed, provide } from 'vue'
+import { computed, inject, Ref } from 'vue'
 import LegacyTrack from '../legacy-track.vue'
 import ProgressListItem from '../progress/progress-list-item.vue'
-import { IronswornActor } from '../../../actor/actor.js'
 import { ProgressDataPropertiesData } from '../../../item/itemtypes.js'
+import { ActorKey } from '../../provisions.js'
 
-const props = defineProps<{ actor: IronswornActor }>()
-
-provide(
-  'actor',
-  computed(() => props.actor)
-)
+const actor = inject(ActorKey) as Ref
 
 const starredProgresses = computed(() =>
-  props.actor.items.filter(
+  actor?.value.items.filter(
     (item) =>
       item.type === 'progress' &&
       (item.data as unknown as ProgressDataPropertiesData)?.starred

--- a/src/module/vue/components/character-sheet-tabs/sf-notes.vue
+++ b/src/module/vue/components/character-sheet-tabs/sf-notes.vue
@@ -11,10 +11,10 @@
 <script setup lang="ts">
 import { debounce } from 'lodash'
 import { inject, Ref } from 'vue'
-import { $ActorKey } from '../../provisions'
+import { $ActorKey, ActorKey } from '../../provisions'
 import MceEditor from '../mce-editor.vue'
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 const $actor = inject($ActorKey)
 
 const immediateSave = () => {

--- a/src/module/vue/components/conditions/condition-checkbox.vue
+++ b/src/module/vue/components/conditions/condition-checkbox.vue
@@ -12,9 +12,9 @@
 <script lang="ts" setup>
 import { inject, nextTick, Ref } from 'vue'
 import { IronswornSettings } from '../../../helpers/settings'
-import { $ActorKey } from '../../provisions'
+import { $ActorKey, ActorKey } from '../../provisions'
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 const $actor = inject($ActorKey)
 
 const props = defineProps<{

--- a/src/module/vue/components/conditions/custom-condition-checkbox.vue
+++ b/src/module/vue/components/conditions/custom-condition-checkbox.vue
@@ -28,11 +28,11 @@ input[type='text'] {
 <script lang="ts" setup>
 import { throttle } from 'lodash'
 import { computed, inject, nextTick, Ref } from 'vue'
-import { $ActorKey } from '../../provisions'
+import { $ActorKey, ActorKey } from '../../provisions'
 
 const props = defineProps<{ debilitykey: string }>()
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 const $actor = inject($ActorKey)
 
 const nameKey = computed(() => `${props.debilitykey}name`)

--- a/src/module/vue/components/foe-sheet.vue
+++ b/src/module/vue/components/foe-sheet.vue
@@ -67,7 +67,7 @@
 import SheetHeaderBasic from '../sheet-header-basic.vue'
 import { computed, inject, provide } from 'vue'
 import { IronswornActor } from '../../actor/actor'
-import { $ActorKey } from '../provisions'
+import { $ActorKey, ActorKey } from '../provisions'
 import { throttle } from 'lodash'
 import RankPips from './rank-pips/rank-pips.vue'
 import BtnFaicon from './buttons/btn-faicon.vue'
@@ -80,13 +80,10 @@ import Track from './progress/track.vue'
 import ProgressTrack from './progress/progress-track.vue'
 
 const props = defineProps<{
-  actor: ReturnType<typeof IronswornActor.prototype.toObject>
+  actor: ReturnType<typeof IronswornActor.prototype.toObject> &
+    FoeDataProperties
 }>()
-provide(
-  'actor',
-  computed(() => props.actor)
-)
-const actorData = props.actor as FoeDataProperties
+provide(ActorKey, computed(() => props.actor) as any)
 const foe = props.actor.items.find(
   (x) => x.type === 'progress'
 ) as ProgressDataProperties

--- a/src/module/vue/components/legacy-track.vue
+++ b/src/module/vue/components/legacy-track.vue
@@ -142,7 +142,7 @@
 </style>
 <script setup lang="ts">
 import { computed, inject, Ref } from 'vue'
-import { $ActorKey } from '../provisions'
+import { $ActorKey, ActorKey } from '../provisions'
 import BtnFaicon from './buttons/btn-faicon.vue'
 import { capitalize } from 'lodash'
 import { IronswornActor } from '../../actor/actor.js'
@@ -178,7 +178,7 @@ const props = defineProps<{
 }>()
 
 const $actor = inject($ActorKey)
-const actor = inject('actor') as Ref<
+const actor = inject(ActorKey) as Ref<
   ReturnType<typeof IronswornActor.prototype.toObject> &
     CharacterDataSource &
     ActorData

--- a/src/module/vue/components/progress/progress-list-item.vue
+++ b/src/module/vue/components/progress/progress-list-item.vue
@@ -144,7 +144,7 @@
 
 <script lang="ts" setup>
 import { capitalize, computed, inject, provide, Ref } from 'vue'
-import { $ActorKey } from '../../provisions'
+import { $ActorKey, $ItemKey, ActorKey, ItemKey } from '../../provisions'
 import Clock from '../clock.vue'
 import BtnRollprogress from '../buttons/btn-rollprogress.vue'
 import BtnFaicon from '../buttons/btn-faicon.vue'
@@ -152,10 +152,6 @@ import RankPips from '../rank-pips/rank-pips.vue'
 import DocumentImg from '../document-img.vue'
 import { RANKS } from '../../../constants.js'
 import ProgressTrack from './progress-track.vue'
-import { IronswornActor } from '../../../actor/actor.js'
-import { IronswornItem } from '../../../item/item.js'
-import { CharacterDataSource } from '../../../actor/actortypes.js'
-import { ProgressDataSource } from '../../../item/itemtypes.js'
 
 const props = defineProps<{
   item: any
@@ -166,24 +162,16 @@ const props = defineProps<{
   compactProgress?: boolean
 }>()
 
-const item = props.item as ReturnType<typeof IronswornItem.prototype.toObject> &
-  ProgressDataSource
-
+const actor = inject(ActorKey)
 const $actor = inject($ActorKey)
-const actor = inject('actor') as Ref<
-  ReturnType<typeof IronswornActor.prototype.toObject> & CharacterDataSource
->
 
-// ProgressListItem is embedded in a sheet but the sheet usually doesn't provide it -- in other words, this
-// So, get the id of the nonreactive item
-const progressId = computed<string>(() => props.item.id ?? props.item._id)
-// Then use it in a getter, $item
-const progressTrackData = $actor?.items.get(progressId.value)
-// and finally, provide the item getter's value for this component's children
-provide('item', progressTrackData)
+const foundryItem = $actor?.items.get(props.item.id ?? props.item._id)
+
+provide(ItemKey, computed(() => foundryItem?.toObject()) as any)
+provide($ItemKey, foundryItem)
 
 const editMode = computed(() => {
-  return (actor.value.flags as any)['foundry-ironsworn']?.['edit-mode']
+  return (actor?.value.flags as any)['foundry-ironsworn']?.['edit-mode']
 })
 const showTrackButtons = computed(() => {
   return props.item.data.hasTrack
@@ -202,30 +190,28 @@ const completedTooltip = computed(() => {
 })
 
 function edit() {
-  progressTrackData?.sheet?.render(true)
+  foundryItem?.sheet?.render(true)
 }
 function destroy() {
-  const titleKey = `IRONSWORN.Delete${capitalize(
-    progressTrackData?.type || ''
-  )}`
+  const titleKey = `IRONSWORN.Delete${capitalize(foundryItem?.type || '')}`
 
   Dialog.confirm({
     title: game.i18n.localize(titleKey),
     content: `<p><strong>${game.i18n.localize(
       'IRONSWORN.ConfirmDelete'
     )}</strong></p>`,
-    yes: () => progressTrackData?.delete(),
+    yes: () => foundryItem?.delete(),
     defaultYes: false,
   })
 }
 function rankClick(rank: keyof typeof RANKS) {
-  progressTrackData?.update({ data: { rank } })
+  foundryItem?.update({ data: { rank } })
 }
 function advance() {
-  progressTrackData?.markProgress(1)
+  foundryItem?.markProgress(1)
 }
 function retreat() {
-  progressTrackData?.markProgress(-1)
+  foundryItem?.markProgress(-1)
 }
 
 const $emit = defineEmits(['completed'])
@@ -233,14 +219,14 @@ const $emit = defineEmits(['completed'])
 function toggleComplete() {
   const completed = !props.item.data.completed
   if (completed) $emit('completed')
-  progressTrackData?.update({ data: { completed } })
+  foundryItem?.update({ data: { completed } })
 }
 function toggleStar() {
-  progressTrackData?.update({
+  foundryItem?.update({
     data: { starred: !props.item.data.starred },
   })
 }
 function setClock(clockTicks: number) {
-  progressTrackData?.update({ data: { clockTicks } })
+  foundryItem?.update({ data: { clockTicks } })
 }
 </script>

--- a/src/module/vue/components/sf-characterheader.vue
+++ b/src/module/vue/components/sf-characterheader.vue
@@ -61,10 +61,10 @@ textarea {
 import SheetHeader from '../sheet-header.vue'
 import { debounce } from 'lodash'
 import { inject, ref, Ref } from 'vue'
-import { $ActorKey } from '../provisions'
+import { $ActorKey, ActorKey } from '../provisions'
 import DocumentImg from './document-img.vue'
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 const $actor = inject($ActorKey)
 
 const name = ref<HTMLInputElement | null>(null)

--- a/src/module/vue/components/site/site-denizenbox.vue
+++ b/src/module/vue/components/site/site-denizenbox.vue
@@ -41,12 +41,12 @@ import { reactive, Ref } from '@vue/reactivity'
 import { inject } from '@vue/runtime-core'
 import { computed, ref } from 'vue'
 import { SiteDataProperties } from '../../../actor/actortypes'
-import { $ActorKey } from '../../provisions'
+import { $ActorKey, ActorKey } from '../../provisions'
 
 const props = defineProps<{ idx: number }>()
 const data = reactive({ focused: false })
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 const $actor = inject($ActorKey)
 
 const editMode = computed(() => {

--- a/src/module/vue/components/site/site-droparea.vue
+++ b/src/module/vue/components/site/site-droparea.vue
@@ -40,8 +40,8 @@
 </template>
 
 <script setup lang="ts">
-import { inject } from '@vue/runtime-core'
-import { $ActorKey } from '../../provisions'
+import { inject, Ref } from '@vue/runtime-core'
+import { $ActorKey, ActorKey } from '../../provisions'
 import { computed } from 'vue'
 import DocumentImg from '../document-img.vue'
 import BtnFaicon from '../buttons/btn-faicon.vue'
@@ -56,7 +56,7 @@ const props = defineProps<{
 
 const $actor = inject($ActorKey)
 
-const actor = inject('actor') as any
+const actor = inject(ActorKey) as Ref
 const editMode = computed(() => {
   return actor.value.flags['foundry-ironsworn']?.['edit-mode']
 })

--- a/src/module/vue/components/site/site-movebox.vue
+++ b/src/module/vue/components/site/site-movebox.vue
@@ -21,7 +21,6 @@ const props = defineProps<{
   disabled?: boolean
 }>()
 
-const actor = inject('actor') as Ref
 const $actor = inject($ActorKey)
 
 const i18nKey = computed(() => `IRONSWORN.MoveContents.${props.movename}.title`)

--- a/src/module/vue/components/stack/stack-box.vue
+++ b/src/module/vue/components/stack/stack-box.vue
@@ -12,12 +12,10 @@
 
 <script lang="ts" setup>
 import { computed, inject, Ref } from 'vue'
-import { IronswornActor } from '../../../actor/actor'
-import { CharacterDataProperties } from '../../../actor/actortypes'
 import { IronswornSettings } from '../../../helpers/settings'
-import { $ActorKey } from '../../provisions'
+import { $ActorKey, ActorKey } from '../../provisions'
 
-const actor = inject('actor') as Ref
+const actor = inject(ActorKey) as Ref
 const $actor = inject($ActorKey)
 
 const props = defineProps<{

--- a/src/module/vue/provisions.ts
+++ b/src/module/vue/provisions.ts
@@ -1,4 +1,4 @@
-import { InjectionKey } from 'vue'
+import { InjectionKey, Ref } from 'vue'
 import { enrichHtml, enrichMarkdown } from './vue-plugin'
 import { IronswornActor } from '../actor/actor'
 import { IronswornItem } from '../item/item'
@@ -14,7 +14,10 @@ export const $EnrichMarkdownKey = Symbol('$enrichMarkdown') as InjectionKey<
 // Sheets have to provide these
 export const $ActorKey = Symbol('$actor') as InjectionKey<IronswornActor>
 export const ActorKey = Symbol('actor') as InjectionKey<
-  ReturnType<typeof IronswornActor.prototype.toObject>
+  Ref<ReturnType<typeof IronswornActor.prototype.toObject>>
 >
 
 export const $ItemKey = Symbol('$item') as InjectionKey<IronswornItem>
+export const ItemKey = Symbol('actor') as InjectionKey<
+  Ref<ReturnType<typeof IronswornItem.prototype.toObject>>
+>

--- a/src/module/vue/sf-charactermovesheet.vue
+++ b/src/module/vue/sf-charactermovesheet.vue
@@ -20,16 +20,14 @@ import SfMovesheetmoves from './components/sf-movesheetmoves.vue'
 import SfMovesheetoracles from './components/sf-movesheetoracles.vue'
 import { computed, provide, ref } from 'vue'
 import { CharacterDataProperties } from '../actor/actortypes'
+import { ActorKey } from './provisions.js'
 
 const props = defineProps<{
   actor: CharacterDataProperties
   toolset: 'ironsworn' | 'starforged'
 }>()
 
-provide(
-  'actor',
-  computed(() => props.actor)
-)
+provide(ActorKey, computed(() => props.actor) as any)
 
 const tabs = ref<InstanceType<typeof Tabs>>()
 const movesTab = ref<InstanceType<typeof SfMovesheetmoves>>()

--- a/src/module/vue/sf-charactersheet.vue
+++ b/src/module/vue/sf-charactersheet.vue
@@ -162,13 +162,11 @@ import sfImpacts from './components/sf-impacts.vue'
 import SfAssets from './components/character-sheet-tabs/sf-assets.vue'
 import SfProgresses from './components/character-sheet-tabs/sf-progresses.vue'
 import SfNotes from './components/character-sheet-tabs/sf-notes.vue'
+import { ActorKey } from './provisions.js'
 
 const props = defineProps<{
   actor: any
 }>()
 
-provide(
-  'actor',
-  computed(() => props.actor)
-)
+provide(ActorKey, computed(() => props.actor) as any)
 </script>

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -171,7 +171,7 @@ import SheetHeaderBasic from './sheet-header-basic.vue'
 import { capitalize, flatten, sample, throttle } from 'lodash'
 import { provide, computed, reactive, inject } from 'vue'
 import { IronswornActor } from '../actor/actor'
-import { $ActorKey } from './provisions'
+import { $ActorKey, ActorKey } from './provisions'
 import BtnIsicon from './components/buttons/btn-isicon.vue'
 import DocumentImg from './components/document-img.vue'
 import DocumentName from './components/document-name.vue'
@@ -185,10 +185,7 @@ const props = defineProps<{
   actor: any
 }>()
 
-provide(
-  'actor',
-  computed(() => props.actor)
-)
+provide(ActorKey, computed(() => props.actor) as any)
 const $actor = inject($ActorKey)
 
 const sceneId = game.user?.viewedScene

--- a/src/module/vue/sfmove-sheet.vue
+++ b/src/module/vue/sfmove-sheet.vue
@@ -131,7 +131,7 @@
 import SheetHeader from './sheet-header.vue'
 import { provide, computed, reactive, inject } from 'vue'
 import { get, set } from 'lodash'
-import { $ItemKey } from './provisions'
+import { $ItemKey, ItemKey } from './provisions'
 import DocumentName from './components/document-name.vue'
 import SfmoveTab from './components/sfmove-tab.vue'
 import BtnFaicon from './components/buttons/btn-faicon.vue'
@@ -139,10 +139,8 @@ import BtnFaicon from './components/buttons/btn-faicon.vue'
 const props = defineProps<{
   item: any
 }>()
-provide(
-  'item',
-  computed(() => props.item)
-)
+provide(ItemKey, computed(() => props.item) as any)
+
 const $item = inject($ItemKey)
 
 const state = reactive<{

--- a/src/module/vue/shared-sheet.vue
+++ b/src/module/vue/shared-sheet.vue
@@ -64,7 +64,7 @@ textarea.notes {
 import { provide, computed, inject } from 'vue'
 import { RollDialog } from '../helpers/rolldialog'
 import { IronswornSettings } from '../helpers/settings'
-import { $ActorKey } from './provisions'
+import { $ActorKey, ActorKey } from './provisions'
 import Boxrow from './components/boxrow/boxrow.vue'
 import Bonds from './components/bonds.vue'
 import MceEditor from './components/mce-editor.vue'
@@ -77,10 +77,7 @@ import SheetBasic from './sheet-basic.vue'
 const props = defineProps<{
   actor: any
 }>()
-provide(
-  'actor',
-  computed(() => props.actor)
-)
+provide(ActorKey, computed(() => props.actor) as any)
 const $actor = inject($ActorKey)
 
 const hasBonds = computed(() => {

--- a/src/module/vue/site-sheet.vue
+++ b/src/module/vue/site-sheet.vue
@@ -156,7 +156,7 @@ textarea {
 import SheetHeaderBasic from './sheet-header-basic.vue'
 import { provide, computed, inject, nextTick, ref, Component } from 'vue'
 import { IronswornActor } from '../actor/actor'
-import { $ActorKey } from './provisions'
+import { $ActorKey, ActorKey } from './provisions'
 import { throttle } from 'lodash'
 import DocumentImg from './components/document-img.vue'
 import DocumentName from './components/document-name.vue'
@@ -189,10 +189,7 @@ const props = defineProps<{
   actor: any
 }>()
 
-provide(
-  'actor',
-  computed(() => props.actor)
-)
+provide(ActorKey, computed(() => props.actor) as any)
 
 const $actor = inject($ActorKey)
 

--- a/src/module/vue/starship-sheet.vue
+++ b/src/module/vue/starship-sheet.vue
@@ -43,13 +43,11 @@ import SfAssets from './components/character-sheet-tabs/sf-assets.vue'
 import SfNotes from './components/character-sheet-tabs/sf-notes.vue'
 import ConditionCheckbox from './components/conditions/condition-checkbox.vue'
 import SheetBasic from './sheet-basic.vue'
+import { ActorKey } from './provisions.js'
 
 const props = defineProps<{
   actor: ReturnType<typeof IronswornActor.prototype.toObject>
 }>()
 
-provide(
-  'actor',
-  computed(() => props.actor)
-)
+provide(ActorKey, computed(() => props.actor) as any)
 </script>


### PR DESCRIPTION
this replaces all instances of 'actor' and 'item' used as injection keys with ActorKey and a new constant, ItemKey. this in turn resolves some nonreactive progress items in the previous PR from this branch.