### PR TITLE
Allow hooks to provide tables in non-standard packs (or not in a pack at all)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Next Release
 
-- Under the hood: Remove the old `tables.db` (superceded by `ironsworn-oracles.db`) and all remaining references to it ([#614](https://github.com/ben/foundry-ironsworn/pull/614))
 - Add a loading spinner for the asset browser ([#618](https://github.com/ben/foundry-ironsworn/pull/618))
+- Fix a few bugs around custom oracles overriding the built-in ones ([#616](https://github.com/ben/foundry-ironsworn/pull/616))
+- Under the hood: Remove the old `tables.db` (superceded by `ironsworn-oracles.db`) and all remaining references to it ([#614](https://github.com/ben/foundry-ironsworn/pull/614))
 
 ## 1.20.14
 

--- a/src/module/rolls/oracle-roll-message.ts
+++ b/src/module/rolls/oracle-roll-message.ts
@@ -33,6 +33,7 @@ export class OracleRollMessage {
   protected dfOracleId?: string
   protected tableId?: string
   protected tablePack?: string // valid if tableId is set
+  protected diceFormula?: string
   protected tableRows?: TableRow[]
 
   // Display properties
@@ -50,6 +51,7 @@ export class OracleRollMessage {
     dfOracleId?: string
     tableId?: string
     tablePack?: string
+    diceFormula?: string
     tableRows?: TableRow[]
     title?: string
     subtitle?: string
@@ -82,8 +84,12 @@ export class OracleRollMessage {
     })
   }
 
-  static fromTableId(tableId: string, tablePack?: string) {
-    return new OracleRollMessage({ tableId, tablePack })
+  static fromTableId(
+    tableId: string,
+    tablePack?: string,
+    diceFormula?: string
+  ) {
+    return new OracleRollMessage({ tableId, tablePack, diceFormula })
   }
 
   static fromRows(tableRows: TableRow[], title: string, subtitle?: string) {
@@ -161,7 +167,7 @@ export class OracleRollMessage {
     const rows = await this.getTableRows()
 
     const highestValue = rows[rows.length - 1].high
-    this.roll = new Roll(`1d${highestValue}`)
+    this.roll = new Roll(this.diceFormula ?? `1d${highestValue}`)
     await this.roll.evaluate({ async: true })
   }
 

--- a/src/module/rolls/oracle-roll-message.ts
+++ b/src/module/rolls/oracle-roll-message.ts
@@ -116,7 +116,9 @@ export class OracleRollMessage {
 
     if (this.tablePack) {
       const pack = game.packs.get(this.tablePack)
-      const packTable = pack?.get(this.tableId ?? '') as RollTable
+      const packTable = (await pack?.getDocument(
+        this.tableId ?? ''
+      )) as RollTable
       if (packTable) return packTable
     }
 

--- a/src/module/rolls/oracle-roll-message.ts
+++ b/src/module/rolls/oracle-roll-message.ts
@@ -187,8 +187,8 @@ export class OracleRollMessage {
     const starforgedRoot = await createStarforgedOracleTree()
     const ironswornRooot = await createIronswornOracleTree()
     const pathElements =
-      findPathToNodeByTableId(starforgedRoot, this.tableId) ??
-      findPathToNodeByTableId(ironswornRooot, this.tableId)
+      (await findPathToNodeByTableId(starforgedRoot, this.tableId)) ??
+      (await findPathToNodeByTableId(ironswornRooot, this.tableId))
     pathElements.shift() // no display name for root node
     pathElements.pop() // last node is the table we rolled
     return pathElements.map((x) => x.displayName).join(' / ')

--- a/src/module/vue/components/buttons/btn-oracle.vue
+++ b/src/module/vue/components/buttons/btn-oracle.vue
@@ -37,12 +37,13 @@ const $emit = defineEmits(['click'])
 async function rollOracle() {
   if (props.overrideClick && props.onClick) return $emit('click')
 
-  const randomTable = sample(props.node.tables)?.()
+  const tableGetter = sample(props.node.tables)
+  const table = await tableGetter?.()
 
   const orm = await OracleRollMessage.fromTableId(
-    randomTable?.id ?? '',
-    randomTable?.pack || undefined,
-    (randomTable as any)?.formula
+    table?.id ?? '',
+    table?.pack || undefined,
+    (table as any)?.formula
   )
   orm.createOrUpdate()
 }

--- a/src/module/vue/components/buttons/btn-oracle.vue
+++ b/src/module/vue/components/buttons/btn-oracle.vue
@@ -32,21 +32,16 @@ const props = defineProps<{
   onClick?: Function
 }>()
 
-const toolset = inject<'ironsworn' | 'starforged'>('toolset')
 const $emit = defineEmits(['click'])
 
 async function rollOracle() {
   if (props.overrideClick && props.onClick) return $emit('click')
 
-  const randomTable = sample(props.node.tables)
-  const pack = {
-    ironsworn: 'foundry-ironsworn.ironswornoracles',
-    starforged: 'foundry-ironsworn.starforgedoracles',
-  }[toolset ?? '']
+  const randomTable = sample(props.node.tables)?.()
 
   const orm = await OracleRollMessage.fromTableId(
-    randomTable?.()?.id ?? '',
-    pack
+    randomTable?.id ?? '',
+    randomTable?.pack || undefined
   )
   orm.createOrUpdate()
 }

--- a/src/module/vue/components/buttons/btn-oracle.vue
+++ b/src/module/vue/components/buttons/btn-oracle.vue
@@ -41,7 +41,8 @@ async function rollOracle() {
 
   const orm = await OracleRollMessage.fromTableId(
     randomTable?.id ?? '',
-    randomTable?.pack || undefined
+    randomTable?.pack || undefined,
+    (randomTable as any)?.formula
   )
   orm.createOrUpdate()
 }

--- a/src/module/vue/components/rules-text/rules-text-oracle.vue
+++ b/src/module/vue/components/rules-text/rules-text-oracle.vue
@@ -20,5 +20,8 @@ import RulesText from './rules-text.vue'
 import OracleTable from './oracle-table.vue'
 import { ISource } from 'dataforged'
 
-const props = defineProps<{ oracleTable: () => RollTable; source?: ISource }>()
+const props = defineProps<{
+  oracleTable: () => RollTable | Promise<RollTable>
+  source?: ISource
+}>()
 </script>

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -196,6 +196,10 @@ import { OracleRollMessage } from '../rolls'
 import { LocationDataProperties } from '../actor/actortypes'
 import SheetBasic from './sheet-basic.vue'
 import IronBtn from './components/buttons/iron-btn.vue'
+import {
+  createStarforgedOracleTree,
+  findPathToNodeByDfId,
+} from '../features/customoracles'
 
 const props = defineProps<{
   actor: any
@@ -673,9 +677,11 @@ async function rollFirstLook() {
 }
 
 async function rollOracle(oracle) {
-  const table = await CONFIG.IRONSWORN.dataforgedHelpers.getFoundryTableByDfId(
-    oracle.dfId
-  )
+  // Make sure we use customized oracles
+  const tree = await createStarforgedOracleTree()
+  const nodes = await findPathToNodeByDfId(tree, oracle.dfId)
+  const node = nodes[nodes.length - 1]
+  const table = sample(node.tables)?.()
   const drawText = await drawAndReturnResult(table)
   if (!drawText) return
 

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -10,13 +10,13 @@
           <span class="select-label">{{ $t('IRONSWORN.Region') }}</span>
           <select v-model="region" @change="regionChanged">
             <option value="terminus">
-              {{ $t('IRONSWORN.Terminus') }}
+              {{ $t('IRONSWORN.REGION.Terminus') }}
             </option>
             <option value="outlands">
-              {{ $t('IRONSWORN.Outlands') }}
+              {{ $t('IRONSWORN.REGION.Outlands') }}
             </option>
             <option value="expanse">
-              {{ $t('IRONSWORN.Expanse') }}
+              {{ $t('IRONSWORN.REGION.Expanse') }}
             </option>
           </select>
         </label>
@@ -551,7 +551,7 @@ const randomKlassTooltip = computed(() => {
 
 const subtypeSelectText = computed(() => {
   const { subtype } = props.actor.system
-  return game.i18n.localize(`IRONSWORN.${camelCase(subtype)}Type`)
+  return game.i18n.localize(`IRONSWORN.${capitalize(subtype)}Type`)
 })
 
 const klassIsNotValid = computed(() => {

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -681,14 +681,15 @@ async function rollOracle(oracle) {
   const tree = await createStarforgedOracleTree()
   const nodes = await findPathToNodeByDfId(tree, oracle.dfId)
   const node = nodes[nodes.length - 1]
-  const table = sample(node.tables)?.()
+  const tableGetter = sample(node.tables)
+  const table = await tableGetter?.()
   const drawText = await drawAndReturnResult(table)
   if (!drawText) return
 
   // Append to description
   const actor = props.actor as LocationDataProperties
   const parts = [
-    props.actor.system.description,
+    actor.system.description,
     '<p><strong>',
     oracle.title,
     ':</strong> ',


### PR DESCRIPTION
As discussed in [Discord](https://discord.com/channels/437120373436186625/867434336201605160/1067089434295685170), we were making the mistake that all oracle-tree-node RollTables would come from the standard packs, and that's just not true.

- [x] Allow tables to be pulled from other packs
- [x] Use that table's formula to roll the tables (i.e. `((d3-1) * 100) + d100` for a 300-table entry that still rolls 3d dice)
- [x] Fix strings and oracle resolution in the location sheet
- [x] Update CHANGELOG.md
