### PR TITLE
Reinstate asset descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Reinstate visibility of the description field for custom assets ([#499](https://github.com/ben/foundry-ironsworn/pull/499))
+
 ## 1.18.0
 
 - Updated asset-selection UI, with a better browsing experience ([#488](https://github.com/ben/foundry-ironsworn/pull/488))

--- a/src/module/item/itemtypes.ts
+++ b/src/module/item/itemtypes.ts
@@ -31,6 +31,7 @@ interface AssetExclusiveOption {
 
 interface AssetDataSourceData {
   category: string
+  description?: string
   requirement: string
   color: string
   fields: AssetField[]

--- a/src/module/vue/asset-sheet.vue
+++ b/src/module/vue/asset-sheet.vue
@@ -21,15 +21,29 @@
       />
     </section>
 
-    <p>
-      <input
-        v-if="editMode"
-        type="text"
-        v-model="item.data.requirement"
-        @blur="setRequirement"
-      />
+    <section style="margin-top: 1em" v-if="item.data.description">
+      <div v-if="editMode">
+        <label>{{ $t('IRONSWORN.Description') }}</label>
+        <input
+          type="text"
+          v-model="item.data.description"
+          @blur="setDescription"
+        />
+      </div>
+      <span v-else v-html="$enrichHtml(item.data.description)"></span>
+    </section>
+
+    <section style="margin-top: 1em">
+      <div v-if="editMode">
+        <label>Requirement</label>
+        <input
+          type="text"
+          v-model="item.data.requirement"
+          @blur="setRequirement"
+        />
+      </div>
       <span v-else v-html="$enrichHtml(item.data.requirement)"></span>
-    </p>
+    </section>
 
     <!-- FIELDS -->
     <div v-if="hasFields || editMode">
@@ -96,6 +110,9 @@ const hasFields = computed(() => {
 
 function setRequirement() {
   $item?.update({ data: { requirement: props.item.data.requirement } })
+}
+function setDescription() {
+  $item?.update({ data: { description: props.item.data.description } })
 }
 function setCategory() {
   $item?.update({ data: { category: props.item.data.category } })

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -36,6 +36,10 @@
         :aria-expanded="state.expanded"
         :id="bodyId"
       >
+        <div
+          v-html="$enrichHtml(data.data.description ?? '')"
+          v-if="data.data.description"
+        ></div>
         <div v-html="$enrichHtml(data.data.requirement ?? '')"></div>
 
         <dl class="asset-fields" v-if="data.data.fields?.length">

--- a/src/module/vue/components/asset/asset.vue
+++ b/src/module/vue/components/asset/asset.vue
@@ -41,6 +41,10 @@
         :aria-expanded="expanded"
         :id="bodyId"
       >
+        <div
+          v-html="$enrichHtml(asset.data.description ?? '')"
+          v-if="asset.data.description"
+        ></div>
         <div v-html="$enrichHtml(asset.data.requirement ?? '')"></div>
 
         <dl class="asset-fields" v-if="asset.data.fields?.length">


### PR DESCRIPTION
Wups, these got hidden. Reinstating visibility and editability for assets that already have them.

- [x] Editor - view and edit mode
- [x] PC sheet
- [x] Asset catalog
- [x] Update CHANGELOG.md
