### PR TITLE
Better hints if the clipboard is. disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Replace the delve theme/domain sheet with a vue implementation ([#677](https://github.com/ben/foundry-ironsworn/pull/677))
+- Disable and add a tooltip to chat-message copy buttons if access to the clipboard is restricted ([#678](https://github.com/ben/foundry-ironsworn/pull/678))
 
 ## 1.20.29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next Release
 
 - Replace the delve theme/domain sheet with a vue implementation ([#677](https://github.com/ben/foundry-ironsworn/pull/677))
-- Disable and add a tooltip to chat-message copy buttons if access to the clipboard is restricted ([#678](https://github.com/ben/foundry-ironsworn/pull/678))
+- Disable chat-message copy buttons (and add a tooltip) if access to the clipboard is restricted ([#678](https://github.com/ben/foundry-ironsworn/pull/678))
 
 ## 1.20.29
 

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -74,9 +74,18 @@ export class IronswornChatCard {
     html
       .find('.oracle-roll .oracle-reroll')
       .on('click', (ev) => this._oracleReroll.call(this, ev))
-    html
-      .find('.copy-result')
-      .on('click', (ev) => this._oracleResultCopy.call(this, ev))
+    if (!navigator.clipboard) {
+      html
+        .find('.copy-result')
+        .addClass('disabled')
+        .parent()
+        .attr('data-tooltip', game.i18n.localize('IRONSWORN.ClipboardDisabled'))
+        .attr('data-tooltip-direction', 'LEFT')
+    } else {
+      html
+        .find('.copy-result')
+        .on('click', (ev) => this._oracleResultCopy.call(this, ev))
+    }
     html
       .find('.ironsworn-roll-resolve')
       .on('click', (ev) => this._resolveChallenge.call(this, ev))

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -12,6 +12,7 @@
     "Roll": "Roll",
     "SendToChat": "Send text to chat: <i>{move}</i>",
     "CopyTextToClipboard": "Copy text to clipboard",
+    "ClipboardDisabled": "The browser has prevented access to the clipboard. You'll need to load Foundry from localhost or using an <code>https://</code> URL to use this feature.",
     "Adds": "Adds",
     "Versus": "vs.",
     "CappedAt10": "Action score is capped at 10",


### PR DESCRIPTION
This is better than a silent failure if the browser window is in a context where access to the clipboard is disabled. Fixes #671.

![CleanShot 2023-03-12 at 16 15 30](https://user-images.githubusercontent.com/39902/224579994-6e4a9c33-9ee3-4b83-9dd3-6bcdd6a50b96.jpg)


- [x] Disabled "copy" button
- [x] Tooltip
- [x] Update CHANGELOG.md
