### PR TITLE
New searchbox component

### DIFF
--- a/src/module/vue/components/search-box.vue
+++ b/src/module/vue/components/search-box.vue
@@ -1,0 +1,44 @@
+<template>
+  <nav :class="$style.searchBox">
+    <slot name="before"></slot>
+    <input
+      type="search"
+      :class="$style.searchInput"
+      @search="$emit"
+      name="q"
+      autocorrect="off"
+      spellcheck="false"
+      incremental
+      @submit.prevent
+    />
+    <section :class="$style.searchBoxControls">
+      <!-- may be possible to omit -- needs testing -->
+      <!-- <BtnFaicon
+        icon="times-circle"
+        class="nogrow clickable text"
+        @click="clearSearch()"
+        :class="$style.searchBtn"
+      /> -->
+      <slot name="controls"></slot>
+    </section>
+    <slot name="after"></slot>
+  </nav>
+</template>
+
+<style lang="less" module>
+.searchBox {
+}
+.searchInput {
+}
+.searchBoxControls {
+}
+</style>
+
+<script lang="ts" setup>
+import BtnFaicon from './buttons/btn-faicon.vue'
+
+// consider: inject search query + a function to clear search?
+// is skipping the clear search button worthwhile here, since the native ui may provide it anyways?
+
+const $emit = defineEmits(['search'])
+</script>

--- a/src/module/vue/components/sf-movesheetmoves.vue
+++ b/src/module/vue/components/sf-movesheetmoves.vue
@@ -32,7 +32,12 @@
         :key="move.moveItem().id ?? `move${resultIndex}`"
         class="nogrow"
       >
-        <SfMoverow :move="move" ref="allMoves" :thematicColor="move.color" />
+        <SfMoverow
+          :move="move"
+          ref="allMoves"
+          :thematicColor="move.color"
+          :class="$style.moveRow"
+        />
       </li>
     </ul>
 
@@ -74,6 +79,10 @@
 .itemList {
   gap: var(--ironsworn-spacer-md);
   margin: 0;
+}
+
+.moveRow {
+  border-radius: var(--ironsworn-border-radius-lg);
 }
 </style>
 


### PR DESCRIPTION
Search/filter box component that should make things a bit DRYer on the movesheet. Will hopefully plug into the asset browser, too.

- [ ] make sure it works with the `search` event
- [ ] determine whether this is best managed via emit, injection, or some combination of the two
- [ ] review + revise CSS styling
- [ ] optional: implement on e.g. the asset browser?
- [x] fix border radius bug on move filter results