### PR TITLE
Fix some move-clicking issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Next Release
 
+- Fix some bugs around move-link navigation throughout the UI ([#647](https://github.com/ben/foundry-ironsworn/pull/647))
+
 ## 1.20.21
 
 - Assets like **Bonded** with move links in their requirement fields now work properly when you click the links.
-- Update the compact PC sheet, fixing visual glitches, and converting it to Vue.
-- Under the hood: refactored the Vue layer to have a more sensible architecture.
+- Update the compact PC sheet, fixing visual glitches, and converting it to Vue ([#640](https://github.com/ben/foundry-ironsworn/pull/640)).
+- Under the hood: refactored the Vue layer to have a more sensible architecture ([#638](https://github.com/ben/foundry-ironsworn/pull/638) and [#639](https://github.com/ben/foundry-ironsworn/pull/639)).
 
 ## 1.20.20
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,7 @@ import { WorldTruthsDialog } from './module/applications/worldTruthsDialog'
 import { OracleWindow } from './module/applications/oracle-window'
 
 export type EmitterEvents = {
-  highlightMove: string // Foundry ID
+  highlightMove: string // Foundry UUID
   highlightOracle: string // DF ID
   globalConditionChanged: { name: string; enabled: boolean } // info about condition that changed
   dragStart: string // type of item

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -87,21 +87,15 @@ export class IronswornChatCard {
 
   async _moveNavigate(ev: JQuery.ClickEvent) {
     ev.preventDefault()
-    const { pack, id } = ev.target.dataset
+    const { uuid } = ev.currentTarget.dataset
 
-    let item: IronswornItem | undefined
-    if (pack) {
-      const fPack = game.packs.get(pack)
-      item = (await fPack?.getDocument(id)) as IronswornItem
-    } else {
-      item = await game.items?.get(id)
-    }
+    const item = (await fromUuid(uuid)) as IronswornItem
     if (item?.type !== 'sfmove') {
       console.log('falling through')
       return (TextEditor as any)._onClickContentLink(ev)
     }
 
-    CONFIG.IRONSWORN.emitter.emit('highlightMove', item.id ?? '')
+    CONFIG.IRONSWORN.emitter.emit('highlightMove', item.uuid)
   }
 
   async _oracleNavigate(ev: JQuery.ClickEvent) {

--- a/src/module/vue/asset-compendium-browser.vue
+++ b/src/module/vue/asset-compendium-browser.vue
@@ -95,6 +95,6 @@ const categories = await (props.data.toolset === 'ironsworn'
 const data = reactive({ categories })
 
 function moveClick(item) {
-  CONFIG.IRONSWORN.emitter.emit('highlightMove', item.id)
+  CONFIG.IRONSWORN.emitter.emit('highlightMove', item.uuid)
 }
 </script>

--- a/src/module/vue/components/asset/asset-browser-card.vue
+++ b/src/module/vue/components/asset/asset-browser-card.vue
@@ -136,7 +136,7 @@ const state = reactive({
 const bodyId = `asset-body-${props.foundryItem().id}`
 
 function moveClick(item) {
-  CONFIG.IRONSWORN.emitter.emit('highlightMove', item.id)
+  CONFIG.IRONSWORN.emitter.emit('highlightMove', item.uuid)
 }
 
 function dragStart(ev) {

--- a/src/module/vue/components/asset/asset-overview.vue
+++ b/src/module/vue/components/asset/asset-overview.vue
@@ -17,11 +17,13 @@
 
     <section class="asset-body flexcol">
       <!-- DESCRIPTION -->
-      <div
+      <WithRollListeners
+        element="div"
+        @moveclick="moveClick"
         class="nogrow"
         v-if="item.system.description"
         v-html="$enrichHtml(item.system.description)"
-      ></div>
+      />
 
       <!-- FIELDS -->
       <div
@@ -193,7 +195,7 @@ function exclusiveOptionClick(selectedIdx: number) {
 }
 
 function moveClick(item) {
-  CONFIG.IRONSWORN.emitter.emit('highlightMove', item.id)
+  CONFIG.IRONSWORN.emitter.emit('highlightMove', item.uuid)
 }
 
 function toggleCondition(idx: number) {

--- a/src/module/vue/components/asset/asset.vue
+++ b/src/module/vue/components/asset/asset.vue
@@ -192,7 +192,7 @@ function exclusiveOptionClick(selectedIdx) {
   foundryItem?.update({ system: { exclusiveOptions: options } })
 }
 function moveclick(item) {
-  CONFIG.IRONSWORN.emitter.emit('highlightMove', item.id)
+  CONFIG.IRONSWORN.emitter.emit('highlightMove', item.uuid)
 }
 function setAbilityClock(abilityIdx: number, clockTicks: number) {
   const abilities = Object.values(

--- a/src/module/vue/components/mce-editor.vue
+++ b/src/module/vue/components/mce-editor.vue
@@ -45,7 +45,7 @@ const data = reactive({ editing: props.editing ?? false })
 
 // Outbound link clicks: broadcast events
 function moveClick(move: IronswornItem) {
-  CONFIG.IRONSWORN.emitter.emit('highlightMove', move.id ?? '')
+  CONFIG.IRONSWORN.emitter.emit('highlightMove', move.uuid)
 }
 function oracleClick(dfId: string) {
   CONFIG.IRONSWORN.emitter.emit('highlightOracle', dfId)

--- a/src/module/vue/components/oracle-tree-node.vue
+++ b/src/module/vue/components/oracle-tree-node.vue
@@ -134,7 +134,7 @@ function toggleManually() {
 
 // Click on a move link: broadcast event
 function moveclick(item: IronswornItem) {
-  CONFIG.IRONSWORN.emitter.emit('highlightMove', item.id ?? '')
+  CONFIG.IRONSWORN.emitter.emit('highlightMove', item.uuid)
 }
 
 function oracleclick(dfid) {

--- a/src/module/vue/components/sf-move-category-rows.vue
+++ b/src/module/vue/components/sf-move-category-rows.vue
@@ -171,12 +171,13 @@ function collapseMoves() {
   }
 }
 
-async function expandAndHighlightMove(targetMoveId: string) {
+async function expandAndHighlightMove(targetMoveUuid: string) {
   if ($collapsible.value?.isExpanded === false) {
     $collapsible.value.expand()
     await nextTick()
   }
-  const move = $children.value.find((child) => child.moveId === targetMoveId)
+  const { documentId } = _parseUuid(targetMoveUuid)
+  const move = $children.value.find((child) => child.moveId === documentId)
   highlightMove(move?.$collapsible?.$element as HTMLElement)
   if (move?.$collapsible?.isExpanded === false) {
     await move?.$collapsible?.expand()

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -290,7 +290,7 @@ Promise.all(oracleIds.map(getDFOracleByDfId)).then(async (dfOracles) => {
 
 // Outbound link clicks: broadcast events
 function moveClick(move: IronswornItem) {
-  CONFIG.IRONSWORN.emitter.emit('highlightMove', move.id ?? '')
+  CONFIG.IRONSWORN.emitter.emit('highlightMove', move.uuid)
 }
 
 defineExpose({

--- a/src/module/vue/components/sf-movesheetmoves.vue
+++ b/src/module/vue/components/sf-movesheetmoves.vue
@@ -172,14 +172,15 @@ function collapseMoveCategories() {
   }
 }
 
-CONFIG.IRONSWORN.emitter.on('highlightMove', async (targetMoveId) => {
+CONFIG.IRONSWORN.emitter.on('highlightMove', async (targetMoveUuid) => {
   clearSearch()
   await nextTick()
+  const { documentId } = _parseUuid(targetMoveUuid)
   const categoryWithMove = allCategories.value.find((moveCategory) =>
-    moveCategory.moveItems.has(targetMoveId)
+    moveCategory.moveItems.has(documentId ?? '')
   )
   if (categoryWithMove) {
-    categoryWithMove.expandAndHighlightMove(targetMoveId)
+    categoryWithMove.expandAndHighlightMove(targetMoveUuid)
   }
 })
 </script>


### PR DESCRIPTION
Fixes #479.

- [x] Use UUIDs in the `highlightMove` broadcast event
- [x] Fix move-label clicks in the asset half-edit view
- [x] Update CHANGELOG.md
