### PR TITLE
Asset loading spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Add a loading spinner for the asset browser ([#618](https://github.com/ben/foundry-ironsworn/pull/618))
+
 ## 1.20.14
 
 - Allow pre-setting of challenge dice, and revamp the advanced rolling options UI ([#606](https://github.com/ben/foundry-ironsworn/pull/606))

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "vite-plugin-svg-icons": "^2.0.1",
         "vite-plugin-vue-inspector": "^3.2.1",
         "vue": "^3.2.45",
+        "vue-spinner": "^1.0.4",
         "vue-template-compiler": "^2.6.14",
         "vue-tsc": "^1.0.24",
         "vue2-animate": "^2.1.4"
@@ -9993,6 +9994,11 @@
         "@vue/shared": "3.2.45"
       }
     },
+    "node_modules/vue-spinner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vue-spinner/-/vue-spinner-1.0.4.tgz",
+      "integrity": "sha512-GNG2F+8BLX201JT/jUX+84Gsi3ZteVQwt9K7mues3ts9FcQ95dGn7uu6a5ndSxdYYUEzfh1KngZiOE0u+l4itA=="
+    },
     "node_modules/vue-template-compiler": {
       "version": "2.7.14",
       "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
@@ -17736,6 +17742,11 @@
         "@vue/server-renderer": "3.2.45",
         "@vue/shared": "3.2.45"
       }
+    },
+    "vue-spinner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vue-spinner/-/vue-spinner-1.0.4.tgz",
+      "integrity": "sha512-GNG2F+8BLX201JT/jUX+84Gsi3ZteVQwt9K7mues3ts9FcQ95dGn7uu6a5ndSxdYYUEzfh1KngZiOE0u+l4itA=="
     },
     "vue-template-compiler": {
       "version": "2.7.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "vite-plugin-svg-icons": "^2.0.1",
         "vite-plugin-vue-inspector": "^3.2.1",
         "vue": "^3.2.45",
-        "vue-spinner": "^1.0.4",
+        "vue-loading-overlay": "^6.0.2",
         "vue-template-compiler": "^2.6.14",
         "vue-tsc": "^1.0.24",
         "vue2-animate": "^2.1.4"
@@ -9994,10 +9994,16 @@
         "@vue/shared": "3.2.45"
       }
     },
-    "node_modules/vue-spinner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/vue-spinner/-/vue-spinner-1.0.4.tgz",
-      "integrity": "sha512-GNG2F+8BLX201JT/jUX+84Gsi3ZteVQwt9K7mues3ts9FcQ95dGn7uu6a5ndSxdYYUEzfh1KngZiOE0u+l4itA=="
+    "node_modules/vue-loading-overlay": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/vue-loading-overlay/-/vue-loading-overlay-6.0.2.tgz",
+      "integrity": "sha512-5GCvv6hPjNfHg+tKnLkk6yO/b/AdCCkdZb2dfrVFOuDyJz38dbm34k6oohVy/xIoFzPGsEEVtwCxq5G3RIYZ1Q==",
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
     },
     "node_modules/vue-template-compiler": {
       "version": "2.7.14",
@@ -17743,10 +17749,11 @@
         "@vue/shared": "3.2.45"
       }
     },
-    "vue-spinner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/vue-spinner/-/vue-spinner-1.0.4.tgz",
-      "integrity": "sha512-GNG2F+8BLX201JT/jUX+84Gsi3ZteVQwt9K7mues3ts9FcQ95dGn7uu6a5ndSxdYYUEzfh1KngZiOE0u+l4itA=="
+    "vue-loading-overlay": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/vue-loading-overlay/-/vue-loading-overlay-6.0.2.tgz",
+      "integrity": "sha512-5GCvv6hPjNfHg+tKnLkk6yO/b/AdCCkdZb2dfrVFOuDyJz38dbm34k6oohVy/xIoFzPGsEEVtwCxq5G3RIYZ1Q==",
+      "requires": {}
     },
     "vue-template-compiler": {
       "version": "2.7.14",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "vite-plugin-svg-icons": "^2.0.1",
     "vite-plugin-vue-inspector": "^3.2.1",
     "vue": "^3.2.45",
+    "vue-spinner": "^1.0.4",
     "vue-template-compiler": "^2.6.14",
     "vue-tsc": "^1.0.24",
     "vue2-animate": "^2.1.4"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "vite-plugin-svg-icons": "^2.0.1",
     "vite-plugin-vue-inspector": "^3.2.1",
     "vue": "^3.2.45",
-    "vue-spinner": "^1.0.4",
+    "vue-loading-overlay": "^6.0.2",
     "vue-template-compiler": "^2.6.14",
     "vue-tsc": "^1.0.24",
     "vue2-animate": "^2.1.4"

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -1,7 +1,7 @@
 <template>
   <section
     class="nogrow asset-category"
-    v-for="category in categories"
+    v-for="category in data.categories"
     :key="category.title"
   >
     <h2 class="flexrow">
@@ -74,7 +74,7 @@ h2 {
 </style>
 
 <script setup lang="ts">
-import { provide } from 'vue'
+import { provide, reactive } from 'vue'
 import WithRolllisteners from './components/with-rolllisteners.vue'
 import AssetBrowserCard from './components/asset/asset-browser-card.vue'
 import CollapseTransition from './components/transition/collapse-transition.vue'
@@ -91,6 +91,8 @@ provide('toolset', props.toolset)
 const categories = await (props.toolset === 'ironsworn'
   ? createIronswornAssetTree()
   : createStarforgedAssetTree())
+
+const data = reactive({ categories })
 
 function moveClick(item) {
   CONFIG.IRONSWORN.emitter.emit('highlightMove', item.id)

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -1,7 +1,7 @@
 <template>
   <section
     class="nogrow asset-category"
-    v-for="category in data.categories"
+    v-for="category in categories"
     :key="category.title"
   >
     <h2 class="flexrow">
@@ -74,33 +74,23 @@ h2 {
 </style>
 
 <script setup lang="ts">
-import { provide, reactive } from 'vue'
+import { provide } from 'vue'
 import WithRolllisteners from './components/with-rolllisteners.vue'
 import AssetBrowserCard from './components/asset/asset-browser-card.vue'
 import CollapseTransition from './components/transition/collapse-transition.vue'
 import {
   createIronswornAssetTree,
   createStarforgedAssetTree,
-  DisplayCategory,
 } from '../features/customassets'
 import IronBtn from './components/buttons/iron-btn.vue'
 
 const props = defineProps<{ toolset: 'starforged' | 'ironsworn' }>()
 
-const data = reactive({
-  categories: [] as DisplayCategory[],
-})
-
 provide('toolset', props.toolset)
 
-// Kick into async without requiring a <Suspense>
-const promise =
-  props.toolset === 'ironsworn'
-    ? createIronswornAssetTree()
-    : createStarforgedAssetTree()
-promise.then((categories) => {
-  data.categories = categories
-})
+const categories = await (props.toolset === 'ironsworn'
+  ? createIronswornAssetTree()
+  : createStarforgedAssetTree())
 
 function moveClick(item) {
   CONFIG.IRONSWORN.emitter.emit('highlightMove', item.id)

--- a/src/module/vue/components/character-sheet-tabs/ironsworn-main.vue
+++ b/src/module/vue/components/character-sheet-tabs/ironsworn-main.vue
@@ -120,6 +120,6 @@ function assetBrowser() {
       $actor?.toolset ?? 'starforged'
     )
   }
-  theAssetBrowser.render(true)
+  theAssetBrowser.render(true, { focus: true })
 }
 </script>

--- a/src/module/vue/components/character-sheet-tabs/sf-assets.vue
+++ b/src/module/vue/components/character-sheet-tabs/sf-assets.vue
@@ -98,6 +98,6 @@ function assetBrowser() {
       $actor?.toolset ?? 'starforged'
     )
   }
-  theAssetBrowser.render(true)
+  theAssetBrowser.render(true, { focus: true })
 }
 </script>

--- a/src/module/vue/components/loading-spinner.vue
+++ b/src/module/vue/components/loading-spinner.vue
@@ -1,0 +1,13 @@
+<template>
+  <GridLoader
+    :loading="true"
+    color="#ccc"
+    style="margin: auto; max-width: 57px"
+  />
+</template>
+
+<script lang="ts" setup>
+import * as Loaders from 'vue-spinner/src/index'
+
+const GridLoader = Loaders.GridLoader
+</script>

--- a/src/module/vue/components/loading-spinner.vue
+++ b/src/module/vue/components/loading-spinner.vue
@@ -1,5 +1,5 @@
 <template>
-  <Loading :active="true" loader="bars" :isFullPage="false" />
+  <Loading :active="true" loader="bars" :is-full-page="false" />
 </template>
 
 <script lang="ts" setup>

--- a/src/module/vue/components/loading-spinner.vue
+++ b/src/module/vue/components/loading-spinner.vue
@@ -1,13 +1,8 @@
 <template>
-  <GridLoader
-    :loading="true"
-    color="#ccc"
-    style="margin: auto; max-width: 57px"
-  />
+  <Loading :active="true" loader="bars" :isFullPage="false" />
 </template>
 
 <script lang="ts" setup>
-import * as Loaders from 'vue-spinner/src/index'
-
-const GridLoader = Loaders.GridLoader
+import Loading from 'vue-loading-overlay'
+import 'vue-loading-overlay/dist/css/index.css'
 </script>

--- a/src/module/vue/vue-render-helper.ts
+++ b/src/module/vue/vue-render-helper.ts
@@ -7,6 +7,7 @@ import {
   LocalEmitter,
   LocalEmitterEvents,
 } from './provisions'
+import LoadingSpinner from './components/loading-spinner.vue'
 import * as Loaders from 'vue-spinner/src/index'
 
 export interface VueSheetRenderHelperOptions {
@@ -50,7 +51,7 @@ export class VueSheetRenderHelper {
         },
 
         components: {
-          'grid-loader': Loaders.GridLoader,
+          'loading-spinner': LoadingSpinner,
           ...this.options.components,
         },
 

--- a/src/module/vue/vue-render-helper.ts
+++ b/src/module/vue/vue-render-helper.ts
@@ -7,6 +7,7 @@ import {
   LocalEmitter,
   LocalEmitterEvents,
 } from './provisions'
+import * as Loaders from 'vue-spinner/src/index'
 
 export interface VueSheetRenderHelperOptions {
   vueData: () => Promise<Record<string, any>>
@@ -48,7 +49,10 @@ export class VueSheetRenderHelper {
           return { data: data }
         },
 
-        components: this.options.components,
+        components: {
+          'grid-loader': Loaders.GridLoader,
+          ...this.options.components,
+        },
 
         provide: {
           context: {

--- a/src/module/vue/vue-render-helper.ts
+++ b/src/module/vue/vue-render-helper.ts
@@ -8,7 +8,6 @@ import {
   LocalEmitterEvents,
 } from './provisions'
 import LoadingSpinner from './components/loading-spinner.vue'
-import * as Loaders from 'vue-spinner/src/index'
 
 export interface VueSheetRenderHelperOptions {
   vueData: () => Promise<Record<string, any>>

--- a/system/templates/asset-compendium-browser.hbs
+++ b/system/templates/asset-compendium-browser.hbs
@@ -6,11 +6,7 @@
 
     <template #fallback>
       <div class='flexrow'>
-        <grid-loader
-          :loading='true'
-          color='#ccc'
-          style='margin: auto; max-width: 57px'
-        />
+        <loading-spinner />
       </div>
     </template>
   </Suspense>

--- a/system/templates/asset-compendium-browser.hbs
+++ b/system/templates/asset-compendium-browser.hbs
@@ -1,5 +1,17 @@
 <form class='{{cssClass}} flexcol vueroot' autocomplete='off'>
-  <asset-compendium-browser :toolset='data.toolset'>
-    Loading…
-  </asset-compendium-browser>
+  <Suspense>
+    <asset-compendium-browser :toolset='data.toolset'>
+      Loading…
+    </asset-compendium-browser>
+
+    <template #fallback>
+      <div class='flexrow'>
+        <grid-loader
+          :loading='true'
+          color='#ccc'
+          style='margin: auto; max-width: 57px'
+        />
+      </div>
+    </template>
+  </Suspense>
 </form>


### PR DESCRIPTION
This adds a loading spinner to the asset compendium browser. I noticed it sat blank when I ran a game from not-my-machine. This leverages [vue-loading-overlay](https://www.npmjs.com/package/vue-loading-overlay). A sample using a synthetically-slow network connection:

https://user-images.githubusercontent.com/39902/214358579-a3dd0640-151a-4098-9741-3b30d34c8e23.mp4

Fixes #517, at least partway. In a separate PR I'll rework all the nearly-the-same Handlebars templates for vue-root things, and give every one of them a `<Suspense>` and a loading spinner, which will help with more stuff and be cleaner.

- [x] Provide a loading spinner component to all templates
- [x] `<Suspense>` and loading spinner for asset browser
- [x] Update CHANGELOG.md
