### PR TITLE
ORM uses table UUIDs instead of pack/id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Under the hood: using Foundry v10 uuids more than id/pack pairs
+
 ## 1.20.18
 
 - Fix some string bugs in the sector and location sheets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next Release
 
-- Under the hood: using Foundry v10 uuids more than id/pack pairs
+- Under the hood: using Foundry v10 uuids more than id/pack pairs ([#629](https://github.com/ben/foundry-ironsworn/pull/629))
 
 ## 1.20.18
 

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -1,7 +1,6 @@
 import { compact, flatten } from 'lodash'
 import { SFMoveDataPropertiesData } from '../item/itemtypes'
 import { IronswornItem } from '../item/item'
-import { cachedDocumentsForPack } from '../features/pack-cache'
 import { IronswornRollMessage, OracleRollMessage } from '../rolls'
 import { ChallengeResolutionDialog } from '../rolls/challenge-resolution-dialog'
 import { getFoundryTableByDfId } from '../dataforged'
@@ -43,10 +42,7 @@ export class IronswornChatCard {
         name: t.name || '',
         icon: '<i class="isicon-oracle"></i>',
         callback: async () => {
-          const msg = await OracleRollMessage.fromTableId(
-            t.id,
-            t.pack || undefined
-          )
+          const msg = await OracleRollMessage.fromTableUuid(t.uuid)
           msg.createOrUpdate()
         },
       }))
@@ -147,10 +143,7 @@ export class IronswornChatCard {
       (await isPack?.getDocument(tableid))) as RollTable | undefined
     if (!table?.id) return
 
-    const msg = await OracleRollMessage.fromTableId(
-      table.id,
-      table.pack || undefined
-    )
+    const msg = await OracleRollMessage.fromTableUuid(table.uuid)
     msg.createOrUpdate()
   }
 

--- a/src/module/rolls/oracle-roll-message.ts
+++ b/src/module/rolls/oracle-roll-message.ts
@@ -256,6 +256,16 @@ export class OracleRollMessage {
     const json = html?.find('.oracle-roll').data('oracleroll')
     if (!json) return undefined
 
+    // Older messages include tableId/tablePack; if that's the case we reconstruct a uuid
+    // Compendium.foundry-ironsworn.starforgedoracles.16fbeb54dfe52e19
+    const { tableId, tablePack } = json
+    if (tableId) {
+      delete json.tableId
+      delete json.tablePack
+      if (tablePack) json.tableUuid = `Compendium.${tablePack}.${tableId}`
+      else json.tableUuid = `RollTable.${tableId}`
+    }
+
     const orm = new OracleRollMessage(json)
     orm.roll = msg?.roll || undefined
     orm.chatMessageId = messageId

--- a/src/module/vue/components/buttons/btn-oracle.vue
+++ b/src/module/vue/components/buttons/btn-oracle.vue
@@ -44,10 +44,7 @@ async function rollOracle() {
     starforged: 'foundry-ironsworn.starforgedoracles',
   }[toolset ?? '']
 
-  const orm = await OracleRollMessage.fromTableId(
-    randomTable?.()?.id ?? '',
-    pack
-  )
+  const orm = await OracleRollMessage.fromTableUuid(randomTable?.()?.uuid ?? '')
   orm.createOrUpdate()
 }
 </script>

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -603,10 +603,7 @@ async function drawAndReturnResult(
 ): Promise<string | undefined> {
   if (!table) return undefined
 
-  const orm = await OracleRollMessage.fromTableId(
-    table.id || '',
-    table.pack || undefined
-  )
+  const orm = await OracleRollMessage.fromTableUuid(table.uuid)
   orm.createOrUpdate()
   const result = await orm.getResult()
   return result?.text


### PR DESCRIPTION
Part of #450.

- [x] ORM now uses/stores UUIDs instead of tableId/tablePack
  - [x] Consider supporting old chat messages here
- [x] Update CHANGELOG.md
