### PR TITLE
change css assets to relative imports

### DIFF
--- a/src/styles/assets.less
+++ b/src/styles/assets.less
@@ -159,14 +159,14 @@
   --ironsworn-bullet-margin-top: 0.15em;
 
   margin-top: var(--ironsworn-bullet-margin-top);
-  background-image: url('/assets/misc/hex-checkbox-unchecked.svg');
+  background-image: url('../../system/assets/misc/hex-checkbox-unchecked.svg');
   height: var(--ironsworn-bullet-height);
   aspect-ratio: var(--ironsworn-hexagon-aspect-ratio);
-  mask-image: url('/assets/misc/hex-checkbox-unchecked.svg');
+  mask-image: url('../../system/assets/misc/hex-checkbox-unchecked.svg');
 }
 
 .asset-ability-bullet-starforged-marked {
-  mask-image: url('/assets/misc/hex-checkbox-checked.svg');
+  mask-image: url('../../system/assets/misc/hex-checkbox-checked.svg');
 }
 
 .asset-ironsworn,

--- a/src/styles/dice.less
+++ b/src/styles/dice.less
@@ -113,7 +113,7 @@
 
     &.d6::before {
       background-color: var(--ironsworn-dice-background-color);
-      mask-image: url('/assets/icons/d6-blank.svg');
+      mask-image: url('../../system/assets/icons/d6-blank.svg');
       content: '';
     }
 
@@ -123,7 +123,7 @@
 
     &.d10::before {
       background-color: var(--ironsworn-dice-background-color);
-      mask-image: url('/assets/icons/d10-blank.svg');
+      mask-image: url('../../system/assets/icons/d10-blank.svg');
       content: '';
     }
 

--- a/src/styles/icons.less
+++ b/src/styles/icons.less
@@ -253,7 +253,7 @@ i {
 each(@icons, {
   .isicon-@{key}, .isiconbg-@{key} {
     &:before {
-      mask-image: url('/assets/icons/@{key}.svg');
+      mask-image: url('../../system/assets/icons/@{key}.svg');
   }}
 });
 
@@ -310,7 +310,7 @@ a[data-pack='foundry-ironsworn.starforgedmoves'] {
       mask-repeat: no-repeat;
       mask-position: center;
       mask-size: contain;
-      mask-image: url('/assets/icons/d10-tilt.svg');
+      mask-image: url('../../system/assets/icons/d10-tilt.svg');
     }
   }
 }

--- a/src/styles/themes/mixins/decorations.less
+++ b/src/styles/themes/mixins/decorations.less
@@ -39,7 +39,8 @@
     height: var(--ironsworn-asset-deco-collapsed-height);
     content: '';
     pointer-events: none;
-    mask-image: url('/assets/misc/hex-deco.svg');
+    // This seems wrong, but imports. See https://github.com/vitejs/vite/issues/7651
+    mask-image: url('/../../../system/assets/misc/hex-deco.svg');
     aspect-ratio: var(--ironsworn-asset-deco-aspect-ratio);
     mask-repeat: no-repeat;
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ const config: UserConfig = {
     'process.env': process.env,
   },
   publicDir: 'system',
-  base: '/systems/foundry-ironsworn/',
+  base: '',
   server: {
     port: 8080,
     proxy: {
@@ -47,6 +47,7 @@ const config: UserConfig = {
     },
   },
   build: {
+    assetsInlineLimit: 0,
     outDir: 'dist',
     emptyOutDir: true,
     sourcemap: true,


### PR DESCRIPTION
In the current release, most icons fail to load if foundry is configured with a routePrefix.

This PR switches to using a relative base for vite and relative imports in the css.

This fixes the issues with icons not loading and also might be slightly faster since the icons are now inlined into the css directly so additional requests for the icons will be skipped.