### PR TITLE
Fix this action again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
First it was only running on PRs, and never on `main`. Next it was running twice on intra-repo PRs but only once on external PRs. This should be the last time I have to touch this line.