### PR TITLE
Stop using `Object.freeze`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Release
 
+- Rework code that was freezing Foundry objects, causing issues with asset sheets ([#510](https://github.com/ben/foundry-ironsworn/pull/510))
+  - **NOTE:** this change may break your custom move/oracle/asset hooks, check [the guide](https://github.com/ben/foundry-ironsworn/wiki/Extensibility#using-hooks) for the new format
+
 ## 1.18.4
 
 - Progress-roll button now has the correct number of filled boxes in its tooltip

--- a/src/module/features/customassets.ts
+++ b/src/module/features/customassets.ts
@@ -6,7 +6,7 @@ import { IronswornItem } from '../item/item'
 
 export interface DisplayAsset {
   df?: IAsset
-  foundryItem: Readonly<IronswornItem>
+  foundryItem: () => IronswornItem
 }
 
 export interface DisplayCategory {
@@ -81,7 +81,7 @@ async function compendiumMoves(
       )) as IronswornItem
       cat.assets.push({
         df: dfAsset,
-        foundryItem: Object.freeze(item),
+        foundryItem: () => item,
       })
     }
 
@@ -101,7 +101,7 @@ async function augmentWithFolderContents(categories: DisplayCategory[]) {
   const customAssets = [] as DisplayAsset[]
   for (const item of folder.contents) {
     if (item.documentName !== 'Item' || item.type !== 'asset') continue
-    customAssets.push({ foundryItem: Object.freeze(item) })
+    customAssets.push({ foundryItem: () => item })
   }
 
   categories.push({

--- a/src/module/features/custommoves.ts
+++ b/src/module/features/custommoves.ts
@@ -12,7 +12,7 @@ export interface MoveCategory {
 
 export interface Move {
   displayName: string
-  moveItem: IronswornItem
+  moveItem: () => IronswornItem
   dataforgedMove?: IMove
 }
 
@@ -37,13 +37,6 @@ async function createMoveTree(
 
   // Fire the hook and allow extensions to modify the list
   await Hooks.call('ironswornMoves', ret)
-
-  // Prevent Vue from adding reactivity to Foundry objects
-  for (const cat of ret) {
-    for (const move of cat.moves) {
-      ;(move.moveItem as any) = Object.freeze(move.moveItem)
-    }
-  }
 
   return ret
 }
@@ -74,7 +67,7 @@ function walkCategory(
       newCategory.moves.push({
         dataforgedMove: move,
         displayName: moveItem.name || move.Display.Title,
-        moveItem,
+        moveItem: () => moveItem,
       })
     } else {
       console.warn(`Couldn't find item for move ${move.$id}`)
@@ -96,7 +89,7 @@ async function augmentWithFolderContents(categories: MoveCategory[]) {
     if (moveItem.documentName !== 'Item' || moveItem.type !== 'sfmove') continue
     customMoves.push({
       displayName: moveItem.name ?? '(move)',
-      moveItem,
+      moveItem: () => moveItem,
     })
   }
 

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -34,9 +34,9 @@
 
           <AssetBrowserCard
             :df="asset.df"
-            :foundry-item="(asset.foundryItem as any)"
+            :foundry-item="asset.foundryItem"
             v-for="asset in category.assets"
-            :key="asset.foundryItem.id ?? ''"
+            :key="asset.foundryItem()?.id ?? ''"
             class="nogrow movesheet-row"
           />
         </section>
@@ -51,6 +51,7 @@ h2 {
   line-height: 1.5;
   border: none;
   height: min-content;
+
   button {
     line-height: 1.5;
     height: min-content;

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -2,9 +2,9 @@
   <article
     class="item-row document ironsworn__asset"
     draggable="true"
-    :data-pack="foundryItem.pack"
-    :data-id="foundryItem.id"
-    :data-document-id="foundryItem.id"
+    :data-pack="foundryItem().pack"
+    :data-id="foundryItem().id"
+    :data-document-id="foundryItem().id"
     :class="{ [`asset-${toolset}`]: true }"
     :style="
       data.data.color
@@ -23,7 +23,7 @@
         class="clickable text asset-expand-toggle"
       >
         <h4 class="asset-title">
-          {{ foundryItem.name }}
+          {{ foundryItem().name }}
         </h4>
       </button>
     </header>
@@ -118,22 +118,22 @@ import { $ItemKey, ItemKey } from '../../provisions.js'
 
 const props = defineProps<{
   df?: IAsset
-  foundryItem: Readonly<IronswornItem>
+  foundryItem: () => IronswornItem
 }>()
 
 const toolset = inject('toolset')
-const data = props.foundryItem.data as AssetDataProperties
-provide($ItemKey, props.foundryItem)
+const data = props.foundryItem().data as AssetDataProperties
+provide($ItemKey, props.foundryItem())
 provide(
   ItemKey,
-  computed(() => props.foundryItem.toObject() as any)
+  computed(() => props.foundryItem().toObject() as any)
 )
 
 const state = reactive({
   expanded: false,
 })
 
-const bodyId = `asset-body-${props.foundryItem.id}`
+const bodyId = `asset-body-${props.foundryItem().id}`
 
 function moveClick(item) {
   CONFIG.IRONSWORN.emitter.emit('highlightMove', item.id)
@@ -144,9 +144,9 @@ function dragStart(ev) {
     'text/plain',
     JSON.stringify({
       type: 'AssetBrowserData',
-      pack: props.foundryItem.pack || undefined,
-      id: props.foundryItem.id,
-      uuid: props.foundryItem.uuid,
+      pack: props.foundryItem().pack || undefined,
+      id: props.foundryItem().id,
+      uuid: props.foundryItem().uuid,
     })
   )
 }

--- a/src/module/vue/components/buttons/btn-oracle.vue
+++ b/src/module/vue/components/buttons/btn-oracle.vue
@@ -17,12 +17,12 @@
 <script setup lang="ts">
 import { sample } from 'lodash'
 import { inject } from 'vue'
-import { IOracleTreeNodeVue } from '../../../features/customoracles.js'
+import { IOracleTreeNode } from '../../../features/customoracles.js'
 import { OracleRollMessage } from '../../../rolls'
 import BtnIsicon from './btn-isicon.vue'
 
 const props = defineProps<{
-  node: IOracleTreeNodeVue
+  node: IOracleTreeNode
   disabled?: boolean
 }>()
 

--- a/src/module/vue/components/buttons/btn-oracle.vue
+++ b/src/module/vue/components/buttons/btn-oracle.vue
@@ -17,12 +17,12 @@
 <script setup lang="ts">
 import { sample } from 'lodash'
 import { inject } from 'vue'
-import { IOracleTreeNode } from '../../../features/customoracles.js'
+import { IOracleTreeNodeVue } from '../../../features/customoracles.js'
 import { OracleRollMessage } from '../../../rolls'
 import BtnIsicon from './btn-isicon.vue'
 
 const props = defineProps<{
-  node: IOracleTreeNode
+  node: IOracleTreeNodeVue
   disabled?: boolean
 }>()
 
@@ -35,7 +35,10 @@ async function rollOracle() {
     starforged: 'foundry-ironsworn.starforgedoracles',
   }[toolset ?? '']
 
-  const orm = await OracleRollMessage.fromTableId(randomTable?.id ?? '', pack)
+  const orm = await OracleRollMessage.fromTableId(
+    randomTable?.()?.id ?? '',
+    pack
+  )
   orm.createOrUpdate()
 }
 </script>

--- a/src/module/vue/components/buttons/btn-rollmove.vue
+++ b/src/module/vue/components/buttons/btn-rollmove.vue
@@ -30,14 +30,12 @@ const props = defineProps<{
 const $actor = inject($ActorKey)
 
 async function rollMove() {
-  if (props.move?.dataforgedMove)
+  if (!props.move) throw new Error('No move?')
+  if (props.move.dataforgedMove)
     return IronswornPrerollDialog.showForOfficialMove(
       props.move?.dataforgedMove.$id,
       $actor
     )
-  IronswornPrerollDialog.showForMove(
-    props.move?.moveItem as Move['moveItem'],
-    $actor
-  )
+  IronswornPrerollDialog.showForMove(props.move.moveItem(), $actor)
 }
 </script>

--- a/src/module/vue/components/buttons/btn-sendmovetochat.vue
+++ b/src/module/vue/components/buttons/btn-sendmovetochat.vue
@@ -23,6 +23,6 @@ const props = defineProps<{
 }>()
 
 function sendToChat(e) {
-  createSfMoveChatMessage(props.move.moveItem)
+  createSfMoveChatMessage(props.move.moveItem())
 }
 </script>

--- a/src/module/vue/components/oracle-tree-node.vue
+++ b/src/module/vue/components/oracle-tree-node.vue
@@ -87,14 +87,14 @@ h4 {
 
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue'
-import { IOracleTreeNodeVue } from '../../features/customoracles'
+import { IOracleTreeNode } from '../../features/customoracles'
 import BtnFaicon from './buttons/btn-faicon.vue'
 import BtnOracle from './buttons/btn-oracle.vue'
 import { IronswornItem } from '../../item/item'
 import RulesTextOracle from './rules-text/rules-text-oracle.vue'
 import CollapseTransition from './transition/collapse-transition.vue'
 
-const props = defineProps<{ node: IOracleTreeNodeVue }>()
+const props = defineProps<{ node: IOracleTreeNode }>()
 
 const state = reactive({
   manuallyExpanded: props.node.forceExpanded ?? false,

--- a/src/module/vue/components/oracle-tree-node.vue
+++ b/src/module/vue/components/oracle-tree-node.vue
@@ -86,15 +86,15 @@ h4 {
 </style>
 
 <script setup lang="ts">
-import { computed, inject, reactive, ref } from 'vue'
-import { IOracleTreeNode } from '../../features/customoracles'
+import { computed, reactive, ref } from 'vue'
+import { IOracleTreeNodeVue } from '../../features/customoracles'
 import BtnFaicon from './buttons/btn-faicon.vue'
 import BtnOracle from './buttons/btn-oracle.vue'
 import { IronswornItem } from '../../item/item'
 import RulesTextOracle from './rules-text/rules-text-oracle.vue'
 import CollapseTransition from './transition/collapse-transition.vue'
 
-const props = defineProps<{ node: IOracleTreeNode }>()
+const props = defineProps<{ node: IOracleTreeNodeVue }>()
 
 const state = reactive({
   manuallyExpanded: props.node.forceExpanded ?? false,

--- a/src/module/vue/components/rules-text/oracle-table.vue
+++ b/src/module/vue/components/rules-text/oracle-table.vue
@@ -1,8 +1,8 @@
 <template>
   <table class="oracle-table">
     <caption
-      v-if="!noCaption && oracleTable.data.description"
-      v-html="enrichMarkdown(oracleTable.data.description)"
+      v-if="!noCaption && oracleTable().data.description"
+      v-html="enrichMarkdown(oracleTable().data.description ?? '')"
     />
     <thead>
       <tr>
@@ -50,7 +50,10 @@ import { computed } from '@vue/reactivity'
 import { sortBy } from 'lodash'
 import { enrichMarkdown } from '../../vue-plugin.js'
 
-const props = defineProps<{ oracleTable: RollTable; noCaption?: boolean }>()
+const props = defineProps<{
+  oracleTable: () => RollTable
+  noCaption?: boolean
+}>()
 
 type TableRowData = {
   low: number
@@ -67,7 +70,7 @@ function rangeString({ low, high }: TableRowData) {
 }
 const tableRows = computed(() =>
   sortBy(
-    props.oracleTable.data.results.contents.map(
+    props.oracleTable().data.results.contents.map(
       (row) =>
         ({
           low: row.data.range[0],

--- a/src/module/vue/components/rules-text/rules-text-move.vue
+++ b/src/module/vue/components/rules-text/rules-text-move.vue
@@ -2,7 +2,7 @@
   <RulesText
     class="rules-text-move"
     :source="move.dataforgedMove?.Source"
-    :content="(props.move.moveItem.data as SFMoveDataProperties).data.Text"
+    :content="(props.move.moveItem().data as SFMoveDataProperties).data.Text"
     type="markdown"
   >
     <template #before-main>

--- a/src/module/vue/components/rules-text/rules-text-oracle.vue
+++ b/src/module/vue/components/rules-text/rules-text-oracle.vue
@@ -20,5 +20,5 @@ import RulesText from './rules-text.vue'
 import OracleTable from './oracle-table.vue'
 import { ISource } from 'dataforged'
 
-const props = defineProps<{ oracleTable: RollTable; source?: ISource }>()
+const props = defineProps<{ oracleTable: () => RollTable; source?: ISource }>()
 </script>

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -99,7 +99,7 @@ const data = reactive({
 })
 
 const fulltext = computed(() => {
-  const foundryMoveData = props.move.moveItem?.data as
+  const foundryMoveData = props.move.moveItem()?.data as
     | SFMoveDataProperties
     | undefined
   return IronswornHandlebarsHelpers.stripTables(
@@ -107,7 +107,7 @@ const fulltext = computed(() => {
   )
 })
 const canRoll = computed(() => {
-  return moveHasRollableOptions(props.move.moveItem)
+  return moveHasRollableOptions(props.move.moveItem())
 })
 
 if (props.move.dataforgedMove) {
@@ -125,7 +125,7 @@ const $el = ref<HTMLElement>()
 
 // Inbound move clicks: if this is the intended move, expand/highlight/scroll
 CONFIG.IRONSWORN.emitter.on('highlightMove', async (moveId) => {
-  if (moveId === props.move.moveItem.id) {
+  if (moveId === props.move.moveItem()?.id) {
     data.expanded = true
     data.highlighted = true
     await nextTick()

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -72,14 +72,10 @@ h4 {
 </style>
 
 <script setup lang="ts">
-import { computed, inject, nextTick, reactive, ref } from 'vue'
+import { computed, nextTick, reactive, ref } from 'vue'
 import { getDFOracleByDfId } from '../../dataforged'
 import { Move } from '../../features/custommoves'
-import {
-  convertToVueTree,
-  IOracleTreeNodeVue,
-  walkOracle,
-} from '../../features/customoracles'
+import { IOracleTreeNode, walkOracle } from '../../features/customoracles'
 import { IronswornHandlebarsHelpers } from '../../helpers/handlebars'
 import { IronswornItem } from '../../item/item'
 import { moveHasRollableOptions } from '../../rolls/preroll-dialog'
@@ -95,7 +91,7 @@ const props = defineProps<{ move: Move }>()
 const data = reactive({
   expanded: false,
   highlighted: false,
-  oracles: [] as IOracleTreeNodeVue[],
+  oracles: [] as IOracleTreeNode[],
 })
 
 const fulltext = computed(() => {
@@ -114,7 +110,7 @@ if (props.move.dataforgedMove) {
   const oracleIds = props.move.dataforgedMove.Oracles ?? []
   Promise.all(oracleIds.map(getDFOracleByDfId)).then(async (dfOracles) => {
     const nodes = await Promise.all(dfOracles.map(walkOracle))
-    data.oracles.push(...nodes.map(convertToVueTree))
+    data.oracles.push(...nodes)
   })
 }
 

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -76,8 +76,8 @@ import { computed, inject, nextTick, reactive, ref } from 'vue'
 import { getDFOracleByDfId } from '../../dataforged'
 import { Move } from '../../features/custommoves'
 import {
-  IOracleTreeNode,
-  walkAndFreezeTables,
+  convertToVueTree,
+  IOracleTreeNodeVue,
   walkOracle,
 } from '../../features/customoracles'
 import { IronswornHandlebarsHelpers } from '../../helpers/handlebars'
@@ -95,7 +95,7 @@ const props = defineProps<{ move: Move }>()
 const data = reactive({
   expanded: false,
   highlighted: false,
-  oracles: [] as IOracleTreeNode[],
+  oracles: [] as IOracleTreeNodeVue[],
 })
 
 const fulltext = computed(() => {
@@ -114,10 +114,7 @@ if (props.move.dataforgedMove) {
   const oracleIds = props.move.dataforgedMove.Oracles ?? []
   Promise.all(oracleIds.map(getDFOracleByDfId)).then(async (dfOracles) => {
     const nodes = await Promise.all(dfOracles.map(walkOracle))
-    for (const n of nodes) {
-      walkAndFreezeTables(n)
-    }
-    data.oracles.push(...nodes)
+    data.oracles.push(...nodes.map(convertToVueTree))
   })
 }
 

--- a/src/module/vue/components/sf-movesheetoracles.vue
+++ b/src/module/vue/components/sf-movesheetoracles.vue
@@ -42,7 +42,7 @@ import { findOracleWithIntermediateNodes } from '../../dataforged'
 import {
   createIronswornOracleTree,
   createStarforgedOracleTree,
-  IOracleTreeNode,
+  IOracleTreeNodeVue,
 } from '../../features/customoracles'
 import OracleTreeNode from './oracle-tree-node.vue'
 
@@ -53,13 +53,9 @@ const tempTreeRoot =
   props.toolset === 'ironsworn'
     ? await createIronswornOracleTree()
     : await createStarforgedOracleTree()
-// Add the flags we'll use for UI stuff later
-function walk(node: IOracleTreeNode) {
-  node.forceExpanded = node.forceHidden = false
-  node.children.forEach(walk)
-}
-walk(tempTreeRoot)
-const treeRoot = reactive<IOracleTreeNode>(tempTreeRoot)
+
+const treeRoot = reactive<IOracleTreeNodeVue>(tempTreeRoot)
+type ReactiveNode = typeof treeRoot
 
 const search = reactive({ q: '' })
 watch(search, ({ q }) => {
@@ -72,7 +68,7 @@ watch(search, ({ q }) => {
   if (q && re) {
     // Walk the tree and test each name.
     // Force expanded on all parent nodes leading to a match
-    const walk = (node: IOracleTreeNode, parentMatch: boolean): boolean => {
+    const searchWalk = (node: ReactiveNode, parentMatch: boolean): boolean => {
       // Match against current name (i18n) but also aliases in Dataforged
       let thisMatch = re.test(node.displayName)
       for (const alias of node.dataforgedNode?.Aliases ?? []) {
@@ -82,7 +78,7 @@ watch(search, ({ q }) => {
       // Check for descendant matches
       let childMatch = false
       for (const child of node.children) {
-        childMatch ||= walk(child, thisMatch || parentMatch)
+        childMatch ||= searchWalk(child, thisMatch || parentMatch)
       }
 
       // Expanded if part of a tree with a match
@@ -93,7 +89,7 @@ watch(search, ({ q }) => {
       // Pass match up to ancestors
       return thisMatch || childMatch
     }
-    walk(treeRoot, false)
+    searchWalk(treeRoot, false)
   } else {
     // Walk the tree setting all force flags to false
     function resetflags(node) {

--- a/src/module/vue/components/sf-movesheetoracles.vue
+++ b/src/module/vue/components/sf-movesheetoracles.vue
@@ -42,7 +42,7 @@ import { findOracleWithIntermediateNodes } from '../../dataforged'
 import {
   createIronswornOracleTree,
   createStarforgedOracleTree,
-  IOracleTreeNodeVue,
+  IOracleTreeNode,
 } from '../../features/customoracles'
 import OracleTreeNode from './oracle-tree-node.vue'
 
@@ -54,7 +54,7 @@ const tempTreeRoot =
     ? await createIronswornOracleTree()
     : await createStarforgedOracleTree()
 
-const treeRoot = reactive<IOracleTreeNodeVue>(tempTreeRoot)
+const treeRoot = reactive<IOracleTreeNode>(tempTreeRoot)
 type ReactiveNode = typeof treeRoot
 
 const search = reactive({ q: '' })


### PR DESCRIPTION
Turns out it freezes in place, and that's introducing bugs. Foundry objects that are fetched for Vue were being frozen, which meant they couldn't have their sheets opened.

- [x] Stop using `Object.freeze`
- [x] Update CHANGELOG.md, mention breaking change for hooks
