### PR TITLE
Reduce use of color in move sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- Update move-sheet aesthetics to reduce the use of color a bit ([#672](https://github.com/ben/foundry-ironsworn/pull/672))
 - Under the hood: updated dependencies, and switched to ES modules
 
 ## 1.20.28

--- a/src/module/vue/components/sf-move-category-rows.vue
+++ b/src/module/vue/components/sf-move-category-rows.vue
@@ -46,7 +46,8 @@
   .thematicColorMixin();
 
   border-radius: var(--ironsworn-border-radius-lg);
-  background-color: var(--ironsworn-color-thematic);
+  border: var(--ironsworn-border-width-lg) solid var(--ironsworn-color-thematic);
+  border-left-width: 10px;
 }
 
 .list {
@@ -59,18 +60,15 @@
 
 .toggleWrapper {
   box-sizing: content-box;
-  // background-color: var(--ironsworn-color-thematic);
 }
 
 .toggleSection {
   box-sizing: content-box;
   border-radius: var(--ironsworn-border-radius-lg);
 
-  // height: var(--ironsworn-line-height);
-
   button {
-    --ironsworn-color-clickable-text: var(--ironsworn-color-light);
-    --ironsworn-color-clickable-text-hover: var(--ironsworn-color-light-warm);
+    --ironsworn-color-clickable-text: var(--ironsworn-color-fg);
+    --ironsworn-color-clickable-text-hover: var(--ironsworn-color-fg-warm);
     .clickableTextMixin();
 
     height: inherit;
@@ -78,8 +76,6 @@
 }
 
 .toggleButton {
-  .textStrokeMixin( var(--ironsworn-color-dark));
-
   background: none;
 }
 

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -68,21 +68,19 @@
 
   border-color: var(--ironsworn-color-thematic);
   background-color: var(--ironsworn-color-thematic);
-  color: var(--ironsworn-color-light);
+  color: var(--ironsworn-color-fg);
 }
 
 .cardColorsMixin {
   border-color: var(--ironsworn-color-thematic);
-  background-color: var(--ironsworn-color-bg);
-  color: var(--ironsworn-color-fg);
 }
 
 .sfMoveRow {
   --ironsworn-line-height: (--ironsworn-line-height-md);
-  .thematicColorMixin();
 
   position: relative;
   padding: 0 var(--ironsworn-spacer-md);
+  transition: var(--ironsworn-transition);
 
   &[aria-expanded='true'] {
     padding-top: var(--ironsworn-spacer-md);
@@ -96,8 +94,8 @@
 }
 
 .moveButton {
-  --ironsworn-color-clickable-text: var(--ironsworn-color-light);
-  --ironsworn-color-clickable-text-hover: var(--ironsworn-color-light-warm);
+  --ironsworn-color-clickable-text: var(--ironsworn-color-fg);
+  --ironsworn-color-clickable-text-hover: var(--ironsworn-color-fg-warm);
   .clickableTextMixin();
 
   align-self: center;
@@ -106,11 +104,10 @@
 }
 
 .toggleButton {
-  --ironsworn-color-clickable-text: var(--ironsworn-color-light);
-  --ironsworn-color-clickable-text-hover: var(--ironsworn-color-light-warm);
+  --ironsworn-color-clickable-text: var(--ironsworn-color-fg);
+  --ironsworn-color-clickable-text-hover: var(--ironsworn-color-fg-warm);
 
   .clickableTextMixin();
-  .textStrokeMixin( var(--ironsworn-color-dark));
   .thematicColorMixin();
 
   display: flex;
@@ -165,7 +162,6 @@
 
   header:not(:last-child) & {
     border-color: var(--ironsworn-color-clickable-block-border-selected);
-    background-color: var(--ironsworn-color-dark);
     color: var(--ironsworn-color-light);
   }
 }

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -65,14 +65,7 @@
 
 .thematicColorMixin {
   --ironsworn-color-thematic: v-bind('thematicColor');
-
-  border-color: var(--ironsworn-color-thematic);
-  background-color: var(--ironsworn-color-thematic);
   color: var(--ironsworn-color-fg);
-}
-
-.cardColorsMixin {
-  border-color: var(--ironsworn-color-thematic);
 }
 
 .sfMoveRow {
@@ -113,11 +106,6 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  border: none;
-  border-width: var(--ironsworn-border-width-md)
-    var(--ironsworn-border-width-md) 0 var(--ironsworn-border-width-md);
-  border-style: solid;
-  border-color: transparent;
   background: none;
   padding: 0;
   padding-left: var(--ironsworn-spacer-sm);
@@ -131,10 +119,6 @@
 }
 
 .contentWrapper {
-  border: var(--ironsworn-border-width-md) solid var(--ironsworn-color-light);
-  border-radius: 0 var(--ironsworn-border-radius-lg)
-    var(--ironsworn-border-radius-lg) var(--ironsworn-border-radius-lg);
-  background-color: var(--ironsworn-color-bg-80);
   color: var(--ironsworn-color-fg);
 }
 
@@ -152,16 +136,9 @@
 
 .toggleWrapper {
   transition: var(--ironsworn-transition);
-  border: var(--ironsworn-border-width-md) solid transparent;
-  border-bottom-width: 0;
-  border-top-left-radius: var(--ironsworn-border-radius-lg);
-  border-top-right-radius: var(--ironsworn-border-radius-lg);
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
   line-height: 1.5;
 
   header:not(:last-child) & {
-    border-color: var(--ironsworn-color-clickable-block-border-selected);
     color: var(--ironsworn-color-light);
   }
 }


### PR DESCRIPTION
This reduces the use of color in the move sheet to just borders and a bold stripe on the left-hand side. This matches a bit better with the style of the rest of the system.

- [x] Update backgrounds and borders
- [x] Fix type for categories
- [x] Fix type and borders for moves
- [x] Fix move buttons
- [x] Update CHANGELOG.md
