### PR TITLE
SF truths from journal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Updates to the Starforged theme, now covers the MCE editor drop-down menus ([#557](https://github.com/ben/foundry-ironsworn/pull/557))
 - Dragging from the asset browser now triggers the drop-zone animation ([#561](https://github.com/ben/foundry-ironsworn/pull/561))
 - Completing the challenge-resolution dialog or the world-truths dalog now only closes that single window, instead of all Vue windows.
-- Setting truths are now stored as compendia, making translation efforts easier/possible. ([#564](https://github.com/ben/foundry-ironsworn/pull/564))
+- Setting truths are now stored as compendia, making translation efforts easier/possible. ([#564](https://github.com/ben/foundry-ironsworn/pull/564) for the data, [#569](https://github.com/ben/foundry-ironsworn/pull/569) for the new UI)
 
 ## 1.20.5
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,6 @@ import {
 } from './module/rolls'
 import { AssetCompendiumBrowser } from './module/item/asset-compendium-browser'
 import Mitt, { Emitter } from 'mitt'
-import { SFSettingTruthsDialogVue } from './module/applications/vueSfSettingTruthsDialog'
 
 export type EmitterEvents = {
   highlightMove: string // Foundry ID
@@ -39,9 +38,6 @@ export interface IronswornConfig {
 
   emitter: IronswornEmitter
 
-  // DELETEME
-  SFSettingTruthsDialogVue: typeof SFSettingTruthsDialogVue
-
   beta: { [k: string]: any }
 }
 
@@ -63,8 +59,6 @@ export const IRONSWORN: IronswornConfig = {
   dataforgedHelpers,
 
   emitter: Mitt<EmitterEvents>(),
-
-  SFSettingTruthsDialogVue,
 
   beta: {
     AssetCompendiumBrowser,

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ import {
 } from './module/rolls'
 import { AssetCompendiumBrowser } from './module/item/asset-compendium-browser'
 import Mitt, { Emitter } from 'mitt'
+import { SFSettingTruthsDialogVue } from './module/applications/vueSfSettingTruthsDialog'
 
 export type EmitterEvents = {
   highlightMove: string // Foundry ID
@@ -38,6 +39,9 @@ export interface IronswornConfig {
 
   emitter: IronswornEmitter
 
+  // DELETEME
+  SFSettingTruthsDialogVue: typeof SFSettingTruthsDialogVue
+
   beta: { [k: string]: any }
 }
 
@@ -59,6 +63,8 @@ export const IRONSWORN: IronswornConfig = {
   dataforgedHelpers,
 
   emitter: Mitt<EmitterEvents>(),
+
+  SFSettingTruthsDialogVue,
 
   beta: {
     AssetCompendiumBrowser,

--- a/src/module/applications/vueSfSettingTruthsDialog.ts
+++ b/src/module/applications/vueSfSettingTruthsDialog.ts
@@ -1,5 +1,4 @@
 import { Starforged, starforged } from 'dataforged'
-import { hashLookup } from '../dataforged'
 import sfTruthsVue from '../vue/sf-truths.vue'
 import { VueSheetRenderHelperOptions } from '../vue/vue-render-helper'
 import { VueAppMixin } from '../vue/vueapp.js'

--- a/src/module/rolls/oracle-roll-message.ts
+++ b/src/module/rolls/oracle-roll-message.ts
@@ -81,18 +81,11 @@ export class OracleRollMessage {
     })
   }
 
-  static async fromTableId(
-    tableId: string,
-    tablePack?: string
-  ): Promise<OracleRollMessage> {
+  static fromTableId(tableId: string, tablePack?: string) {
     return new OracleRollMessage({ tableId, tablePack })
   }
 
-  static async fromRows(
-    tableRows: TableRow[],
-    title: string,
-    subtitle?: string
-  ) {
+  static fromRows(tableRows: TableRow[], title: string, subtitle?: string) {
     return new OracleRollMessage({ tableRows, title, subtitle })
   }
 

--- a/src/module/vue/components/mce-editor.vue
+++ b/src/module/vue/components/mce-editor.vue
@@ -50,6 +50,11 @@ const $emit = defineEmits<{ (e: 'save') }>()
 
 onUnmounted(() => $emit('save'))
 
+function enableEditor() {
+  data.editing = true
+}
+defineExpose({ enableEditor })
+
 const mceConfig: RawEditorSettings = {
   ...CONFIG.TinyMCE,
 

--- a/src/module/vue/components/truth/custom-truth.vue
+++ b/src/module/vue/components/truth/custom-truth.vue
@@ -7,7 +7,12 @@
       @change="select"
       ref="radio"
     />
-    <MceEditor v-model="state.html" ref="editor" @save="emitHtml" />
+    <MceEditor
+      v-model="state.html"
+      ref="editor"
+      @save="emitHtml"
+      :style="{ height: state.height, 'min-height': state.height }"
+    />
   </label>
 </template>
 
@@ -30,10 +35,14 @@ const props = defineProps<{
 const radio = ref<HTMLElement>()
 const editor = ref<typeof MceEditor>()
 
-const state = reactive({ html: '' })
+const state = reactive({
+  html: '',
+  height: '35px',
+})
 
 function select() {
   editor.value?.enableEditor()
+  state.height = '300px'
 }
 
 const $emit = defineEmits<{

--- a/src/module/vue/components/truth/custom-truth.vue
+++ b/src/module/vue/components/truth/custom-truth.vue
@@ -1,0 +1,45 @@
+<template>
+  <label class="nogrow flexrow">
+    <input
+      type="radio"
+      :name="radioGroup"
+      class="nogrow"
+      @change="select"
+      ref="radio"
+    />
+    <MceEditor v-model="state.html" ref="editor" @save="emitHtml" />
+  </label>
+</template>
+
+<style lang="less" scoped>
+input[type='radio'] {
+  flex-grow: 0;
+  align-self: flex-start;
+  margin: var(--ironsworn-spacer-lg);
+}
+</style>
+
+<script lang="ts" setup>
+import { reactive, ref } from 'vue'
+import MceEditor from '../mce-editor.vue'
+
+const props = defineProps<{
+  radioGroup: string
+}>()
+
+const radio = ref<HTMLElement>()
+const editor = ref<typeof MceEditor>()
+
+const state = reactive({ html: '' })
+
+function select() {
+  editor.value?.enableEditor()
+}
+
+const $emit = defineEmits<{
+  (e: 'change', html: string)
+}>()
+function emitHtml() {
+  $emit('change', state.html)
+}
+</script>

--- a/src/module/vue/components/truth/truth-category.vue
+++ b/src/module/vue/components/truth/truth-category.vue
@@ -21,6 +21,7 @@
 
 <script lang="ts" setup>
 import { ISettingTruth } from 'dataforged'
+import { reactive } from 'vue'
 import TruthSelectable from './truth-selectable.vue'
 
 const props = defineProps<{
@@ -33,11 +34,19 @@ const nonTruthPages = (props.je()?.pages ?? []).filter(
   (p) => p.type !== 'truth'
 )
 
-const $emit = defineEmits<{
-  (e: 'select', df: ISettingTruth, title: string, value: string)
-}>()
+type State = {
+  title?: string
+  text?: string
+}
 
-function select(categoryid: string, title: string, text: string) {
-  console.log({ categoryid, title, text })
+const state = reactive<State>({})
+function select(title: string, text: string) {
+  state.title = title
+  state.text = text
+}
+
+defineExpose({ selectedValue })
+function selectedValue(): State {
+  return state
 }
 </script>

--- a/src/module/vue/components/truth/truth-category.vue
+++ b/src/module/vue/components/truth/truth-category.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flexcol">
+  <div class="flexcol" ref="root">
     <h1>{{ je().name }}</h1>
 
     <TruthSelectable
@@ -21,7 +21,7 @@
 
 <script lang="ts" setup>
 import { ISettingTruth } from 'dataforged'
-import { reactive } from 'vue'
+import { reactive, ref } from 'vue'
 import TruthSelectable from './truth-selectable.vue'
 
 const props = defineProps<{
@@ -45,8 +45,19 @@ function select(title: string, text: string) {
   state.text = text
 }
 
-defineExpose({ selectedValue })
-function selectedValue(): State {
-  return state
+const selectedValue = () => ({
+  title: props.je().name,
+  p1: state.title,
+  p2: state.text,
+})
+
+const root = ref<HTMLElement>()
+function scrollIntoView() {
+  root.value?.scrollIntoView({
+    behavior: 'smooth',
+    block: 'start',
+  })
 }
+
+defineExpose({ selectedValue, scrollIntoView })
 </script>

--- a/src/module/vue/components/truth/truth-category.vue
+++ b/src/module/vue/components/truth/truth-category.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="flexcol">
+    <h1>{{ je().name }}</h1>
+
+    <TruthSelectable
+      v-for="page in truthPages"
+      :page="page"
+      :radio-group="df.$id"
+    />
+
+    <!-- TODO: custom entry -->
+
+    <div
+      class="nogrow"
+      v-for="page in nonTruthPages"
+      v-html="page.text.content"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ISettingTruth } from 'dataforged'
+import TruthSelectable from './truth-selectable.vue'
+
+const props = defineProps<{
+  df: ISettingTruth
+  je: () => JournalEntry
+}>()
+
+const truthPages = (props.je()?.pages ?? []).filter((p) => p.type === 'truth')
+const nonTruthPages = (props.je()?.pages ?? []).filter(
+  (p) => p.type !== 'truth'
+)
+
+const $emit = defineEmits<{
+  (e: 'select', df: ISettingTruth, title: string, value: string)
+}>()
+</script>

--- a/src/module/vue/components/truth/truth-category.vue
+++ b/src/module/vue/components/truth/truth-category.vue
@@ -47,10 +47,9 @@ const props = defineProps<{
   je: () => JournalEntry
 }>()
 
-const truthPages = (props.je()?.pages ?? []).filter((p) => p.type === 'truth')
-const nonTruthPages = (props.je()?.pages ?? []).filter(
-  (p) => p.type !== 'truth'
-)
+const jePages = (props.je() as any | undefined)?.pages ?? []
+const truthPages = jePages.filter((p) => p.type === 'truth')
+const nonTruthPages = jePages.filter((p) => p.type !== 'truth')
 
 const state = reactive<{
   title?: string

--- a/src/module/vue/components/truth/truth-category.vue
+++ b/src/module/vue/components/truth/truth-category.vue
@@ -22,6 +22,7 @@
 <script lang="ts" setup>
 import { ISettingTruth } from 'dataforged'
 import { reactive, ref } from 'vue'
+import { enrichMarkdown } from '../../vue-plugin'
 import TruthSelectable from './truth-selectable.vue'
 
 const props = defineProps<{
@@ -48,9 +49,9 @@ function select(title: string, text: string) {
 const selectedValue = () => ({
   title: props.je().name,
   html: `
-    <p><strong>${state.title}</strong></p>
-    <p>${state.text}</p>
-  `,
+    ${enrichMarkdown(`**${state.title}**`)}
+    ${enrichMarkdown(state.text)}
+  `.trim(),
   valid: !!state.title,
 })
 

--- a/src/module/vue/components/truth/truth-category.vue
+++ b/src/module/vue/components/truth/truth-category.vue
@@ -47,8 +47,11 @@ function select(title: string, text: string) {
 
 const selectedValue = () => ({
   title: props.je().name,
-  p1: state.title,
-  p2: state.text,
+  html: `
+    <p><strong>${state.title}</strong></p>
+    <p>${state.text}</p>
+  `,
+  valid: !!state.title,
 })
 
 const root = ref<HTMLElement>()

--- a/src/module/vue/components/truth/truth-category.vue
+++ b/src/module/vue/components/truth/truth-category.vue
@@ -6,6 +6,7 @@
       v-for="page in truthPages"
       :page="page"
       :radio-group="df.$id"
+      @select="select"
     />
 
     <!-- TODO: custom entry -->
@@ -35,4 +36,8 @@ const nonTruthPages = (props.je()?.pages ?? []).filter(
 const $emit = defineEmits<{
   (e: 'select', df: ISettingTruth, title: string, value: string)
 }>()
+
+function select(categoryid: string, title: string, text: string) {
+  console.log({ categoryid, title, text })
+}
 </script>

--- a/src/module/vue/components/truth/truth-category.vue
+++ b/src/module/vue/components/truth/truth-category.vue
@@ -58,14 +58,18 @@ function select(title: string, text: string) {
   state.text = text
 }
 
-const selectedValue = () => ({
-  title: props.je().name,
-  html: `
-    ${enrichMarkdown(`**${state.title}**`)}
-    ${enrichMarkdown(state.text)}
-  `.trim(),
-  valid: !!state.title,
-})
+function selectedValue() {
+  const nonTruthMarkdown = nonTruthPages.map((x) => x.text.content).join('\n\n')
+  return {
+    title: props.je().name,
+    html: `
+      ${enrichMarkdown(`**${state.title}**`)}
+      ${enrichMarkdown(state.text)}
+      ${enrichMarkdown(nonTruthMarkdown)}
+    `.trim(),
+    valid: !!state.title,
+  }
+}
 
 const root = ref<HTMLElement>()
 function scrollIntoView() {

--- a/src/module/vue/components/truth/truth-selectable.vue
+++ b/src/module/vue/components/truth/truth-selectable.vue
@@ -65,7 +65,7 @@ function subtableSelect(entry: ISettingTruthOptionSubtableRow) {
 }
 
 const $emit = defineEmits<{
-  (e: 'select', title: string, text: string)
+  (e: 'change', title: string, text: string)
 }>()
 function emitValue() {
   let text = `${pageSystem.Description} ${state.suboption ?? ''}`
@@ -73,7 +73,7 @@ function emitValue() {
   if (state.suboption && template?.Description) {
     text = template.Description.replace(/\${{.*?}}/, state.suboption)
   }
-  $emit('select', props.page.name, text.trim())
+  $emit('change', props.page.name, text.trim())
 }
 
 const suboptions = ref<HTMLElement[]>([])

--- a/src/module/vue/components/truth/truth-selectable.vue
+++ b/src/module/vue/components/truth/truth-selectable.vue
@@ -63,14 +63,13 @@ function subtableSelect(entry: ISettingTruthOptionSubtableRow) {
 }
 
 const $emit = defineEmits<{
-  (e: 'select', categoryid: string, title: string, text: string)
+  (e: 'select', title: string, text: string)
 }>()
 function emitValue() {
   $emit(
     'select',
-    props.radioGroup,
     props.page.name,
-    `${props.page.system.Description} ${state.suboption ?? ''}`
+    `${props.page.system.Description} ${state.suboption ?? ''}`.trim()
   )
 }
 </script>

--- a/src/module/vue/components/truth/truth-selectable.vue
+++ b/src/module/vue/components/truth/truth-selectable.vue
@@ -6,7 +6,16 @@
         <strong>{{ page.name }}</strong>
       </p>
 
-      <p v-html="$enrichMarkdown(page.system.Description)" />
+      <div v-html="$enrichMarkdown(page.system.Description)" />
+
+      <section v-if="page.system.Subtable">
+        <label class="flexrow nogrow" v-for="entry in page.system.Subtable">
+          <input type="radio" class="nogrow" :name="page.system.dfid" />
+          <p v-html="entry.Result" />
+        </label>
+
+        <!-- TODO: custom input -->
+      </section>
     </div>
   </label>
 </template>
@@ -20,6 +29,8 @@ input[type='radio'] {
 </style>
 
 <script setup lang="ts">
+import IronBtn from '../buttons/iron-btn.vue'
+
 const props = defineProps<{
   //@ts-ignore
   page: JournalEntryPage

--- a/src/module/vue/components/truth/truth-selectable.vue
+++ b/src/module/vue/components/truth/truth-selectable.vue
@@ -66,10 +66,11 @@ const $emit = defineEmits<{
   (e: 'select', title: string, text: string)
 }>()
 function emitValue() {
-  $emit(
-    'select',
-    props.page.name,
-    `${props.page.system.Description} ${state.suboption ?? ''}`.trim()
-  )
+  let text = `${props.page.system.Description} ${state.suboption ?? ''}`
+  const template = props.page.system['Roll template']
+  if (state.suboption && template?.Description) {
+    text = template.Description.replace(/\${{.*?}}/, state.suboption)
+  }
+  $emit('select', props.page.name, text.trim())
 }
 </script>

--- a/src/module/vue/components/truth/truth-selectable.vue
+++ b/src/module/vue/components/truth/truth-selectable.vue
@@ -21,7 +21,7 @@
             ref="suboptions"
             class="nogrow"
             :name="page.system.dfid"
-            @change="subtableSelect(entry)"
+            @change="subtableSelect(entry as any)"
           />
           <p v-html="entry.Result" />
         </label>

--- a/src/module/vue/components/truth/truth-selectable.vue
+++ b/src/module/vue/components/truth/truth-selectable.vue
@@ -1,6 +1,12 @@
 <template>
   <label class="nogrow flexrow">
-    <input class="nogrow" type="radio" :name="radioGroup" />
+    <input
+      type="radio"
+      class="nogrow"
+      @change="select"
+      :name="radioGroup"
+      ref="topRadio"
+    />
     <div class="flexcol">
       <p>
         <strong>{{ page.name }}</strong>
@@ -10,7 +16,12 @@
 
       <section v-if="page.system.Subtable">
         <label class="flexrow nogrow" v-for="entry in page.system.Subtable">
-          <input type="radio" class="nogrow" :name="page.system.dfid" />
+          <input
+            type="radio"
+            class="nogrow"
+            @change="subtableSelect(entry)"
+            :name="page.system.dfid"
+          />
           <p v-html="entry.Result" />
         </label>
 
@@ -29,6 +40,8 @@ input[type='radio'] {
 </style>
 
 <script setup lang="ts">
+import { ISettingTruthOptionSubtableRow } from 'dataforged'
+import { reactive, ref } from 'vue'
 import IronBtn from '../buttons/iron-btn.vue'
 
 const props = defineProps<{
@@ -36,4 +49,28 @@ const props = defineProps<{
   page: JournalEntryPage
   radioGroup: string
 }>()
+
+function select() {
+  emitValue()
+}
+
+const topRadio = ref<HTMLElement>()
+const state = reactive({ suboption: undefined as string | undefined })
+function subtableSelect(entry: ISettingTruthOptionSubtableRow) {
+  state.suboption = entry.Result
+  topRadio.value?.click()
+  emitValue()
+}
+
+const $emit = defineEmits<{
+  (e: 'select', categoryid: string, title: string, text: string)
+}>()
+function emitValue() {
+  $emit(
+    'select',
+    props.radioGroup,
+    props.page.name,
+    `${props.page.system.Description} ${state.suboption ?? ''}`
+  )
+}
 </script>

--- a/src/module/vue/components/truth/truth-selectable.vue
+++ b/src/module/vue/components/truth/truth-selectable.vue
@@ -1,0 +1,28 @@
+<template>
+  <label class="nogrow flexrow">
+    <input class="nogrow" type="radio" :name="radioGroup" />
+    <div class="flexcol">
+      <p>
+        <strong>{{ page.name }}</strong>
+      </p>
+
+      <p v-html="$enrichMarkdown(page.system.Description)" />
+    </div>
+  </label>
+</template>
+
+<style lang="less" scoped>
+input[type='radio'] {
+  flex-grow: 0;
+  align-self: flex-start;
+  margin: var(--ironsworn-spacer-lg);
+}
+</style>
+
+<script setup lang="ts">
+const props = defineProps<{
+  //@ts-ignore
+  page: JournalEntryPage
+  radioGroup: string
+}>()
+</script>

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -70,7 +70,7 @@ async function saveTruths() {
     .map((x) => x.selectedValue())
     .filter((x) => x.valid)
 
-  const html = values
+  const content = values
     .map(
       ({ title, html }) => `
         <h2>${title}</h2>
@@ -81,7 +81,7 @@ async function saveTruths() {
 
   const journal = await JournalEntry.create({
     name: game.i18n.localize('IRONSWORN.SFSettingTruthsTitle'),
-    content: html,
+    content,
   })
   journal?.sheet?.render(true)
   $localEmitter?.emit('closeApp')

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -1,28 +1,34 @@
 <template>
-  <div class="flexcol">
-    <div v-for="category in truths" :key="category.Name">
-      <h2 style="margin-top: 1em">{{ category.Name }}</h2>
-
-      <SfTruth
-        v-for="option in category.Table"
-        :key="option.$id"
-        :radiogroup="category.Name"
-        :truth="option"
-        @change="radioselect"
+  <div class="flexrow" style="position: relative">
+    <nav class="flexcol">
+      <IronBtn
+        v-for="truth in truths"
+        nogrow
+        :text="truth.je().name ?? '???'"
+        @click="scrollToCategory(truth.df.$id)"
       />
-
-      <!-- TODO: custom truth entry -->
-    </div>
-
-    <hr />
-    <IronBtn
-      block
-      @click="saveTruths"
-      :text="$t('IRONSWORN.SaveYourTruths')"
-      icon="fa:feather"
-    />
+    </nav>
+    <section class="flexcol">
+      <TruthCategory
+        v-for="truth in truths"
+        :key="truth.df.$id"
+        :df="truth.df"
+        :je="truth.je"
+        @select="categorySelect"
+      />
+    </section>
   </div>
 </template>
+
+<style lang="less" scoped>
+nav {
+  position: fixed;
+  margin-top: 1em;
+}
+section {
+  margin-left: 15em;
+}
+</style>
 
 <script setup lang="ts">
 import { computed, inject, reactive } from 'vue'
@@ -30,8 +36,14 @@ import SfTruth from './components/sf-truth.vue'
 import { ISettingTruth } from 'dataforged'
 import IronBtn from './components/buttons/iron-btn.vue'
 import { $LocalEmitterKey } from './provisions'
+import TruthCategory from './components/truth/truth-category.vue'
 
-const props = defineProps<{ truths: ISettingTruth[] }>()
+const props = defineProps<{
+  truths: {
+    df: ISettingTruth
+    je: () => JournalEntry
+  }[]
+}>()
 
 const output = {}
 for (const category of props.truths ?? []) {
@@ -53,6 +65,14 @@ const composedOutput = computed(() =>
 )
 function radioselect(category, value) {
   data.output[category] = value
+}
+
+function scrollToCategory(dfid: string) {
+  // TODO:
+}
+
+function categorySelect(df: ISettingTruth, title: string, value: string) {
+  // TODO:
 }
 
 const $localEmitter = inject($LocalEmitterKey)

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -2,10 +2,10 @@
   <div class="flexrow" style="position: relative">
     <nav class="flexcol">
       <IronBtn
-        v-for="truth in truths"
+        v-for="(truth, i) in truths"
         nogrow
         :text="truth.je().name ?? '???'"
-        @click="scrollToCategory(truth.df.$id)"
+        @click="scrollToCategory(i)"
       />
 
       <IronBtn
@@ -22,7 +22,6 @@
         :key="truth.df.$id"
         :df="truth.df"
         :je="truth.je"
-        @select="categorySelect"
       />
     </section>
   </div>
@@ -58,23 +57,34 @@ const props = defineProps<{
   }[]
 }>()
 
-function scrollToCategory(dfid: string) {
-  // TODO:
+const categoryComponents = ref<typeof TruthCategory[]>([])
+
+function scrollToCategory(i: number) {
+  categoryComponents.value[i]?.scrollIntoView()
 }
 
 const $localEmitter = inject($LocalEmitterKey)
-const categoryComponents = ref<TruthCategory[]>([])
 async function saveTruths() {
   // Fetch values from the category components
   const values = categoryComponents.value
     .map((x) => x.selectedValue())
-    .filter((x) => x.title)
-  console.log(values)
-  // const journal = await JournalEntry.create({
-  //   name: game.i18n.localize('IRONSWORN.SFSettingTruthsTitle'),
-  //   content: composedOutput.value,
-  // })
-  // journal?.sheet?.render(true)
-  // $localEmitter?.emit('closeApp')
+    .filter((x) => x.p1)
+
+  const html = values
+    .map(
+      ({ title, p1, p2 }) => `
+        <h2>${title}</h2>
+        <p><strong>${p1}</strong></p>
+        <p>${p2}</p>
+      `
+    )
+    .join('\n\n')
+
+  const journal = await JournalEntry.create({
+    name: game.i18n.localize('IRONSWORN.SFSettingTruthsTitle'),
+    content: html,
+  })
+  journal?.sheet?.render(true)
+  $localEmitter?.emit('closeApp')
 }
 </script>

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -18,6 +18,7 @@
     <section class="flexcol">
       <TruthCategory
         v-for="truth in truths"
+        ref="categoryComponents"
         :key="truth.df.$id"
         :df="truth.df"
         :je="truth.je"
@@ -44,11 +45,10 @@ section {
 </style>
 
 <script setup lang="ts">
-import { computed, inject, reactive } from 'vue'
-import SfTruth from './components/sf-truth.vue'
+import { inject, ref } from 'vue'
 import { ISettingTruth } from 'dataforged'
-import IronBtn from './components/buttons/iron-btn.vue'
 import { $LocalEmitterKey } from './provisions'
+import IronBtn from './components/buttons/iron-btn.vue'
 import TruthCategory from './components/truth/truth-category.vue'
 
 const props = defineProps<{
@@ -58,43 +58,23 @@ const props = defineProps<{
   }[]
 }>()
 
-const output = {}
-for (const category of props.truths ?? []) {
-  output[category.Name] = null
-}
-
-const data = reactive({ output })
-
-const composedOutput = computed(() =>
-  props.truths
-    .map((category) => category.Name)
-    .map((name) =>
-      data.output[name]
-        ? `<h2>${name}</h2>\n${data.output[name]}\n\n`
-        : undefined
-    )
-    .filter((x) => x !== undefined)
-    .join('\n')
-)
-function radioselect(category, value) {
-  data.output[category] = value
-}
-
 function scrollToCategory(dfid: string) {
   // TODO:
 }
 
-function categorySelect(df: ISettingTruth, title: string, value: string) {
-  // TODO:
-}
-
 const $localEmitter = inject($LocalEmitterKey)
+const categoryComponents = ref<TruthCategory[]>([])
 async function saveTruths() {
-  const journal = await JournalEntry.create({
-    name: game.i18n.localize('IRONSWORN.SFSettingTruthsTitle'),
-    content: composedOutput.value,
-  })
-  journal?.sheet?.render(true)
-  $localEmitter?.emit('closeApp')
+  // Fetch values from the category components
+  const values = categoryComponents.value
+    .map((x) => x.selectedValue())
+    .filter((x) => x.title)
+  console.log(values)
+  // const journal = await JournalEntry.create({
+  //   name: game.i18n.localize('IRONSWORN.SFSettingTruthsTitle'),
+  //   content: composedOutput.value,
+  // })
+  // journal?.sheet?.render(true)
+  // $localEmitter?.emit('closeApp')
 }
 </script>

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -68,14 +68,13 @@ async function saveTruths() {
   // Fetch values from the category components
   const values = categoryComponents.value
     .map((x) => x.selectedValue())
-    .filter((x) => x.p1)
+    .filter((x) => x.valid)
 
   const html = values
     .map(
-      ({ title, p1, p2 }) => `
+      ({ title, html }) => `
         <h2>${title}</h2>
-        <p><strong>${p1}</strong></p>
-        <p>${p2}</p>
+        ${html}
       `
     )
     .join('\n\n')

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -8,6 +8,13 @@
         @click="scrollToCategory(i)"
       />
 
+      <hr class="nogrow" />
+      <IronBtn
+        nogrow
+        icon="ironsworn:d10-tilt"
+        :text="$t('IRONSWORN.RandomizeAll')"
+        @click="randomizeAll"
+      />
       <IronBtn
         nogrow
         :text="$t('IRONSWORN.SaveYourTruths')"
@@ -85,5 +92,11 @@ async function saveTruths() {
   })
   journal?.sheet?.render(true)
   $localEmitter?.emit('closeApp')
+}
+
+async function randomizeAll() {
+  for (const cat of categoryComponents.value) {
+    await cat.randomize()
+  }
 }
 </script>

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -7,6 +7,13 @@
         :text="truth.je().name ?? '???'"
         @click="scrollToCategory(truth.df.$id)"
       />
+
+      <IronBtn
+        nogrow
+        :text="$t('IRONSWORN.SaveYourTruths')"
+        icon="fa:feather"
+        @click="saveTruths"
+      />
     </nav>
     <section class="flexcol">
       <TruthCategory
@@ -24,9 +31,15 @@
 nav {
   position: fixed;
   margin-top: 1em;
+  height: 100%;
 }
+
 section {
   margin-left: 15em;
+}
+
+.save-button {
+  justify-self: flex-end;
 }
 </style>
 

--- a/src/styles/editor.less
+++ b/src/styles/editor.less
@@ -1,8 +1,7 @@
 // styles for TinyMCE and ProseMirror editors
 
 // Editors: shared styles
-.editor,
-.editor-content {
+.editor {
   min-height: 100px;
 }
 .editor {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -8,6 +8,7 @@
     "QuestStarter": "Quest Starter",
     "SaveYourTruths": "Save Your Truths",
     "CustomTruth": "Custom Truth",
+    "RandomizeAll": "Randomize All",
     "Roll": "Roll",
     "Chat": "Chat",
     "SendToChat": "Send text to chat: <i>{move}</i>",


### PR DESCRIPTION
This reworks the Vue-based SF truths selection dialog to use the journal entries from #564 as their data source, which allows them to be translated with a Babele module.

- [x] Categories
- [x] Subtables
- [x] Custom entries
- [x] Saving to a journal entry
- [x] Randomization at all levels (fixes #431)
- [x] Update CHANGELOG.md
