### PR TITLE
Stop setting `position:absolute` on leaving elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Fix a visual bug with sliding transition groups, e.g. marking a vow as complete ([#521](https://github.com/ben/foundry-ironsworn/pull/521))
+
 ## 1.18.11
 
 - Minor updates to layout of the progress sheet ([#520](https://github.com/ben/foundry-ironsworn/pull/520))

--- a/src/module/vue/components/transition/collapse-transition.vue
+++ b/src/module/vue/components/transition/collapse-transition.vue
@@ -166,12 +166,6 @@ function beforeLeave(el: HTMLElement) {
   $emit('before-leave', el)
 }
 
-function setAbsolutePosition(el) {
-  if (props.group) {
-    el.style.position = 'absolute'
-  }
-}
-
 function leave(el: HTMLElement, callback: () => void) {
   // For some reason, @leave triggered when starting
   // from open state on page load. So for safety,
@@ -188,7 +182,6 @@ function leave(el: HTMLElement, callback: () => void) {
   forceRepaint(el)
   setTransition(el)
   setClosedDimensions(el)
-  setAbsolutePosition(el)
 
   // Emit the event to the parent
   $emit('leave', el, callback)


### PR DESCRIPTION
It was causing a weird visual glitch on elements that were shrinking out of view.

- [x] Fix the bug
- [x] Update CHANGELOG.md
