### PR TITLE
package versioning workaround so volar will stop complaining

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tinymce/tinymce-vue": "^5.0.0",
         "@types/lodash": "^4.14.170",
         "@types/marked": "^4.0.3",
+        "@types/node": "^18.8.0",
         "@typescript-eslint/eslint-plugin": "^5.28.0",
         "@typescript-eslint/parser": "^5.28.0",
         "@typescript/analyze-trace": "^0.9.0",
@@ -2680,9 +2681,9 @@
       "integrity": "sha512-eEAhnz21CwvKVW+YvRvcTuFKNU9CV1qH+opcgVK3pIMI6YZzDm6gc8o2vHjldFk6MGKt5pueSB7IOpvpx5Qekw=="
     },
     "node_modules/@types/node": {
-      "version": "18.8.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
-      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w=="
+      "version": "18.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.0.tgz",
+      "integrity": "sha512-u+h43R6U8xXDt2vzUaVP3VwjjLyOJk6uEciZS8OSyziUQGOwmk+l+4drxcsDboHXwyTaqS1INebghmWMRxq3LA=="
     },
     "node_modules/@types/offscreencanvas": {
       "version": "2019.7.0",
@@ -2912,51 +2913,42 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.0.0.tgz",
-      "integrity": "sha512-gUeIyRmPD9dtCAADK+ZCr0n4n1lbwsGJ+ulQn//phfD+p9B1E9B4o2WRoeOOAkcqXZTEFmCxtg+S6Pa0pwUVHA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.0.7.tgz",
+      "integrity": "sha512-T3iJ7Ej5Ywrsn1nEfvOQ98LdFZu3TtoXD8UELHto/u5QyQk4U2GfPl+0ZjuS39ZPocU9l/5CMhrxHsgv/hFWVA==",
       "dependencies": {
-        "@volar/source-map": "1.0.0",
-        "@vue/reactivity": "^3.2.38",
+        "@volar/source-map": "1.0.7",
+        "@vue/reactivity": "^3.2.40",
         "muggle-string": "^0.1.0"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.0.0.tgz",
-      "integrity": "sha512-EyIauGZmii2d4FicOw9eUnjq5nX/lqxKoPDPAZSGfkYOI/zfhhRydjLWR/BTbtPEV+Pqu6p5QjV3ts2/jQtKPw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.0.7.tgz",
+      "integrity": "sha512-58xtTXbriaBoGHl5epE5kYI0Pk81yGmM3Mb/5TEUEzA16dGovXiwtEGce2xCgo0ps42OInFvFuaRv3SvM0k6mg==",
       "dependencies": {
         "muggle-string": "^0.1.0"
       }
     },
     "node_modules/@volar/typescript": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.0.0.tgz",
-      "integrity": "sha512-0BsNJnN/VuQ3WQ3RmdJo7Xf8pwT0JCV0xdtgH9okEMeuXBLPZjg7tKwDHT3TY8ord1mVk0tjNnzyQJAhaQ8t0w==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.0.7.tgz",
+      "integrity": "sha512-VH3dMxTqkdUqjmdVwIytBjppH5iy18qK9peb3E9CNbvzf/+b3TpdX0zoyglaKmC5IeHG68KHXK2yps734yZ4nQ==",
       "dependencies": {
-        "@volar/language-core": "1.0.0",
-        "@volar/typescript-faster": "1.0.0"
-      }
-    },
-    "node_modules/@volar/typescript-faster": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@volar/typescript-faster/-/typescript-faster-1.0.0.tgz",
-      "integrity": "sha512-QsKMB2bEfWMKaPKW5HDmvBsusIgGx0WG1U30EaHwpnME25XZSJh1a5BZh9uUQcZteLkjtEfAmCI2PkfDgz1zew==",
-      "dependencies": {
-        "semver": "^7.3.7"
+        "@volar/language-core": "1.0.7"
       }
     },
     "node_modules/@volar/vue-language-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.0.0.tgz",
-      "integrity": "sha512-BYJvROEGNMDxTbyT7j9B9i8VDeLzEwDijNy2WactsK4mhruYRp911BwI9UNia4dD6RgMhyIShExRNoCwtCNMtw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.0.7.tgz",
+      "integrity": "sha512-5InGpRLu5FGeUkVNr1LvQfvThdSsyzIwvsYqYSGLj6VNmS7rzLacoKjZlTwz68/976aU3zjdgx94PoNl5n/SqA==",
       "dependencies": {
-        "@volar/language-core": "1.0.0",
-        "@volar/source-map": "1.0.0",
-        "@vue/compiler-dom": "^3.2.38",
-        "@vue/compiler-sfc": "^3.2.38",
-        "@vue/reactivity": "^3.2.38",
-        "@vue/shared": "^3.2.38",
+        "@volar/language-core": "1.0.7",
+        "@volar/source-map": "1.0.7",
+        "@vue/compiler-dom": "^3.2.40",
+        "@vue/compiler-sfc": "^3.2.40",
+        "@vue/reactivity": "^3.2.40",
+        "@vue/shared": "^3.2.40",
         "minimatch": "^5.1.0",
         "vue-template-compiler": "^2.7.10"
       }
@@ -2981,12 +2973,12 @@
       }
     },
     "node_modules/@volar/vue-typescript": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.0.0.tgz",
-      "integrity": "sha512-W9qU96gdApnEgHZf6i9BKQVDJqreYKVsXDRdJPtJEeykSwi6an0LYwgkpCfDjW3pyeVYSYAxVegYE8rSo9k4IA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.0.7.tgz",
+      "integrity": "sha512-SZlUJfMh/9NOIfpYtSVcIAbJVEzEiH2qWBIYHPooMXC02qey56Tg6J2eMhIoKWIuZH0VRRbX8IgFHevSQzzGOw==",
       "dependencies": {
-        "@volar/typescript": "1.0.0",
-        "@volar/vue-language-core": "1.0.0"
+        "@volar/typescript": "1.0.7",
+        "@volar/vue-language-core": "1.0.7"
       }
     },
     "node_modules/@vue/babel-helper-vue-transform-on": {
@@ -6662,12 +6654,12 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.0.0.tgz",
-      "integrity": "sha512-QtQunVlF8SLs75s9FTCOOLXx6Fb5ccN6r3xDT4rUzznPzP6xfRC/iWhrJImEBRz74fhqXWPUMfujcmibnwYyXw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.0.7.tgz",
+      "integrity": "sha512-PaeWgISdXsPnV3a1NKfiAZb0iyvgLroxKzjPj1itoR5ZH0UOeVZBbDxpH7VPxAt6tCxiAoAIIisDs1QQrsSu3w==",
       "dependencies": {
-        "@volar/vue-language-core": "1.0.0",
-        "@volar/vue-typescript": "1.0.0"
+        "@volar/vue-language-core": "1.0.7",
+        "@volar/vue-typescript": "1.0.7"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -9180,9 +9172,9 @@
       "integrity": "sha512-eEAhnz21CwvKVW+YvRvcTuFKNU9CV1qH+opcgVK3pIMI6YZzDm6gc8o2vHjldFk6MGKt5pueSB7IOpvpx5Qekw=="
     },
     "@types/node": {
-      "version": "18.8.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
-      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w=="
+      "version": "18.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.0.tgz",
+      "integrity": "sha512-u+h43R6U8xXDt2vzUaVP3VwjjLyOJk6uEciZS8OSyziUQGOwmk+l+4drxcsDboHXwyTaqS1INebghmWMRxq3LA=="
     },
     "@types/offscreencanvas": {
       "version": "2019.7.0",
@@ -9312,51 +9304,42 @@
       "requires": {}
     },
     "@volar/language-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.0.0.tgz",
-      "integrity": "sha512-gUeIyRmPD9dtCAADK+ZCr0n4n1lbwsGJ+ulQn//phfD+p9B1E9B4o2WRoeOOAkcqXZTEFmCxtg+S6Pa0pwUVHA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.0.7.tgz",
+      "integrity": "sha512-T3iJ7Ej5Ywrsn1nEfvOQ98LdFZu3TtoXD8UELHto/u5QyQk4U2GfPl+0ZjuS39ZPocU9l/5CMhrxHsgv/hFWVA==",
       "requires": {
-        "@volar/source-map": "1.0.0",
-        "@vue/reactivity": "^3.2.38",
+        "@volar/source-map": "1.0.7",
+        "@vue/reactivity": "^3.2.40",
         "muggle-string": "^0.1.0"
       }
     },
     "@volar/source-map": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.0.0.tgz",
-      "integrity": "sha512-EyIauGZmii2d4FicOw9eUnjq5nX/lqxKoPDPAZSGfkYOI/zfhhRydjLWR/BTbtPEV+Pqu6p5QjV3ts2/jQtKPw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.0.7.tgz",
+      "integrity": "sha512-58xtTXbriaBoGHl5epE5kYI0Pk81yGmM3Mb/5TEUEzA16dGovXiwtEGce2xCgo0ps42OInFvFuaRv3SvM0k6mg==",
       "requires": {
         "muggle-string": "^0.1.0"
       }
     },
     "@volar/typescript": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.0.0.tgz",
-      "integrity": "sha512-0BsNJnN/VuQ3WQ3RmdJo7Xf8pwT0JCV0xdtgH9okEMeuXBLPZjg7tKwDHT3TY8ord1mVk0tjNnzyQJAhaQ8t0w==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.0.7.tgz",
+      "integrity": "sha512-VH3dMxTqkdUqjmdVwIytBjppH5iy18qK9peb3E9CNbvzf/+b3TpdX0zoyglaKmC5IeHG68KHXK2yps734yZ4nQ==",
       "requires": {
-        "@volar/language-core": "1.0.0",
-        "@volar/typescript-faster": "1.0.0"
-      }
-    },
-    "@volar/typescript-faster": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@volar/typescript-faster/-/typescript-faster-1.0.0.tgz",
-      "integrity": "sha512-QsKMB2bEfWMKaPKW5HDmvBsusIgGx0WG1U30EaHwpnME25XZSJh1a5BZh9uUQcZteLkjtEfAmCI2PkfDgz1zew==",
-      "requires": {
-        "semver": "^7.3.7"
+        "@volar/language-core": "1.0.7"
       }
     },
     "@volar/vue-language-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.0.0.tgz",
-      "integrity": "sha512-BYJvROEGNMDxTbyT7j9B9i8VDeLzEwDijNy2WactsK4mhruYRp911BwI9UNia4dD6RgMhyIShExRNoCwtCNMtw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.0.7.tgz",
+      "integrity": "sha512-5InGpRLu5FGeUkVNr1LvQfvThdSsyzIwvsYqYSGLj6VNmS7rzLacoKjZlTwz68/976aU3zjdgx94PoNl5n/SqA==",
       "requires": {
-        "@volar/language-core": "1.0.0",
-        "@volar/source-map": "1.0.0",
-        "@vue/compiler-dom": "^3.2.38",
-        "@vue/compiler-sfc": "^3.2.38",
-        "@vue/reactivity": "^3.2.38",
-        "@vue/shared": "^3.2.38",
+        "@volar/language-core": "1.0.7",
+        "@volar/source-map": "1.0.7",
+        "@vue/compiler-dom": "^3.2.40",
+        "@vue/compiler-sfc": "^3.2.40",
+        "@vue/reactivity": "^3.2.40",
+        "@vue/shared": "^3.2.40",
         "minimatch": "^5.1.0",
         "vue-template-compiler": "^2.7.10"
       },
@@ -9380,12 +9363,12 @@
       }
     },
     "@volar/vue-typescript": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.0.0.tgz",
-      "integrity": "sha512-W9qU96gdApnEgHZf6i9BKQVDJqreYKVsXDRdJPtJEeykSwi6an0LYwgkpCfDjW3pyeVYSYAxVegYE8rSo9k4IA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.0.7.tgz",
+      "integrity": "sha512-SZlUJfMh/9NOIfpYtSVcIAbJVEzEiH2qWBIYHPooMXC02qey56Tg6J2eMhIoKWIuZH0VRRbX8IgFHevSQzzGOw==",
       "requires": {
-        "@volar/typescript": "1.0.0",
-        "@volar/vue-language-core": "1.0.0"
+        "@volar/typescript": "1.0.7",
+        "@volar/vue-language-core": "1.0.7"
       }
     },
     "@vue/babel-helper-vue-transform-on": {
@@ -11833,12 +11816,12 @@
       }
     },
     "vue-tsc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.0.0.tgz",
-      "integrity": "sha512-QtQunVlF8SLs75s9FTCOOLXx6Fb5ccN6r3xDT4rUzznPzP6xfRC/iWhrJImEBRz74fhqXWPUMfujcmibnwYyXw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.0.7.tgz",
+      "integrity": "sha512-PaeWgISdXsPnV3a1NKfiAZb0iyvgLroxKzjPj1itoR5ZH0UOeVZBbDxpH7VPxAt6tCxiAoAIIisDs1QQrsSu3w==",
       "requires": {
-        "@volar/vue-language-core": "1.0.0",
-        "@volar/vue-typescript": "1.0.0"
+        "@volar/vue-language-core": "1.0.7",
+        "@volar/vue-typescript": "1.0.7"
       }
     },
     "web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tinymce/tinymce-vue": "^5.0.0",
     "@types/lodash": "^4.14.170",
     "@types/marked": "^4.0.3",
+    "@types/node": "^18.8.0",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "@typescript/analyze-trace": "^0.9.0",


### PR DESCRIPTION
<img width="550" alt="Screen Shot 2022-10-13 at 9 41 57 PM" src="https://user-images.githubusercontent.com/5354757/195764082-fecfc226-4317-4554-8634-da1f570e0218.png">

more info [here](https://github.com/johnsoncodehk/volar/issues/1985). it's resolved on volar/main, but won't actually be truly fixed for us until vue 3.2.41.

i don't think this has interactions with anything user-facing -- just TS typings -- anyways, but i'm requesting review anyways to make sure @ben sees it :)