### PR TITLE
New dialog for write-your-epilogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- Clicking the "roll" icon on an Ironsworn character's bonds track now uses the new rolling dialog ([#530](https://github.com/ben/foundry-ironsworn/pull/530))
 - Under the hood: correct console warnings about using `thing.data`, instead using `thing.system` and other v10-friendly methods.
 
 ## 1.19.0

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -1,5 +1,6 @@
 import { createIronswornChatRoll } from '../chat/chatrollhelpers'
 import { RANK_INCREMENTS } from '../constants'
+import { getFoundryMoveByDfId } from '../dataforged'
 import { EnhancedDataswornMove, moveDataByName } from '../helpers/data'
 import { IronswornPrerollDialog } from '../rolls'
 import {
@@ -56,17 +57,13 @@ export class IronswornItem extends Item {
     if (this.type !== 'bondset') return
     const system = this.system as BondsetDataPropertiesData
 
-    const move = await moveDataByName('Write Your Epilogue')
+    const move = await getFoundryMoveByDfId(
+      'Ironsworn/Moves/Relationship/Write_Your_Epilogue'
+    )
     if (!move) throw new Error('Problem loading write-epilogue move')
 
     const progress = Math.floor(Object.values(system.bonds).length / 4)
-    const r = new Roll(`{${progress},d10,d10}`)
-    createIronswornChatRoll({
-      isProgress: true,
-      move,
-      roll: r,
-      actor: this.actor || undefined,
-    })
+    IronswornPrerollDialog.showForProgressMove(move, progress)
   }
 }
 

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -40,12 +40,21 @@ export class IronswornItem extends Item {
     if (this.data.type !== 'progress') return
     const system = this.system as ProgressDataPropertiesData
 
+    let moveDfId: string | undefined
+    if (system.subtype === 'vow') {
+      const toolset = this.actor?.toolset ?? 'starforged'
+      moveDfId =
+        toolset === 'starforged'
+          ? 'Starforged/Moves/Quest/Fulfill_Your_Vow'
+          : 'Ironsworn/Moves/Quest/Fulfill_Your_Vow'
+    }
+
     const progress = Math.floor(system.current / 4)
     return IronswornPrerollDialog.showForProgress(
       this.name || '(progress)',
       progress,
       this.actor || undefined,
-      system.subtype === 'vow'
+      moveDfId
     )
   }
 
@@ -63,7 +72,12 @@ export class IronswornItem extends Item {
     if (!move) throw new Error('Problem loading write-epilogue move')
 
     const progress = Math.floor(Object.values(system.bonds).length / 4)
-    IronswornPrerollDialog.showForProgressMove(move, progress)
+    IronswornPrerollDialog.showForProgress(
+      game.i18n.localize('IRONSWORN.Bonds'),
+      progress,
+      this.actor || undefined,
+      'Ironsworn/Moves/Relationship/Write_Your_Epilogue'
+    )
   }
 }
 

--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -212,19 +212,13 @@ export class IronswornPrerollDialog extends Dialog<
     name: string,
     value: number,
     actor?: IronswornActor,
-    isVow?: boolean
+    moveDfId?: string
   ) {
     const rollText = game.i18n.localize('IRONSWORN.ProgressRoll')
     let title = `${rollText}: ${name}`
 
-    let moveDfId: string | undefined
     let move: IronswornItem | undefined
-    if (isVow && actor) {
-      const toolset = actor?.toolset ?? 'starforged'
-      moveDfId =
-        toolset === 'starforged'
-          ? 'Starforged/Moves/Quest/Fulfill_Your_Vow'
-          : 'Ironsworn/Moves/Quest/Fulfill_Your_Vow'
+    if (moveDfId) {
       move = await getFoundryMoveByDfId(moveDfId)
       if (move?.name) {
         title = `${move.name}: ${name}`
@@ -276,14 +270,6 @@ export class IronswornPrerollDialog extends Dialog<
     }
 
     return this.showForMoveItem(move, { moveId: move.id || undefined }, actor)
-  }
-
-  static async showForProgressMove(move: IronswornItem, progress: number) {
-    if (move.type !== 'sfmove') {
-      throw new Error('this only works with SF moves')
-    }
-
-    return this.showForMoveItem(move, { moveId: move.id, progress })
   }
 
   private static async showForMoveItem(

--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -278,6 +278,14 @@ export class IronswornPrerollDialog extends Dialog<
     return this.showForMoveItem(move, { moveId: move.id || undefined }, actor)
   }
 
+  static async showForProgressMove(move: IronswornItem, progress: number) {
+    if (move.type !== 'sfmove') {
+      throw new Error('this only works with SF moves')
+    }
+
+    return this.showForMoveItem(move, { moveId: move.id, progress })
+  }
+
   private static async showForMoveItem(
     move: IronswornItem,
     prerollOptions: PreRollOptions,

--- a/src/module/vue/components/bonds.vue
+++ b/src/module/vue/components/bonds.vue
@@ -3,7 +3,7 @@
     <div class="flexrow">
       <h4>{{ $t('IRONSWORN.Bonds') }}</h4>
       <btn-faicon class="block nogrow" icon="edit" @click="editBonds" />
-      <btn-faicon class="block nogrow" icon="dice-d6" @click="rollBonds" />
+      <BtnIsicon class="block nogrow" icon="d10-tilt" @click="rollBonds" />
     </div>
     <ProgressTrack
       :ticks="bondcount"
@@ -22,6 +22,7 @@ import {
 } from '../../item/itemtypes.js'
 import { $ActorKey, ActorKey } from '../provisions'
 import btnFaicon from './buttons/btn-faicon.vue'
+import BtnIsicon from './buttons/btn-isicon.vue'
 import ProgressTrack from './progress/progress-track.vue'
 
 const props = defineProps<{ compactProgress?: boolean }>()

--- a/system/templates/rolls/preroll-dialog.hbs
+++ b/system/templates/rolls/preroll-dialog.hbs
@@ -1,11 +1,11 @@
 <form class='preroll-dialog{{#if action}} action-roll-dialog{{else}} progress-roll-dialog{{/if}}'>
   {{#if move}}
   <section class='roll-trigger-text'>
-    {{{enrichMarkdown move.data.data.Trigger.Text}}}
+    {{{enrichMarkdown move.system.Trigger.Text}}}
   </section>
-  {{#if move.data.data.Trigger.Options}}
+  {{#if move.system.Trigger.Options}}
   <ul class='trigger-options'>
-    {{#each move.data.data.Trigger.Options}}
+    {{#each move.system.Trigger.Options}}
     {{#if Text}}
     <li class='trigger-option'>
       {{Text}}:


### PR DESCRIPTION
This is one of the last vestiges of the `MoveContents` area in the translation files, which is confusing and needs to go.

- [x] Rewrite the bondset rolling logic to use the new dialog
- [x] Update the new dialog to allow rolling a progress move
- [x] Update CHANGELOG.md
