### PR TITLE
Item-type labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Add human-readable labels to the dialog when creating a new item, including a nudge away from using the old `'move'` item type ([#513](https://github.com/ben/foundry-ironsworn/pull/513))
+
 ## 1.18.8
 
 - Fix the "liveness" of the Foe sheet

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -1668,12 +1668,12 @@
   },
   "ITEM": {
     "TypeAsset": "Asset",
-    "TypeProgress": "Progress",
-    "TypeVow": "Vow",
+    "TypeProgress": "Progress track",
+    "TypeVow": "Vow progress track",
     "TypeBondset": "Bondset",
     "TypeMove": "(Deprecated move type)",
     "TypeSfmove": "Move",
-    "TypeDelve-theme": "Delve Theme",
-    "TypeDelve-domain": "Delve Domain"
+    "TypeDelve-theme": "Delve site theme",
+    "TypeDelve-domain": "Delve site domain"
   }
 }

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -1669,7 +1669,7 @@
   "ITEM": {
     "TypeAsset": "Asset",
     "TypeProgress": "Progress track",
-    "TypeVow": "Vow progress track",
+    "TypeVow": "(Deprecated vow type)",
     "TypeBondset": "Bondset",
     "TypeMove": "(Deprecated move type)",
     "TypeSfmove": "Move",

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -1665,5 +1665,15 @@
         }
       }
     }
+  },
+  "ITEM": {
+    "TypeAsset": "Asset",
+    "TypeProgress": "Progress",
+    "TypeVow": "Vow",
+    "TypeBondset": "Bondset",
+    "TypeMove": "(Deprecated move type)",
+    "TypeSfmove": "Move",
+    "TypeDelve-theme": "Delve Theme",
+    "TypeDelve-domain": "Delve Domain"
   }
 }

--- a/system/system.json
+++ b/system/system.json
@@ -2,7 +2,7 @@
   "name": "foundry-ironsworn",
   "id": "foundry-ironsworn",
   "title": "Ironsworn & Starforged",
-  "description": "An implementation of the Ironsworn and Starforged systems, by Shawn Tomkins.",
+  "description": "An implementation of the Ironsworn and Starforged systems, by Shawn Tomkin.",
   "license": "LICENSE.txt",
   "version": "1.18.8",
   "url": "https://github.com/ben/foundry-ironsworn",
@@ -62,8 +62,12 @@
       "caption": "Ironsworn & Starforged"
     }
   ],
-  "esmodules": ["ironsworn.js"],
-  "styles": ["ironsworn.css"],
+  "esmodules": [
+    "ironsworn.js"
+  ],
+  "styles": [
+    "ironsworn.css"
+  ],
   "dependencies": [],
   "relationships": {
     "requires": []


### PR DESCRIPTION
This adds i18n strings for item types, which means we can discourage people from using the old `'move'` item type.

![CleanShot 2022-10-18 at 06 22 52](https://user-images.githubusercontent.com/39902/196441788-8e3bb1bd-8c40-4839-bb29-263a317fe273.jpg)

- [x] Add the strings
- [x] Update CHANGELOG.md
