### PR TITLE
Oracle results: copy button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Add a button to oracle-result chat cards, which copies the result to the clipboard ([#516](https://github.com/ben/foundry-ironsworn/pull/516))
+
 ## 1.18.9
 
 - Add human-readable labels to the dialog when creating a new item, including a nudge away from using the old `'move'` item type ([#513](https://github.com/ben/foundry-ironsworn/pull/513))

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -110,6 +110,9 @@ export class IronswornChatCard {
     html
       .find('.starforged__oracle__reroll')
       .on('click', (ev) => this._sfOracleReroll.call(this, ev))
+    html
+      .find('.copy-result')
+      .on('click', (ev) => this._oracleResultCopy.call(this, ev))
   }
 
   async _moveNavigate(ev: JQuery.ClickEvent) {
@@ -362,6 +365,15 @@ export class IronswornChatCard {
       table.pack || undefined
     )
     msg.createOrUpdate()
+  }
+
+  async _oracleResultCopy(ev: JQuery.ClickEvent) {
+    const { result } = ev.currentTarget.dataset
+    await navigator.clipboard.writeText(result)
+    const icon = $(ev.currentTarget).find('i.fas')
+    icon.removeClass('fa-copy').addClass('fa-check')
+    await new Promise((r) => setTimeout(r, 2000))
+    icon.removeClass('fa-check').addClass('fa-copy')
   }
 
   async replaceSelectorWith(

--- a/src/module/vue/components/rules-text/oracle-table.vue
+++ b/src/module/vue/components/rules-text/oracle-table.vue
@@ -6,19 +6,19 @@
     />
     <thead>
       <tr>
-        <th scope="col" class="oracle-table-column-roll">
+        <th scope="col" class="oracle-table-column-roll-range">
           {{ $t('IRONSWORN.OracleTable.ColumnLabel.Roll') }}
         </th>
-        <th scope="col" class="oracle-table-column-result">
+        <th scope="col" class="oracle-table-column-result-text">
           {{ $t('IRONSWORN.OracleTable.ColumnLabel.Result') }}
         </th>
       </tr>
     </thead>
     <tbody>
       <tr v-for="row in tableRows">
-        <td class="oracle-table-column-roll">{{ rangeString(row) }}</td>
+        <td class="oracle-table-column-roll-range">{{ rangeString(row) }}</td>
         <td
-          class="oracle-table-column-result"
+          class="oracle-table-column-result-text"
           v-html="$enrichHtml(row.text)"
         ></td>
       </tr>

--- a/src/styles/chat-message.less
+++ b/src/styles/chat-message.less
@@ -1,0 +1,100 @@
+// oracle table results
+
+.table-draw {
+  h2 {
+    border: none;
+  }
+  table {
+    td:first-child,
+    td:last-child {
+      width: 0;
+    }
+  }
+}
+
+.oracle-table-partial {
+  margin: 2px 0;
+  transition: none;
+  .oracle-result-row {
+    td {
+      > * {
+        transition: 0.5 ease all;
+      }
+    }
+  }
+  .icon {
+    display: flex;
+    aspect-ratio: 1;
+    height: max-content;
+    margin: 0;
+  }
+  .oracle-result-row {
+    .oracle-table-column-roll-result {
+      padding: 0;
+      white-space: nowrap;
+    }
+    > td {
+      position: relative;
+      &:last-child {
+        > .oracle-row-content {
+          padding-right: 2px;
+        }
+      }
+    }
+  }
+  .oracle-row-content {
+    opacity: 1;
+    visibility: visible;
+    height: 100%;
+    display: flex;
+    gap: 2px;
+    align-items: center;
+  }
+  .oracle-result-control {
+    color: inherit;
+    background: none;
+    opacity: 0;
+    visibility: hidden;
+    height: 100%;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    display: flex;
+    gap: 2px;
+    padding: 2px;
+    &.clickable.text {
+      justify-content: center;
+      align-items: center;
+      &:hover {
+        color: inherit !important;
+      }
+    }
+    &:hover {
+      background: none;
+      filter: drop-shadow(0 0 3px var(--color-shadow-primary))
+        drop-shadow(0 0 1px var(--color-shadow-highlight));
+    }
+  }
+  &:hover {
+    .oracle-row-content {
+      opacity: 0;
+      visibility: hidden;
+    }
+    .oracle-result-control {
+      opacity: 1;
+      visibility: visible;
+      background: none;
+      color: inherit;
+    }
+  }
+}
+
+// styling so that old messages don't have their overall layout disrupted. can probably be removed in a few versions
+.hover-controls-anchor {
+  display: none;
+}

--- a/src/styles/chat-message.less
+++ b/src/styles/chat-message.less
@@ -95,6 +95,6 @@
 }
 
 // styling so that old messages don't have their overall layout disrupted. can probably be removed in a few versions
-.hover-controls-anchor {
+.hover-controls {
   display: none;
 }

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -702,22 +702,27 @@ table td:first-child {
 }
 
 .oracle-result-row {
-  position: relative;
+  .first-column {
+    position: relative;
+  }
 
   .row-controls {
     position: absolute;
     left: 0;
+    right: 0;
     top: 0;
     bottom: 0;
     opacity: 0;
+
+    button {
+      height: 100%;
+      width: 100%;
+      background-color: var(--ironsworn-color-bg);
+    }
   }
 
   &:hover .row-controls {
     opacity: 1;
-
-    button {
-      line-height: 20px;
-    }
   }
 }
 

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -701,6 +701,27 @@ table td:first-child {
   }
 }
 
+.oracle-result-row {
+  position: relative;
+
+  .row-controls {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    opacity: 0;
+    transition: all 0.2s ease;
+  }
+
+  &:hover .row-controls {
+    opacity: 1;
+
+    button {
+      line-height: 20px;
+    }
+  }
+}
+
 .hover-controls-anchor {
   position: relative;
 

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -701,28 +701,77 @@ table td:first-child {
   }
 }
 
-.oracle-result-row {
-  .first-column {
-    position: relative;
+.oracle-table-partial {
+  margin: 2px 0;
+  .icon {
+    display: flex;
+    aspect-ratio: 1;
+    height: max-content;
+    margin: 0;
   }
-
-  .row-controls {
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    opacity: 0;
-
-    button {
-      height: 100%;
-      width: 100%;
-      background-color: var(--ironsworn-color-bg);
+  .oracle-result-row {
+    .oracle-table-column-roll-result {
+      padding: 0;
+      white-space: nowrap;
+    }
+    > td {
+      position: relative;
+      &:last-child {
+        > .oracle-table-content {
+          padding-right: 2px;
+        }
+      }
     }
   }
-
-  &:hover .row-controls {
+  .oracle-table-content {
     opacity: 1;
+    visibility: visible;
+    height: 100%;
+    display: flex;
+    gap: 2px;
+    align-items: center;
+  }
+  .oracle-result-control {
+    color: inherit;
+    background: none;
+    opacity: 0;
+    visibility: hidden;
+    height: 100%;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    display: flex;
+    gap: 2px;
+    padding: 2px;
+    &.clickable.text {
+      justify-content: center;
+      align-items: center;
+      &:hover {
+        color: inherit !important;
+      }
+    }
+    &:hover {
+      background: none;
+      filter: drop-shadow(0 0 3px var(--color-shadow-primary))
+        drop-shadow(0 0 1px var(--color-shadow-highlight));
+    }
+  }
+  &:hover {
+    .oracle-table-content {
+      opacity: 0;
+      visibility: hidden;
+    }
+    .oracle-result-control {
+      opacity: 1;
+      visibility: visible;
+      background: none;
+      color: inherit;
+    }
   }
 }
 

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -703,6 +703,16 @@ table td:first-child {
 
 .oracle-table-partial {
   margin: 2px 0;
+  transition: none;
+  .oracle-result-row {
+    // transition: none;
+    td {
+      // transition: none;
+      > * {
+        transition: 0.5 ease all;
+      }
+    }
+  }
   .icon {
     display: flex;
     aspect-ratio: 1;

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -710,7 +710,6 @@ table td:first-child {
     top: 0;
     bottom: 0;
     opacity: 0;
-    transition: all 0.2s ease;
   }
 
   &:hover .row-controls {

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -689,118 +689,6 @@ table td:first-child {
   padding-right: 0.5rem;
 }
 
-.table-draw {
-  h2 {
-    border: none;
-  }
-  table {
-    td:first-child,
-    td:last-child {
-      width: 0;
-    }
-  }
-}
-
-.oracle-table-partial {
-  margin: 2px 0;
-  transition: none;
-  .oracle-result-row {
-    // transition: none;
-    td {
-      // transition: none;
-      > * {
-        transition: 0.5 ease all;
-      }
-    }
-  }
-  .icon {
-    display: flex;
-    aspect-ratio: 1;
-    height: max-content;
-    margin: 0;
-  }
-  .oracle-result-row {
-    .oracle-table-column-roll-result {
-      padding: 0;
-      white-space: nowrap;
-    }
-    > td {
-      position: relative;
-      &:last-child {
-        > .oracle-row-content {
-          padding-right: 2px;
-        }
-      }
-    }
-  }
-  .oracle-row-content {
-    opacity: 1;
-    visibility: visible;
-    height: 100%;
-    display: flex;
-    gap: 2px;
-    align-items: center;
-  }
-  .oracle-result-control {
-    color: inherit;
-    background: none;
-    opacity: 0;
-    visibility: hidden;
-    height: 100%;
-    width: 100%;
-    padding: 0;
-    margin: 0;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    right: 0;
-    left: 0;
-    display: flex;
-    gap: 2px;
-    padding: 2px;
-    &.clickable.text {
-      justify-content: center;
-      align-items: center;
-      &:hover {
-        color: inherit !important;
-      }
-    }
-    &:hover {
-      background: none;
-      filter: drop-shadow(0 0 3px var(--color-shadow-primary))
-        drop-shadow(0 0 1px var(--color-shadow-highlight));
-    }
-  }
-  &:hover {
-    .oracle-row-content {
-      opacity: 0;
-      visibility: hidden;
-    }
-    .oracle-result-control {
-      opacity: 1;
-      visibility: visible;
-      background: none;
-      color: inherit;
-    }
-  }
-}
-
-.hover-controls-anchor {
-  position: relative;
-
-  .hover-controls {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    opacity: 0;
-    transition: all 0.2s ease;
-  }
-
-  &:hover .hover-controls {
-    opacity: 1;
-  }
-}
-
 // workaround to make FA easier to use as button decorations without adding a whole extra element. the pseudo-element is already there, and can be simply be attached to the parent element rather than it being an <i> element
 .fa,
 .fab,
@@ -841,3 +729,5 @@ table td:first-child {
     font-weight: 900;
   }
 }
+
+@import 'chat-message.less';

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -727,13 +727,13 @@ table td:first-child {
     > td {
       position: relative;
       &:last-child {
-        > .oracle-table-content {
+        > .oracle-row-content {
           padding-right: 2px;
         }
       }
     }
   }
-  .oracle-table-content {
+  .oracle-row-content {
     opacity: 1;
     visibility: visible;
     height: 100%;
@@ -772,7 +772,7 @@ table td:first-child {
     }
   }
   &:hover {
-    .oracle-table-content {
+    .oracle-row-content {
       opacity: 0;
       visibility: hidden;
     }

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -60,6 +60,8 @@
     "OracleTable": {
       "ColumnLabel": {
         "Roll": "Roll",
+        "RollRange": "Roll range",
+        "DiceRollResult": "{dice} roll result",
         "Result": "Result"
       }
     },

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -9,6 +9,7 @@
     "CustomTruth": "Custom Truth",
     "Roll": "Roll",
     "Chat": "Chat",
+    "Copy": "Copy",
     "SendToChat": "Send rules text to chat",
     "Rolling": "Rolling",
     "Bonus": "Bonus",

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -9,7 +9,7 @@
     "CustomTruth": "Custom Truth",
     "Roll": "Roll",
     "Chat": "Chat",
-    "CopyText": "CopyText",
+    "CopyTextToClipboard": "Copy text to clipboard",
     "SendToChat": "Send rules text to chat",
     "Rolling": "Rolling",
     "Bonus": "Bonus",

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -9,7 +9,7 @@
     "CustomTruth": "Custom Truth",
     "Roll": "Roll",
     "Chat": "Chat",
-    "Copy": "Copy",
+    "CopyText": "CopyText",
     "SendToChat": "Send rules text to chat",
     "Rolling": "Rolling",
     "Bonus": "Bonus",

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -1,4 +1,4 @@
-<article class="ironsworn table-draw hover-controls-anchor oracle-roll flexcol" data-oracleroll="{{json oracleRoll}}">
+<article class="ironsworn table-draw oracle-roll flexcol" data-oracleroll="{{json oracleRoll}}">
 
   {{#if subtitle}}
   <small class="subtitle">{{subtitle}}</small>

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -1,32 +1,42 @@
 <article class="ironsworn table-draw hover-controls-anchor oracle-roll flexcol" data-oracleroll="{{json oracleRoll}}">
+
   {{#if subtitle}}
   <small class="subtitle">{{subtitle}}</small>
   {{/if}}
   <h2 class="ironsworn-roll-title">{{title}}</h2>
-
   <table class="oracle-table oracle-table-partial">
     <tbody>
       {{#each displayRows}}
-      <tr class="oracle-result-row {{#if selected}}selected{{/if}}">
-        <td class="oracle-table-column-roll">
+      <tr class="oracle-result-row" {{#if selected}}aria-selected="true"{{/if}}>
+        <td class="oracle-table-column-roll-range">
+          <span class="oracle-table-content">
           {{#if (eq low high)}}{{low}}{{else}}{{low}}-{{high}}{{/if}}
-          <div class="row-controls">
-            <button
-              type="button"
-              class="copy-result icon-button clickable block"
-              data-result="{{text}}"
-              data-tooltip="{{localize 'IRONSWORN.CopyTextToClipboard'}}"
-              data-tooltip-direction="LEFT"
-            >
-              <i class="fas fa-copy"></i>
-            </button>
-          </div>
+          </span>
+          <button
+            type="button"
+            class="oracle-result-control copy-result clickable text"
+            data-result="{{text}}"
+            data-tooltip="{{localize 'IRONSWORN.CopyTextToClipboard'}}"
+            data-tooltip-direction="LEFT"
+          >
+            <i class="icon fas fa-copy" role="presentational"></i>
+          </button>
         </td>
-        <td class="oracle-table-column-result">{{{text}}}</td>
-        <td style="padding: 0 5px; white-space: nowrap;">
+        <td class="oracle-table-column-result-text">{{{text}}}</td>
+        <td class="oracle-table-column-roll-result">
           {{#if selected}}
-          <i class="isicon-d10-tilt"></i>
-          {{../oracleRoll.roll.total}}
+          <span class="oracle-table-content">
+            <i class="icon isicon-d10-tilt" role="presentational"></i>
+            {{../oracleRoll.roll.total}}
+          </span>
+          <button type='button'
+            class="oracle-result-control oracle-reroll clickable text"
+            title="{{localize 'IRONSWORN.Reroll'}}"
+            data-tooltip="{{localize 'IRONSWORN.Reroll'}}"
+            aria-label="{{{localize 'IRONSWORN.OracleTable.ColumnLabel.DiceRollResult' dice='d100'}}}"
+            >
+            <i class="icon fas fa-undo-alt" role="presentational"></i>
+          </button>
           {{/if}}
         </td>
       </tr>
@@ -34,10 +44,4 @@
     </tbody>
   </table>
 
-  <div class="hover-controls">
-    <button class="oracle-reroll" title="{{localize 'IRONSWORN.Reroll'}}"
-      data-tooltip="{{localize 'IRONSWORN.Reroll'}}">
-      <i class="fas fa-undo-alt"></i>
-    </button>
-  </div>
 </article>

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -9,7 +9,7 @@
       {{#each displayRows}}
       <tr class="oracle-result-row" {{#if selected}}aria-selected="true"{{/if}}>
         <td class="oracle-table-column-roll-range">
-          <span class="oracle-table-content">
+          <span class="oracle-row-content">
           {{#if (eq low high)}}{{low}}{{else}}{{low}}-{{high}}{{/if}}
           </span>
           <button
@@ -25,7 +25,7 @@
         <td class="oracle-table-column-result-text">{{{text}}}</td>
         <td class="oracle-table-column-roll-result">
           {{#if selected}}
-          <span class="oracle-table-content">
+          <span class="oracle-row-content">
             <i class="icon isicon-d10-tilt" role="presentational"></i>
             {{../oracleRoll.roll.total}}
           </span>

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -1,4 +1,4 @@
-<article class="table-draw hover-controls-anchor oracle-roll flexcol" data-oracleroll="{{json oracleRoll}}">
+<article class="ironsworn table-draw hover-controls-anchor oracle-roll flexcol" data-oracleroll="{{json oracleRoll}}">
   {{#if subtitle}}
   <small>{{subtitle}}</small>
   {{/if}}
@@ -8,13 +8,13 @@
     <tbody>
       {{#each displayRows}}
       <tr class="oracle-result-row {{#if selected}}selected{{/if}}">
-        <td>
+        <td class="first-column">
           {{#if (eq low high)}}{{low}}{{else}}{{low}}-{{high}}{{/if}}
           <div class="row-controls">
             <button
               type="button"
-              class="copy-result"
-              data-result="{{{text}}}"
+              class="copy-result icon-button clickable block"
+              data-result="{{text}}"
               data-tooltip="{{localize 'IRONSWORN.Copy'}}"
             >
               <i class="fas fa-copy"></i>

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -15,7 +15,7 @@
               type="button"
               class="copy-result icon-button clickable block"
               data-result="{{text}}"
-              data-tooltip="{{localize 'IRONSWORN.CopyText'}}"
+              data-tooltip="{{localize 'IRONSWORN.CopyTextToClipboard'}}"
               data-tooltip-direction="LEFT"
             >
               <i class="fas fa-copy"></i>

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -22,7 +22,7 @@
             </button>
           </div>
         </td>
-        <td class="oracle-table-column-roll">{{{text}}}</td>
+        <td class="oracle-table-column-result">{{{text}}}</td>
         <td style="padding: 0 5px; white-space: nowrap;">
           {{#if selected}}
           <i class="isicon-d10-tilt"></i>

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -11,7 +11,12 @@
         <td>
           {{#if (eq low high)}}{{low}}{{else}}{{low}}-{{high}}{{/if}}
           <div class="row-controls">
-            <button type="button" class="copy-result" data-result="{{{text}}}">
+            <button
+              type="button"
+              class="copy-result"
+              data-result="{{{text}}}"
+              data-tooltip="{{localize 'IRONSWORN.Copy'}}"
+            >
               <i class="fas fa-copy"></i>
             </button>
           </div>

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -1,27 +1,28 @@
 <article class="ironsworn table-draw hover-controls-anchor oracle-roll flexcol" data-oracleroll="{{json oracleRoll}}">
   {{#if subtitle}}
-  <small>{{subtitle}}</small>
+  <small class="subtitle">{{subtitle}}</small>
   {{/if}}
   <h2 class="ironsworn-roll-title">{{title}}</h2>
 
-  <table>
+  <table class="oracle-table oracle-table-partial">
     <tbody>
       {{#each displayRows}}
       <tr class="oracle-result-row {{#if selected}}selected{{/if}}">
-        <td class="first-column">
+        <td class="oracle-table-column-roll">
           {{#if (eq low high)}}{{low}}{{else}}{{low}}-{{high}}{{/if}}
           <div class="row-controls">
             <button
               type="button"
               class="copy-result icon-button clickable block"
               data-result="{{text}}"
-              data-tooltip="{{localize 'IRONSWORN.Copy'}}"
+              data-tooltip="{{localize 'IRONSWORN.CopyText'}}"
+              data-tooltip-direction="LEFT"
             >
               <i class="fas fa-copy"></i>
             </button>
           </div>
         </td>
-        <td>{{{text}}}</td>
+        <td class="oracle-table-column-roll">{{{text}}}</td>
         <td style="padding: 0 5px; white-space: nowrap;">
           {{#if selected}}
           <i class="isicon-d10-tilt"></i>

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -7,8 +7,15 @@
   <table>
     <tbody>
       {{#each displayRows}}
-      <tr class="{{#if selected}}selected{{/if}}">
-        <td>{{#if (eq low high)}}{{low}}{{else}}{{low}}-{{high}}{{/if}}</td>
+      <tr class="oracle-result-row {{#if selected}}selected{{/if}}">
+        <td>
+          {{#if (eq low high)}}{{low}}{{else}}{{low}}-{{high}}{{/if}}
+          <div class="row-controls">
+            <button type="button" class="copy-result" data-result="{{{text}}}">
+              <i class="fas fa-copy"></i>
+            </button>
+          </div>
+        </td>
         <td>{{{text}}}</td>
         <td style="padding: 0 5px; white-space: nowrap;">
           {{#if selected}}


### PR DESCRIPTION
This adds a button to copy the result text from an oracle output card, which appears on hover:

![CleanShot 2022-10-21 at 06 22 09](https://user-images.githubusercontent.com/39902/197205935-5af9092f-a4b5-4122-8cc7-b7474b2de897.jpg)

Fixes #514. 

- [x] Add the button
- [x] Copy the text
- [x] Talk @rsek into making it prettier
- [x] Update CHANGELOG.md
