### PR TITLE
Better drag-and-drop events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Under the hood: updated NPM packages and Vite bundler ([#554](https://github.com/ben/foundry-ironsworn/pull/554) and [#555](https://github.com/ben/foundry-ironsworn/pull/555))
 - Updates to the Starforged theme, now covers the MCE editor drop-down menus ([#557](https://github.com/ben/foundry-ironsworn/pull/557))
+- Dragging from the asset browser now triggers the drop-zone animation ([#561](https://github.com/ben/foundry-ironsworn/pull/561))
 
 ## 1.20.5
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,8 @@ export type EmitterEvents = {
   highlightMove: string // Foundry ID
   highlightOracle: string // DF ID
   globalConditionChanged: { name: string; enabled: boolean } // info about condition that changed
+  dragStart: string // type of item
+  dragEnd: string // type of item
 }
 export type IronswornEmitter = Emitter<EmitterEvents>
 

--- a/src/module/features/drag-and-drop.ts
+++ b/src/module/features/drag-and-drop.ts
@@ -16,9 +16,8 @@ export function registerDragAndDropHooks() {
           const indexEntry = getIndexEntry(ev.target) as ReturnType<
             typeof getIndexEntry
           > & { type: string }
-          $(document)
-            .find(`[data-ironsworn-drop-type="${indexEntry?.type}"]`)
-            .attr('data-ironsworn-drop-active', 'true')
+
+          CONFIG.IRONSWORN.emitter.emit('dragStart', indexEntry?.type)
         }
       )
       .on(
@@ -28,9 +27,7 @@ export function registerDragAndDropHooks() {
             typeof getIndexEntry
           > & { type: string }
 
-          $(document)
-            .find(`[data-ironsworn-drop-type="${indexEntry?.type}"]`)
-            .attr('data-ironsworn-drop-active', 'false')
+          CONFIG.IRONSWORN.emitter.emit('dragEnd', indexEntry?.type)
         }
       )
   })

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -147,14 +147,10 @@ function dragStart(ev) {
     })
   )
 
-  $(document)
-    .find(`[data-ironsworn-drop-type="${props.foundryItem()?.type}"]`)
-    .attr('data-ironsworn-drop-active', 'true')
+  CONFIG.IRONSWORN.emitter.emit('dragStart', props.foundryItem().type)
 }
 
-function dragEnd(ev) {
-  $(document)
-    .find(`[data-ironsworn-drop-type="${props.foundryItem()?.type}"]`)
-    .attr('data-ironsworn-drop-active', 'false')
+function dragEnd() {
+  CONFIG.IRONSWORN.emitter.emit('dragEnd', props.foundryItem().type)
 }
 </script>

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -7,6 +7,7 @@
     :data-document-id="foundryItem().id"
     :class="{ [`asset-${toolset}`]: true }"
     @dragstart="dragStart"
+    @dragend="dragEnd"
   >
     <header class="asset-header nogrow flexrow">
       <i class="fa-solid fa-grip nogrow block draggable item"></i>
@@ -86,6 +87,7 @@
     </CollapseTransition>
   </article>
 </template>
+
 <style lang="less" scoped>
 .ironsworn .ironsworn__asset {
   display: flex;
@@ -97,34 +99,43 @@
   --ironsworn-color-thematic: v-bind('system.color');
 }
 </style>
+
 <script setup lang="ts">
 import { IAsset } from 'dataforged'
 import { computed, inject, provide, reactive } from 'vue'
 import { IronswornItem } from '../../../item/item'
 import { AssetDataPropertiesData } from '../../../item/itemtypes'
+import { $ItemKey, ItemKey } from '../../provisions.js'
+
 import Clock from '../clock.vue'
 import WithRolllisteners from '../with-rolllisteners.vue'
 import CollapseTransition from '../transition/collapse-transition.vue'
 import AttrSlider from '../resource-meter/attr-slider.vue'
-import { $ItemKey, ItemKey } from '../../provisions.js'
+
 const props = defineProps<{
   df?: IAsset
   foundryItem: () => IronswornItem
 }>()
+
 const toolset = inject('toolset')
 const system = (props.foundryItem() as any).system as AssetDataPropertiesData
+
 provide($ItemKey, props.foundryItem())
 provide(
   ItemKey,
   computed(() => props.foundryItem().toObject() as any)
 )
+
 const state = reactive({
   expanded: false,
 })
+
 const bodyId = `asset-body-${props.foundryItem().id}`
+
 function moveClick(item) {
   CONFIG.IRONSWORN.emitter.emit('highlightMove', item.id)
 }
+
 function dragStart(ev) {
   ev.dataTransfer.setData(
     'text/plain',
@@ -135,5 +146,15 @@ function dragStart(ev) {
       uuid: props.foundryItem().uuid,
     })
   )
+
+  $(document)
+    .find(`[data-ironsworn-drop-type="${props.foundryItem()?.type}"]`)
+    .attr('data-ironsworn-drop-active', 'true')
+}
+
+function dragEnd(ev) {
+  $(document)
+    .find(`[data-ironsworn-drop-type="${props.foundryItem()?.type}"]`)
+    .attr('data-ironsworn-drop-active', 'false')
 }
 </script>

--- a/src/module/vue/drop-target.vue
+++ b/src/module/vue/drop-target.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, reactive } from 'vue'
+import { onMounted, onUnmounted, reactive } from 'vue'
 
 const props = defineProps<{ is: any; dropType: string }>()
 
@@ -29,5 +29,10 @@ function dragEnd(type: string) {
 onMounted(() => {
   CONFIG.IRONSWORN.emitter.on('dragStart', dragStart)
   CONFIG.IRONSWORN.emitter.on('dragEnd', dragEnd)
+})
+
+onUnmounted(() => {
+  CONFIG.IRONSWORN.emitter.off('dragStart', dragStart)
+  CONFIG.IRONSWORN.emitter.off('dragEnd', dragEnd)
 })
 </script>

--- a/src/module/vue/drop-target.vue
+++ b/src/module/vue/drop-target.vue
@@ -3,12 +3,31 @@
     v-bind="($attrs, $props)"
     :is="is"
     :data-ironsworn-drop-type="dropType"
-    :data-ironsworn-drop-active="false"
+    :data-ironsworn-drop-active="state.active"
   >
     <slot />
   </component>
 </template>
 
 <script setup lang="ts">
-defineProps<{ is: any; dropType: string }>()
+import { onMounted, reactive } from 'vue'
+
+const props = defineProps<{ is: any; dropType: string }>()
+
+const state = reactive({
+  active: false,
+})
+
+function dragStart(type: string) {
+  if (type === props.dropType) state.active = true
+}
+
+function dragEnd(type: string) {
+  if (type === props.dropType) state.active = false
+}
+
+onMounted(() => {
+  CONFIG.IRONSWORN.emitter.on('dragStart', dragStart)
+  CONFIG.IRONSWORN.emitter.on('dragEnd', dragEnd)
+})
 </script>


### PR DESCRIPTION
This uses the global emitter to broadcast dragstart and dragend events, replacing the use of jQuery from before. The upshot is that dragging from the asset-compendium browser now triggers the drop-zone animations. Fixes #550.

- [x] Use the emitter for the FVTT browser
- [x] Also for our browser
- [x] Also for the drop targets
- [x] Update CHANGELOG.md
