### PR TITLE
Preset challenge dice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- Allow pre-setting of challenge dice, and revamp the advanced rolling options UI ([#606](https://github.com/ben/foundry-ironsworn/pull/606))
 - Under the hoood: update Dataforged import with documents built in Foundry v10 ([#601](https://github.com/ben/foundry-ironsworn/pull/601))
 
 ## 1.20.13

--- a/src/module/rolls/ironsworn-roll.ts
+++ b/src/module/rolls/ironsworn-roll.ts
@@ -342,10 +342,21 @@ export class IronswornRoll {
       }))
     }
 
+    // If challenge dice haven't been rolled but values were pre-set, use those
+    if (
+      this.preRollOptions.presetChallenge1 &&
+      this.preRollOptions.presetChallenge2
+    ) {
+      return [
+        this.preRollOptions.presetChallenge1,
+        this.preRollOptions.presetChallenge2,
+      ]
+    }
+
     // Not rolled yet. Definitely include two, then maybe some extras
     const ret = [
-      { source: '', value: undefined },
-      { source: '', value: undefined },
+      { source: '', value: this.preRollOptions.presetChallenge1?.value },
+      { source: '', value: this.preRollOptions.presetChallenge2?.value },
     ] as SourcedValue<number | undefined>[]
     if (this.preRollOptions.extraChallengeDice) {
       for (let i = 0; i < this.preRollOptions.extraChallengeDice.value; i++) {
@@ -361,8 +372,10 @@ export class IronswornRoll {
   // Either [N,N] or undefined
   get finalChallengeDice(): undefined | [SourcedValue, SourcedValue] {
     const replaced = compact([
-      this.postRollOptions.replacedChallenge1,
-      this.postRollOptions.replacedChallenge2,
+      this.postRollOptions.replacedChallenge1 ??
+        this.preRollOptions.presetChallenge1,
+      this.postRollOptions.replacedChallenge2 ??
+        this.preRollOptions.presetChallenge2,
     ])
     if (replaced.length === 2) {
       return replaced as [SourcedValue, SourcedValue]

--- a/src/module/rolls/ironsworn-roll.ts
+++ b/src/module/rolls/ironsworn-roll.ts
@@ -391,7 +391,7 @@ export class IronswornRoll {
         const preset = this.preRollOptions[`presetChallenge${i + 1}`] as
           | SourcedValue
           | undefined
-        const die = this.rawChallengeDiceValues[i] as number
+        const die = this.rawChallengeDiceValues![i] as number
         return {
           source: preset?.source ?? 'd10',
           value: preset?.value ?? die,

--- a/src/module/rolls/ironsworn-roll.ts
+++ b/src/module/rolls/ironsworn-roll.ts
@@ -119,6 +119,11 @@ export interface PreRollOptions {
    */
   presetActionDie?: SourcedValue
   /**
+   * As in Weapon Master #2
+   */
+  presetChallenge1?: SourcedValue
+  presetChallenge2?: SourcedValue
+  /**
    * As in Sleuth #1
    */
   extraChallengeDice?: SourcedValue

--- a/src/module/rolls/ironsworn-roll.ts
+++ b/src/module/rolls/ironsworn-roll.ts
@@ -355,8 +355,14 @@ export class IronswornRoll {
 
     // Not rolled yet. Definitely include two, then maybe some extras
     const ret = [
-      { source: '', value: this.preRollOptions.presetChallenge1?.value },
-      { source: '', value: this.preRollOptions.presetChallenge2?.value },
+      {
+        source: this.preRollOptions.presetChallenge1?.source ?? '',
+        value: this.preRollOptions.presetChallenge1?.value,
+      },
+      {
+        source: this.preRollOptions.presetChallenge2?.source ?? '',
+        value: this.preRollOptions.presetChallenge2?.value,
+      },
     ] as SourcedValue<number | undefined>[]
     if (this.preRollOptions.extraChallengeDice) {
       for (let i = 0; i < this.preRollOptions.extraChallengeDice.value; i++) {
@@ -381,10 +387,16 @@ export class IronswornRoll {
       return replaced as [SourcedValue, SourcedValue]
     }
     if (this.rawChallengeDiceValues?.length === 2) {
-      return this.rawChallengeDiceValues.map((d) => ({
-        source: 'd10',
-        value: d,
-      })) as [SourcedValue, SourcedValue]
+      return [0, 1].map((i) => {
+        const preset = this.preRollOptions[`presetChallenge${i + 1}`] as
+          | SourcedValue
+          | undefined
+        const die = this.rawChallengeDiceValues[i] as number
+        return {
+          source: preset?.source ?? 'd10',
+          value: preset?.value ?? die,
+        }
+      }) as [SourcedValue, SourcedValue]
     }
     return undefined
   }

--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -120,14 +120,12 @@ function prerollOptionsWithFormData(
     .serializeArray()
     .reduce((coll, { name, value }) => {
       if (isSet(value)) {
-        return { ...coll, [name]: parseInt(value, 10) }
+        coll[name] = parseInt(value, 10)
       }
       return coll
     }, {})
 
   opts.adds = valMap.adds
-
-  console.log({ valMap })
 
   if (isSet(valMap.automaticOutcomeValue)) {
     opts.automaticOutcome = {

--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -114,7 +114,7 @@ function prerollOptionsWithFormData(
   }
 
   const isSet = (x) =>
-    x !== null && x !== undefined && x !== NaN && x !== '' && x !== 'null'
+    x !== null && x !== 'null' && x !== undefined && !isNaN(x) && x !== ''
 
   const valMap: ValueMap = form
     .serializeArray()

--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -109,35 +109,51 @@ function prerollOptionsWithFormData(
     automaticOutcomeValue?: number
     extraChallengeDiceValue?: number
     presetActionDieValue?: number
-    automaticOutcome?: boolean
-    extraChallengeDice?: boolean
-    presetActionDie?: boolean
+    presetChallengeDie1Value?: number
+    presetChallengeDie2Value?: number
   }
+
+  const isSet = (x) =>
+    x !== null && x !== undefined && x !== NaN && x !== '' && x !== 'null'
 
   const valMap: ValueMap = form
     .serializeArray()
     .reduce((coll, { name, value }) => {
-      if (name == 'adds' || name.endsWith('Value')) {
+      if (isSet(value)) {
         return { ...coll, [name]: parseInt(value, 10) }
       }
-      return { ...coll, [name]: parseCheckbox(value) }
+      return coll
     }, {})
 
   opts.adds = valMap.adds
 
-  if (valMap.automaticOutcome) {
+  console.log({ valMap })
+
+  if (isSet(valMap.automaticOutcomeValue)) {
     opts.automaticOutcome = {
       source: 'set manually',
       value: valMap.automaticOutcomeValue as RollOutcome,
     }
   }
-  if (valMap.presetActionDie) {
+  if (isSet(valMap.presetActionDieValue)) {
     opts.presetActionDie = {
       source: 'set manually',
       value: valMap.presetActionDieValue as number,
     }
   }
-  if (valMap.extraChallengeDice) {
+  if (isSet(valMap.presetChallengeDie1Value)) {
+    opts.presetChallenge1 = {
+      source: 'set manually',
+      value: valMap.presetChallengeDie1Value as number,
+    }
+  }
+  if (isSet(valMap.presetChallengeDie2Value)) {
+    opts.presetChallenge2 = {
+      source: 'set manually',
+      value: valMap.presetChallengeDie2Value as number,
+    }
+  }
+  if (isSet(valMap.extraChallengeDiceValue)) {
     opts.extraChallengeDice = {
       source: 'set manually',
       value: valMap.extraChallengeDiceValue as number,
@@ -417,7 +433,7 @@ export class IronswornPrerollDialog extends Dialog<
 
     // Resize when expanding the "advanced" section
     html.find('details').on('toggle', (ev) => {
-      const delta = (ev.currentTarget.open ? 1 : -1) * 120
+      const delta = (ev.currentTarget.open ? 1 : -1) * 160
       const app = html.parents('.app')
       app.height((app.height() ?? 0) + delta)
     })

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -273,6 +273,7 @@
     "RollDialog": {
       "AdvancedRollOptions": "Advanced options",
       "PresetActionDie": "Preset action die",
+      "PresetChallengeDice": "Preset challenge dice",
       "PredeterminedOutcome": "Predetermined outcome",
       "ExtraChallengeDice": "Extra challenge dice"
     },

--- a/system/templates/rolls/preroll-dialog.hbs
+++ b/system/templates/rolls/preroll-dialog.hbs
@@ -43,11 +43,11 @@
     <summary>{{localize 'IRONSWORN.RollDialog.AdvancedRollOptions'}}</summary>
 
     <fieldset class='form-group'>
-      <label class='checkbox'>
-        <input type='checkbox' class='advanced-roll-options-toggle' name='automaticOutcome' />
+      <label>
         {{localize 'IRONSWORN.RollDialog.PredeterminedOutcome'}}
       </label>
       <select name='automaticOutcomeValue'>
+        <option value='null'></option>
         <option value='0'>{{localize 'IRONSWORN.Miss'}}</option>
         <option value='1'>{{localize 'IRONSWORN.Weak_hit'}}</option>
         <option value='2'>{{localize 'IRONSWORN.Strong_hit'}}</option>
@@ -56,19 +56,23 @@
 
     {{#if action}}
     <fieldset class='form-group'>
-      <label class='checkbox'>
-        <input type='checkbox' class='advanced-roll-options-toggle' name='presetActionDie' />
-        {{localize 'IRONSWORN.RollDialog.PresetActionDie'}}
-      </label>
-      <input type='number' step='1' name='presetActionDieValue' value='0' />
+      <label>{{localize 'IRONSWORN.RollDialog.PresetActionDie'}}</label>
+      <input type='number' step='1' name='presetActionDieValue' />
+    </fieldset>
+
+    <fieldset class='form-group'>
+      <label>{{localize 'IRONSWORN.RollDialog.PresetChallengeDice'}}</label>
+      <div class="flexrow" style="gap: 5px">
+        <input type='number' step='1' name='presetChallengeDie1Value' />
+        <input type='number' step='1' name='presetChallengeDie2Value' />
+      </div>
     </fieldset>
     {{/if}}
     <fieldset class='form-group'>
-      <label class='checkbox'>
-        <input type='checkbox' class='advanced-roll-options-toggle' name='extraChallengeDice' />
+      <label>
         {{localize 'IRONSWORN.RollDialog.ExtraChallengeDice'}}
       </label>
-      <input type='number' step='1' name='extraChallengeDiceValue' value='0' min='0' />
+      <input type='number' step='1' name='extraChallengeDiceValue' min='0' />
     </fieldset>
 
   </details>

--- a/system/templates/rolls/preroll-dialog.hbs
+++ b/system/templates/rolls/preroll-dialog.hbs
@@ -59,6 +59,7 @@
       <label>{{localize 'IRONSWORN.RollDialog.PresetActionDie'}}</label>
       <input type='number' step='1' name='presetActionDieValue' />
     </fieldset>
+    {{/if}}
 
     <fieldset class='form-group'>
       <label>{{localize 'IRONSWORN.RollDialog.PresetChallengeDice'}}</label>
@@ -67,7 +68,7 @@
         <input type='number' step='1' name='presetChallengeDie2Value' />
       </div>
     </fieldset>
-    {{/if}}
+
     <fieldset class='form-group'>
       <label>
         {{localize 'IRONSWORN.RollDialog.ExtraChallengeDice'}}


### PR DESCRIPTION
This extends the pre-roll dialog to allow setting up to two challenge dice (we already support setting the challenge die).

- [x] Add inputs to the pre-roll dialog
  - [x] Also update the UI here, it's not great
- [x] Obey the settings in the rolling logic
- [x] Update CHANGELOG.md
