### PR TITLE
Clickable links in editable text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated bondset editor ([#546](https://github.com/ben/foundry-ironsworn/pull/546))
 - Updated aesthetics for drop targets ([#547](https://github.com/ben/foundry-ironsworn/pull/547))
 - Replace all native tooltips with Foundry enhanced ones ([#549](https://github.com/ben/foundry-ironsworn/pull/549))
+- Better logic for links embedded in descriptions; clicking a move in an asset description navigates to the move, but clicking an actor link opens the actor's sheet, for instance. ([#552](https://github.com/ben/foundry-ironsworn/pull/552))
 
 ## 1.20.1
 

--- a/src/module/vue/components/with-rolllisteners.vue
+++ b/src/module/vue/components/with-rolllisteners.vue
@@ -44,7 +44,7 @@ async function click(ev: JQuery.ClickEvent) {
     }
 
     // @ts-ignore
-    return gameItem._onClickDocumentLink(ev)
+    return gameItem?._onClickDocumentLink?.(ev)
   }
 
   if (dfid) {

--- a/src/module/vue/components/with-rolllisteners.vue
+++ b/src/module/vue/components/with-rolllisteners.vue
@@ -25,7 +25,7 @@ onMounted(() => {
     actor: $actor,
   })
 
-  $(el.value).find('.content-link').on('click', click)
+  $(el.value).on('click', '.content-link', click)
 })
 
 const $emit = defineEmits(['moveclick', 'oracleclick'])
@@ -35,24 +35,16 @@ async function click(ev: JQuery.ClickEvent) {
   ev.preventDefault()
   ev.stopPropagation()
 
-  const { pack, id, dfid } = ev.currentTarget.dataset
-  if (id) {
-    // TODO: better fallback logic here, allow for custom moves
-    // Might be a move navigation click
-    if (!pack) {
-      const item = game.items?.get(id)
-      return item?.sheet?.render(true)
-    }
-
-    const gamePack = game.packs.get(pack)
-    const gameItem = (await gamePack?.getDocument(id)) as
-      | IronswornItem
-      | IronswornActor
-    if (gameItem && ['move', 'sfmove'].includes(gameItem.type)) {
+  const { uuid, dfid } = ev.currentTarget.dataset
+  if (uuid) {
+    const gameItem = (await fromUuid(uuid)) as IronswornItem | IronswornActor
+    if (gameItem?.type === 'sfmove') {
       $emit('moveclick', gameItem)
+      return !!$attrs['onMoveclick']
     }
 
-    return !!$attrs['onMoveclick']
+    // @ts-ignore
+    return gameItem._onClickDocumentLink(ev)
   }
 
   if (dfid) {


### PR DESCRIPTION
Got a bug report [in Discord](https://discord.com/channels/437120373436186625/867434336201605160/1049348281014157382) regarding clickability of non-move links 

- [x] Proper logic for non-move links (opens actor sheet)
- [x] Attach listener to root element instead of replaceable child elements (edit/save asset description, link should still work)
- [x] Use UUID lookup instead of pack/id lookup
- [x] Update CHANGELOG.md
