### PR TITLE
Border and spacing fixes

### DIFF
--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -417,7 +417,7 @@ export class IronswornPrerollDialog extends Dialog<
 
     // Resize when expanding the "advanced" section
     html.find('details').on('toggle', (ev) => {
-      const delta = (ev.currentTarget.open ? 1 : -1) * 90
+      const delta = (ev.currentTarget.open ? 1 : -1) * 120
       const app = html.parents('.app')
       app.height((app.height() ?? 0) + delta)
     })

--- a/src/module/vue/components/buttons/btn-icon.vue
+++ b/src/module/vue/components/buttons/btn-icon.vue
@@ -70,7 +70,7 @@ const hasDefaultSlot = computed(() => {
     align-content: center;
     align-items: center;
   }
-  &.text:not(.block) {
+  &.text:not(.block):not(:empty) {
     justify-content: left;
   }
 }

--- a/src/module/vue/components/buttons/btn-icon.vue
+++ b/src/module/vue/components/buttons/btn-icon.vue
@@ -46,6 +46,8 @@ const hasDefaultSlot = computed(() => {
   text-align: center;
   justify-content: center;
   border-radius: 0;
+  color: inherit;
+  border-width: 0;
   padding: 0.2em;
   &:not(:empty) {
     gap: 0.2em;

--- a/src/module/vue/components/rank-pips/rank-pips.vue
+++ b/src/module/vue/components/rank-pips/rank-pips.vue
@@ -34,6 +34,7 @@
   width: max-content;
   flex-grow: 0;
   .rank-pip {
+    border: none;
     .pip-shape > * {
       stroke-width: var(--widget-stroke-width);
     }

--- a/src/module/vue/components/rank-pips/rank-pips.vue
+++ b/src/module/vue/components/rank-pips/rank-pips.vue
@@ -34,6 +34,7 @@
   width: max-content;
   flex-grow: 0;
   .rank-pip {
+    margin: 0;
     border: none;
     .pip-shape > * {
       stroke-width: var(--widget-stroke-width);

--- a/src/module/vue/components/sf-move-category-rows.vue
+++ b/src/module/vue/components/sf-move-category-rows.vue
@@ -1,11 +1,12 @@
 <template>
   <Collapsible
+    class="list-block"
     :class="$style.wrapper"
     :toggleButtonClass="$style.toggleButton"
     :toggleTooltip="$enrichMarkdown(category.dataforgedCategory?.Description)"
     :toggleWrapperIs="`h${headingLevel}`"
     :toggleWrapperClass="$style.toggleWrapper"
-    :toggleSectionClass="$style.toggleSection"
+    :toggleSectionClass="`${$style.toggleSection} list-block-header`"
     :baseId="`move_category_${snakeCase(category.displayName)}`"
     :toggleLabel="category.displayName"
     :toggleTextClass="$style.toggleText"
@@ -17,13 +18,14 @@
         <li
           v-for="(move, i) of category.moves"
           :key="i"
-          class="nogrow"
+          class="list-block-item nogrow"
           :class="$style.listItem"
         >
           <SfMoverow
             :move="move"
             ref="children"
             :headingLevel="headingLevel + 1"
+            :class="$style.moveRow"
             :thematicColor="category.color"
           />
         </li>
@@ -42,7 +44,7 @@
 
 .wrapper {
   .thematicColorMixin();
-  border-radius: 5px;
+  border-radius: var(--ironsworn-border-radius-lg);
   background-color: var(--ironsworn-color-thematic);
 }
 
@@ -54,15 +56,9 @@
   padding: 0;
 }
 
-.listItem {
-  border-color: var(--ironsworn-color-thematic);
-  border-style: groove;
-  border-width: 1px 0 0;
-}
-
 .toggleSection {
   background-color: var(--ironsworn-color-thematic);
-  border-radius: 5px;
+  border-radius: var(--ironsworn-border-radius-lg);
   button {
     --ironsworn-color-clickable-text: var(--ironsworn-color-light);
     --ironsworn-color-clickable-text-hover: var(--ironsworn-color-light-warm);
@@ -72,6 +68,10 @@
 .toggleButton {
   .textStrokeMixin( var(--ironsworn-color-dark));
   background: none;
+}
+
+.moveRow {
+  border-radius: var(--ironsworn-border-radius-lg);
 }
 </style>
 <script setup lang="ts">

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -67,8 +67,8 @@
 @import '../../../styles/mixins.less';
 
 @icon_size: 1.2em;
-@border_width: 2px;
-@border_radius: 5px;
+@border_width: var(--ironsworn-border-width-lg);
+@border_radius: var(--ironsworn-border-radius-lg);
 @wrapper_spacing: 4px;
 
 .thematicColorMixin {
@@ -86,7 +86,6 @@
 
 .wrapper {
   .thematicColorMixin();
-  border-radius: @border_radius;
   padding-left: @wrapper_spacing;
   padding-right: @wrapper_spacing;
   &[aria-expanded='true'] {
@@ -124,7 +123,8 @@
   line-height: 1.25;
   font-size: var(--font-size-16);
   border-color: transparent;
-  border-width: 1px 1px 0 1px;
+  border-width: var(--ironsworn-border-width-md)
+    var(--ironsworn-border-width-md) 0 var(--ironsworn-border-width-md);
   border-style: solid;
   align-items: center;
   &:hover {

--- a/src/module/vue/components/sf-movesheetmoves.vue
+++ b/src/module/vue/components/sf-movesheetmoves.vue
@@ -55,16 +55,25 @@
 
 <style lang="less" module>
 .navSearch {
-  margin-top: 0.5rem;
+  margin-top: var(--ironsworn-spacer-lg);
 }
 .searchBtn {
-  padding: 6px;
+  // padding: 6px;
+  &:empty {
+    // to override default icon-button styling
+    height: var(--form-field-height);
+    width: var(--form-field-height);
+    padding: var(--ironsworn-spacer-md);
+  }
+  aspect-ratio: 1;
+  flex: 0;
 }
 .wrapper {
-  gap: 0.5rem;
+  gap: var(--ironsworn-spacer-lg);
 }
 .itemList {
   gap: var(--ironsworn-spacer-md);
+  margin: 0;
 }
 </style>
 

--- a/src/module/vue/components/sf-movesheetoracles.vue
+++ b/src/module/vue/components/sf-movesheetoracles.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flexcol">
-    <div class="flexrow nogrow" style="margin-top: 0.5rem">
+  <div class="flexcol" :class="$style.wrapper">
+    <div class="flexrow nogrow" :class="$style.navSearch">
       <input
         type="text"
         :placeholder="$t('IRONSWORN.Search')"
@@ -19,7 +19,7 @@
       />
     </div>
 
-    <div class="item-list scrollable flexcol">
+    <div class="item-list scrollable flexcol" :class="$style.itemList">
       <OracleTreeNode
         v-for="node in treeRoot.children"
         :key="node.displayName"
@@ -30,9 +30,15 @@
   </div>
 </template>
 
-<style lang="less" scoped>
-.item-list {
-  padding: 0 0.5rem;
+<style lang="less" module>
+.wrapper {
+  gap: var(--ironsworn-spacer-lg);
+}
+.navSearch {
+  margin-top: var(--ironsworn-spacer-lg);
+}
+.itemList {
+  padding: 0 var(--ironsworn-spacer-lg);
 }
 </style>
 

--- a/src/module/vue/components/site/site-moves.vue
+++ b/src/module/vue/components/site/site-moves.vue
@@ -1,58 +1,81 @@
 <template>
-  <div class="flexcol scrollable">
-    <SfMoverow
-      :move="moves.discoverASite"
-      v-if="moves.discoverASite"
-      :thematic-color="thematicColor"
-      class="nogrow"
-    />
-    <SfMoverow
-      :move="moves.delveTheDepths"
-      v-if="moves.delveTheDepths"
-      :thematic-color="thematicColor"
-      class="nogrow"
-    />
-    <SfMoverow
-      :move="moves.findAnOpportunity"
-      v-if="moves.findAnOpportunity"
-      :thematic-color="thematicColor"
-      class="nogrow"
-    />
-    <SfMoverow
-      :move="moves.revealADanger"
-      v-if="moves.revealADanger"
-      :thematic-color="thematicColor"
-      class="nogrow"
-      @oracleClick="revealADanger"
-      :oracle-disabled="!hasThemeAndDomain"
-    />
-    <SfMoverow
-      :move="moves.checkYourGear"
-      v-if="moves.checkYourGear"
-      :thematic-color="thematicColor"
-      class="nogrow"
-    />
-    <SfMoverow
-      :move="moves.locateObjective"
-      v-if="moves.locateObjective"
-      :thematic-color="thematicColor"
-      class="nogrow"
-      @rollClick="locateObjective"
-    />
-    <SfMoverow
-      :move="moves.escapeTheDepths"
-      v-if="moves.escapeTheDepths"
-      :thematic-color="thematicColor"
-      class="nogrow"
-    />
-    <SfMoverow
-      :move="moves.revealADangerAlt"
-      v-if="moves.revealADangerAlt"
-      :thematic-color="thematicColor"
-      class="nogrow"
-    />
-  </div>
+  <ul class="list-block flexcol" :class="$style.wrapper">
+    <li class="list-block-item" :class="$style.moveRowWrapper">
+      <SfMoverow
+        :move="moves.discoverASite"
+        v-if="moves.discoverASite"
+        class="nogrow"
+      />
+    </li>
+    <li class="list-block-item" :class="$style.moveRowWrapper">
+      <SfMoverow
+        :move="moves.delveTheDepths"
+        v-if="moves.delveTheDepths"
+        class="nogrow"
+      />
+    </li>
+    <li class="list-block-item" :class="$style.moveRowWrapper">
+      <SfMoverow
+        :move="moves.findAnOpportunity"
+        v-if="moves.findAnOpportunity"
+        class="nogrow"
+      />
+    </li>
+    <li class="list-block-item" :class="$style.moveRowWrapper">
+      <SfMoverow
+        :move="moves.revealADanger"
+        v-if="moves.revealADanger"
+        class="nogrow"
+        @oracleClick="revealADanger"
+        :oracle-disabled="!hasThemeAndDomain"
+      />
+    </li>
+    <li class="list-block-item" :class="$style.moveRowWrapper">
+      <SfMoverow
+        :move="moves.checkYourGear"
+        v-if="moves.checkYourGear"
+        class="nogrow"
+      />
+    </li>
+    <li class="list-block-item" :class="$style.moveRowWrapper">
+      <SfMoverow
+        :move="moves.locateObjective"
+        v-if="moves.locateObjective"
+        class="nogrow"
+        @rollClick="locateObjective"
+      />
+    </li>
+    <li class="list-block-item" :class="$style.moveRowWrapper">
+      <SfMoverow
+        :move="moves.escapeTheDepths"
+        v-if="moves.escapeTheDepths"
+        class="nogrow"
+      />
+    </li>
+    <li class="list-block-item" :class="$style.moveRowWrapper">
+      <SfMoverow
+        :move="moves.revealADangerAlt"
+        v-if="moves.revealADangerAlt"
+        class="nogrow"
+      />
+    </li>
+  </ul>
 </template>
+
+<style lang="less" module>
+.wrapper {
+  border-radius: var(--ironsworn-border-radius-lg);
+  background-color: var(--ironsworn-color-midtone-30);
+  height: max-content;
+  margin: 0;
+}
+
+.moveRowWrapper {
+  flex-grow: 0;
+  height: max-content;
+  border-color: var(--ironsworn-color-midtone-30);
+}
+</style>
 
 <script lang="ts" setup>
 import { computed, inject, reactive } from 'vue'
@@ -74,8 +97,6 @@ const theme = computed(() => {
 const domain = computed(() => {
   return site?.value?.items.find((x) => x.type === 'delve-domain')
 })
-
-const thematicColor = 'var(--ironsworn-color-fg-30)'
 
 const hasThemeAndDomain = computed(() => {
   return !!(theme.value && domain.value)

--- a/src/module/vue/progress-sheet.vue
+++ b/src/module/vue/progress-sheet.vue
@@ -122,30 +122,32 @@
     <!-- DESCRIPTION -->
     <MceEditor v-model="item.system.description" @save="saveDescription" />
 
-    <button
-      class="button nogrow"
+    <BtnFaicon
+      class="nogrow block"
       :class="$style.danger"
-      type="button"
+      icon="trash"
       @click="destroy"
     >
       {{ $t('IRONSWORN.DeleteItem') }}
-    </button>
+    </BtnFaicon>
   </div>
 </template>
 
 <style lang="less" module>
-button.danger {
-  color: var(--ironsworn-color-danger);
-  border: 1px solid;
-  border-radius: 5px;
-  border-color: var(--ironsworn-color-danger);
-  transition: all ease 0.2s;
+.danger {
+  --ironsworn-color-clickable-block-border: var(--ironsworn-color-danger);
+  --ironsworn-color-clickable-block-fg: var(--ironsworn-color-danger);
+  --ironsworn-color-clickable-block-bg: transparent;
 
-  &:hover {
-    background-color: var(--ironsworn-color-danger);
-    color: var(--ironsworn-color-danger-inverted);
-    border-color: var(--ironsworn-color-danger-inverted);
-  }
+  --ironsworn-color-clickable-block-border-hover: var(--ironsworn-color-danger);
+  --ironsworn-color-clickable-block-fg-hover: var(--ironsworn-color-light);
+  --ironsworn-color-clickable-block-bg-hover: var(--ironsworn-color-danger);
+
+  margin: var(--ironsworn-spacer-md) 0 0;
+  color: var(--ironsworn-color-danger);
+  border-width: var(--ironsworn-border-width-lg);
+  border-style: solid;
+  border-radius: var(--ironsworn-border-radius-lg);
 }
 </style>
 

--- a/src/module/vue/site-sheet.vue
+++ b/src/module/vue/site-sheet.vue
@@ -5,14 +5,16 @@
     <div class="flexrow nogrow" style="gap: 10px; margin: 0.5em 0">
       <div class="flexcol" style="flex-basis: 20em">
         <!-- RANK -->
-        <div class="flexrow nogrow">
+        <div class="flexrow nogrow" :class="$style.rankRow">
           <RankPips
             :current="actor.system.rank"
             class="nogrow"
             @click="setRank"
-            style="margin-right: 1em"
+            :id="`${actor._id}_rank`"
           />
-          <h4 style="margin: 0; line-height: 22px">{{ rankText }}</h4>
+          <label :for="`${actor._id}_rank`" :class="$style.rankLabel">{{
+            rankText
+          }}</label>
           <BtnFaicon
             class="block nogrow"
             v-if="editMode"
@@ -54,16 +56,16 @@
           </div>
         </div>
         <!-- DENIZENS -->
-        <h4 class="flexrow nogrow">
+        <h2 class="flexrow nogrow" :class="$style.heading">
           <span>{{ $t('IRONSWORN.Denizens') }}</span>
           <BtnIsicon
             icon="d10-tilt"
-            class="flexrow nogrow text"
+            class="text nogrow"
             style="padding: 2px"
             @click="randomDenizen"
           />
-          <BtnCompendium compendium="ironswornfoes" class="nogrow" />
-        </h4>
+          <BtnCompendium compendium="ironswornfoes" class="text nogrow" />
+        </h2>
         <div class="boxgroup nogrow" style="margin-bottom: 1em">
           <div class="flexrow boxrow">
             <SiteDenizenbox :idx="0" :ref="(e) => (denizenRefs[0] = e)" />
@@ -91,20 +93,15 @@
           </div>
         </div>
       </div>
-      <div
-        class="flexcol"
-        style="flex-basis: 12em; max-height: 430px; overflow: scroll"
-      >
-        <SiteMoves />
-      </div>
+      <SiteMoves class="scrollable flexcol" :class="$style.siteMovesWrapper" />
     </div>
     <div class="flexcol">
       <div class="flexrow nogrow">
-        <h4>{{ $t('IRONSWORN.Notes') }}</h4>
+        <h2 :class="$style.heading">{{ $t('IRONSWORN.Notes') }}</h2>
         <BtnIsicon
           icon="d10-tilt"
           class="box text block nogrow"
-          :class="{ disabled: !hasThemeAndDomain }"
+          :class="{ disabled: !hasThemeAndDomain, [$style.featureBtn]: true }"
           @click="randomFeature"
         >
           {{ $t('IRONSWORN.Feature') }}
@@ -115,18 +112,38 @@
   </div>
 </template>
 
-<style lang="less" scoped>
-.moves {
-  .box {
-    justify-content: center;
-    padding: 5px;
-  }
-  h4 {
-    margin: 0;
-    white-space: nowrap;
-  }
+<style lang="less" module>
+.rankRow {
+  gap: var(--ironsworn-spacer-lg);
 }
+.rankLabel {
+  margin: 0;
+  line-height: 22px;
+  font-size: var(--font-size-14);
+  text-transform: uppercase;
+  display: flex;
+  flex-direction: row nowrap;
+  align-items: center;
+}
+.siteMovesWrapper {
+  flex-basis: 12em;
+  max-height: 430px;
+}
+.heading {
+  font-size: var(--font-size-14);
+  text-transform: uppercase;
+  font-weight: bold;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  line-height: 1.5;
+}
+.featureBtn {
+  text-transform: uppercase;
+}
+</style>
 
+<style lang="less" scoped>
 textarea {
   border-color: rgba(0, 0, 0, 0.1);
   border-radius: 1px;

--- a/src/module/vue/site-sheet.vue
+++ b/src/module/vue/site-sheet.vue
@@ -1,41 +1,42 @@
 <template>
-  <div class="flexcol">
+  <div class="flexcol" :class="$style.siteSheet">
     <!-- HEADER -->
     <SheetHeaderBasic class="nogrow" :document="actor" />
-    <div class="flexrow nogrow" style="gap: 10px; margin: 0.5em 0">
-      <div class="flexcol" style="flex-basis: 20em">
+    <div class="flexrow nogrow" :class="$style.main">
+      <div class="flexcol" :class="$style.leftColumn">
         <!-- RANK -->
-        <div class="flexrow nogrow" :class="$style.rankRow">
-          <RankPips
-            :current="actor.system.rank"
+        <article :class="$style.progressWidget">
+          <div class="flexrow nogrow" :class="$style.rankRow">
+            <RankPips
+              :current="actor.system.rank"
+              class="nogrow"
+              @click="setRank"
+              :id="`${actor._id}_rank`"
+            />
+            <label :for="`${actor._id}_rank`" :class="$style.rankLabel">{{
+              rankText
+            }}</label>
+            <BtnFaicon
+              class="block nogrow"
+              v-if="editMode"
+              icon="trash"
+              @click="clearProgress"
+            />
+            <BtnFaicon
+              class="block nogrow"
+              icon="caret-right"
+              @click="markProgress"
+            />
+          </div>
+          <!-- PROGRESS -->
+          <ProgressTrack
             class="nogrow"
-            @click="setRank"
-            :id="`${actor._id}_rank`"
+            :ticks="actor.system.current"
+            :rank="actor.system.rank"
           />
-          <label :for="`${actor._id}_rank`" :class="$style.rankLabel">{{
-            rankText
-          }}</label>
-          <BtnFaicon
-            class="block nogrow"
-            v-if="editMode"
-            icon="trash"
-            @click="clearProgress"
-          />
-          <BtnFaicon
-            class="block nogrow"
-            icon="caret-right"
-            @click="markProgress"
-          />
-        </div>
-        <!-- PROGRESS -->
-        <ProgressTrack
-          class="nogrow"
-          style="margin-bottom: 1em"
-          :ticks="actor.system.current"
-          :rank="actor.system.rank"
-        />
+        </article>
         <!-- THEME/DOMAIN -->
-        <div class="boxgroup flexcol nogrow" style="margin-bottom: 1em">
+        <div class="boxgroup flexcol nogrow">
           <div class="flexrow boxrow nogrow">
             <SiteDroparea
               class="box"
@@ -56,44 +57,48 @@
           </div>
         </div>
         <!-- DENIZENS -->
-        <h2 class="flexrow nogrow" :class="$style.heading">
-          <span>{{ $t('IRONSWORN.Denizens') }}</span>
-          <BtnIsicon
-            icon="d10-tilt"
-            class="text nogrow"
-            style="padding: 2px"
-            @click="randomDenizen"
-          />
-          <BtnCompendium compendium="ironswornfoes" class="text nogrow" />
-        </h2>
-        <div class="boxgroup nogrow" style="margin-bottom: 1em">
-          <div class="flexrow boxrow">
-            <SiteDenizenbox :idx="0" :ref="(e) => (denizenRefs[0] = e)" />
-            <SiteDenizenbox :idx="1" :ref="(e) => (denizenRefs[1] = e)" />
+        <article :class="$style.denizenMatrix">
+          <h2 class="flexrow nogrow" :class="$style.heading">
+            <span>{{ $t('IRONSWORN.Denizens') }}</span>
+            <BtnIsicon
+              icon="d10-tilt"
+              class="text nogrow"
+              style="padding: 2px"
+              @click="randomDenizen"
+            />
+            <BtnCompendium compendium="ironswornfoes" class="text nogrow" />
+          </h2>
+          <div class="boxgroup nogrow">
+            <div class="flexrow boxrow">
+              <SiteDenizenbox :idx="0" :ref="(e) => (denizenRefs[0] = e)" />
+              <SiteDenizenbox :idx="1" :ref="(e) => (denizenRefs[1] = e)" />
+            </div>
+            <div class="flexrow boxrow">
+              <SiteDenizenbox :idx="2" :ref="(e) => (denizenRefs[2] = e)" />
+              <SiteDenizenbox :idx="3" :ref="(e) => (denizenRefs[3] = e)" />
+            </div>
+            <div class="flexrow boxrow">
+              <SiteDenizenbox :idx="4" :ref="(e) => (denizenRefs[4] = e)" />
+              <SiteDenizenbox :idx="5" :ref="(e) => (denizenRefs[5] = e)" />
+            </div>
+            <div class="flexrow boxrow">
+              <SiteDenizenbox :idx="6" :ref="(e) => (denizenRefs[6] = e)" />
+              <SiteDenizenbox :idx="7" :ref="(e) => (denizenRefs[7] = e)" />
+            </div>
+            <div class="flexrow boxrow">
+              <SiteDenizenbox :idx="8" :ref="(e) => (denizenRefs[8] = e)" />
+              <SiteDenizenbox :idx="9" :ref="(e) => (denizenRefs[9] = e)" />
+            </div>
+            <div class="flexrow boxrow">
+              <SiteDenizenbox :idx="10" :ref="(e) => (denizenRefs[10] = e)" />
+              <SiteDenizenbox :idx="11" :ref="(e) => (denizenRefs[11] = e)" />
+            </div>
           </div>
-          <div class="flexrow boxrow">
-            <SiteDenizenbox :idx="2" :ref="(e) => (denizenRefs[2] = e)" />
-            <SiteDenizenbox :idx="3" :ref="(e) => (denizenRefs[3] = e)" />
-          </div>
-          <div class="flexrow boxrow">
-            <SiteDenizenbox :idx="4" :ref="(e) => (denizenRefs[4] = e)" />
-            <SiteDenizenbox :idx="5" :ref="(e) => (denizenRefs[5] = e)" />
-          </div>
-          <div class="flexrow boxrow">
-            <SiteDenizenbox :idx="6" :ref="(e) => (denizenRefs[6] = e)" />
-            <SiteDenizenbox :idx="7" :ref="(e) => (denizenRefs[7] = e)" />
-          </div>
-          <div class="flexrow boxrow">
-            <SiteDenizenbox :idx="8" :ref="(e) => (denizenRefs[8] = e)" />
-            <SiteDenizenbox :idx="9" :ref="(e) => (denizenRefs[9] = e)" />
-          </div>
-          <div class="flexrow boxrow">
-            <SiteDenizenbox :idx="10" :ref="(e) => (denizenRefs[10] = e)" />
-            <SiteDenizenbox :idx="11" :ref="(e) => (denizenRefs[11] = e)" />
-          </div>
-        </div>
+        </article>
       </div>
-      <SiteMoves class="scrollable flexcol" :class="$style.siteMovesWrapper" />
+      <div class="scrollable flexcol" :class="$style.rightColumn">
+        <SiteMoves class="nogrow" />
+      </div>
     </div>
     <div class="flexcol">
       <div class="flexrow nogrow">
@@ -113,6 +118,9 @@
 </template>
 
 <style lang="less" module>
+.siteSheet {
+  gap: 0.5em;
+}
 .rankRow {
   gap: var(--ironsworn-spacer-lg);
 }
@@ -125,10 +133,26 @@
   flex-direction: row nowrap;
   align-items: center;
 }
-.siteMovesWrapper {
-  flex-basis: 12em;
-  max-height: 430px;
+
+.denizenMatrix {
 }
+
+.main {
+  gap: inherit;
+}
+
+.siteMoves {
+  height: max-content;
+}
+.rightColumn {
+  flex-basis: 12em;
+  max-height: 411px;
+}
+.leftColumn {
+  flex-basis: 20em;
+  gap: 1em;
+}
+
 .heading {
   font-size: var(--font-size-14);
   text-transform: uppercase;
@@ -145,10 +169,8 @@
 
 <style lang="less" scoped>
 textarea {
-  border-color: rgba(0, 0, 0, 0.1);
-  border-radius: 1px;
+  border-radius: var(--ironsworn-border-radius-sm);
   resize: none;
-  font-family: var(--font-primary);
 }
 </style>
 

--- a/src/styles/clickable.less
+++ b/src/styles/clickable.less
@@ -1,9 +1,3 @@
-.ironsworn {
-  button {
-    margin: 0;
-  }
-}
-
 .entity-link,
 .content-link,
 // the following selector is a proxy for compendium links which don't have a class attached to them.

--- a/src/styles/dialog.less
+++ b/src/styles/dialog.less
@@ -8,13 +8,29 @@
 .preroll-dialog {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: var(--ironsworn-spacer-md);
+  p {
+    &:first-child {
+      margin-top: 0;
+    }
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+  .roll-trigger-text {
+    margin: 0;
+  }
+  .trigger-options {
+    margin: 0 0 var(--ironsworn-spacer-md);
+  }
   .form-group,
   fieldset.form-group {
-    padding: 0;
+    padding: var(--ironsworn-spacer-md);
     border: none;
   }
   .advanced-roll-options {
+    border-radius: var(--ironsworn-border-radius-lg);
+    background-color: var(--ironsworn-color-fg-10);
     padding: var(--ironsworn-spacer-md);
     margin: var(--ironsworn-spacer-md) 0;
     border-width: var(--ironsworn-border-width-md);

--- a/src/styles/fvtt/clickable.less
+++ b/src/styles/fvtt/clickable.less
@@ -1,9 +1,5 @@
 @import '../mixins.less';
 
-button {
-  color: inherit;
-}
-
 .app:not(.ironsworn) button {
   .clickableBlockMixin();
   border-radius: var(--ironsworn-border-radius-md);

--- a/src/styles/fvtt/dialog.less
+++ b/src/styles/fvtt/dialog.less
@@ -22,7 +22,11 @@
     }
     .dialog-buttons {
       height: max-content;
-      align-items: end;
+      align-items: flex-end;
+      display: flex;
+      flex-flow: row wrap;
+      flex-grow: 0;
+      gap: var(--ironsworn-spacer-sm);
       button.default,
       button {
         .clickableBlockMixin();
@@ -31,6 +35,7 @@
         justify-content: center;
         height: max-content;
         border-width: 1px;
+        border-radius: 0;
         .button-text {
           .nogrow();
           .initial-caps();
@@ -38,8 +43,7 @@
           height: max-content;
         }
         i {
-          height: 18px;
-          width: 18px;
+          margin: 0;
         }
       }
     }

--- a/src/styles/list.less
+++ b/src/styles/list.less
@@ -53,21 +53,42 @@
 
 // WIP: genericizes appearance of the move tree browser
 .list-block {
-  @border_width: var(--ironsworn-border-width-md);
-  @border_radius: var(--ironsworn-border-radius-lg);
-  @wrapper_spacing: 4px;
-  border-radius: @border_radius;
-  padding-left: @wrapper_spacing;
-  padding-right: @wrapper_spacing;
+  --list-block-border-style: outset;
+  --list-block-border-width: var(--ironsworn-border-width-md);
+  --list-block-border-highlight: var(--ironsworn-color-light-10);
+  --list-block-border-shadow: var(--ironsworn-color-dark-10);
   display: flex;
   flex-flow: column nowrap;
   list-style: none;
   padding: 0;
   .list-block-item {
     margin: 0;
-    border-style: groove;
-    border-width: 1px 0 0;
-    &:first-of-type {
+    height: max-content;
+    border-style: var(--list-block-border-style);
+    border-width: 0;
+    &:not(:first-of-type) {
+      border-top-width: var(--list-block-border-width);
+      border-top-color: var(--list-block-border-highlight);
+    }
+    &:not(:last-of-type) {
+      border-bottom-width: var(--list-block-border-width);
+      border-bottom-color: var(--list-block-border-shadow);
+    }
+  }
+  .list-block-header {
+    &:not(:last-child) {
+      // applies bottom border only if there's subsequent content
+      border-width: 0;
+      border-style: var(--list-block-border-style);
+      border-bottom-width: var(--list-block-border-width);
+      border-bottom-color: var(--list-block-border-shadow);
+      & ~ * {
+        // applies top border to first sibling after list-block-header
+        border-width: 0;
+        border-style: var(--list-block-border-style);
+        border-top-width: var(--list-block-border-width);
+        border-top-color: var(--list-block-border-highlight);
+      }
     }
   }
 }

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -126,6 +126,7 @@
   // .textStrokeMixin();
   background: transparent;
   color: var(--ironsworn-color-clickable-text);
+  border-width: 0;
   box-shadow: none !important;
   transition-property: color, filter, text-shadow, text-stroke;
   transition-duration: var(--ironsworn-transition-duration);

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -123,6 +123,7 @@
 .clickableTextMixin {
   --ironsworn-color-text-stroke: transparent;
   .interactiveMixin();
+  margin: 0;
   // .textStrokeMixin();
   background: transparent;
   color: var(--ironsworn-color-clickable-text);
@@ -235,6 +236,7 @@
 }
 
 .clickableBlockMixin(@blockSize:50px,) {
+  margin: 0;
   .blockMixin(@blockSize);
   &:hover,
   &.hover {

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -118,6 +118,20 @@
       border: none;
     }
   }
+  #tooltip {
+    // disables additional margin on paragraph elements in tooltips (FVTT doesn't use them, but we do)
+    & > {
+      p {
+        &:first-child {
+          margin-top: 0;
+        }
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+
   // importing within this selector to ensure higher specificity
   @import 'assets.less';
   @import 'attr-box.less';

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -107,15 +107,6 @@
       height: 100%;
       padding: var(--ironsworn-spacer-md);
     }
-    // overrides some of foundry's more annoying button styles
-    button {
-      border-width: 0px;
-      border-style: solid;
-    }
-    form button {
-      border-width: 0px;
-      border-style: solid;
-    }
     hr {
       width: 100%;
       border: 0 solid var(--ironsworn-color-border);

--- a/system/templates/rolls/preroll-dialog.hbs
+++ b/system/templates/rolls/preroll-dialog.hbs
@@ -3,7 +3,7 @@
   <section class='roll-trigger-text'>
     {{{enrichMarkdown move.system.Trigger.Text}}}
   </section>
-  {{#if move.system.Trigger.Options}}
+  {{#if (gt move.system.Trigger.Options.length 1)}}
   <ul class='trigger-options'>
     {{#each move.system.Trigger.Options}}
     {{#if Text}}


### PR DESCRIPTION
* several nitpicky fixes to borders, spacing, and sizing
* applies css variables and css module scoping to a few more components
* finishes the `.list-block` class, generalizing some of the styling from the collapsible move widgets. applies `.list-block` to the site sheet moves:
<img width="348" alt="Screen Shot 2022-12-03 at 12 06 02 AM" src="https://user-images.githubusercontent.com/5354757/205431265-6935ce16-3ec8-412c-9573-cf3c051427db.png">
