### PR TITLE
New method for customizing the oracle tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed bug with Starforged asset decoration; it should now switch with the game theme as intended ([#700](https://github.com/ben/foundry-ironsworn/pull/700))
 - Drop the custom font ([#702](https://github.com/ben/foundry-ironsworn/pull/702))
 - Fix a tooltip bug on the edit-sector button
+- Added a new method of customizing oracles, which should work better for larger projects like Ironsmith ([#686](https://github.com/ben/foundry-ironsworn/pull/696))
 
 ## 1.20.30
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,10 @@ import { FirstStartDialog } from './module/applications/firstStartDialog'
 import { SFSettingTruthsDialogVue } from './module/applications/vueSfSettingTruthsDialog'
 import { WorldTruthsDialog } from './module/applications/worldTruthsDialog'
 import { OracleWindow } from './module/applications/oracle-window'
+import {
+	getOracleTree,
+	registerOracleTree
+} from './module/features/customoracles'
 
 export interface EmitterEvents extends Record<EventType, unknown> {
 	highlightMove: string // Foundry UUID
@@ -27,7 +31,6 @@ export type IronswornEmitter = Emitter<EmitterEvents>
 
 export interface IronswornConfig {
 	actorClass: typeof IronswornActor
-	importFromDatasworn: typeof importFromDatasworn
 
 	applications: {
 		// Dialogs
@@ -44,10 +47,15 @@ export interface IronswornConfig {
 		OracleRollMessage: typeof OracleRollMessage
 	}
 
+	importFromDatasworn: typeof importFromDatasworn
+
 	Dataforged: typeof starforged
 	dataforgedHelpers: typeof dataforgedHelpers
 
 	emitter: IronswornEmitter
+
+	registerOracleTree: typeof registerOracleTree
+	getOracleTree: typeof getOracleTree
 }
 
 export const IRONSWORN: IronswornConfig = {
@@ -71,5 +79,8 @@ export const IRONSWORN: IronswornConfig = {
 	Dataforged: starforged,
 	dataforgedHelpers,
 
-	emitter: Mitt<EmitterEvents>()
+	emitter: Mitt<EmitterEvents>(),
+
+	registerOracleTree,
+	getOracleTree
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,8 +222,6 @@ Hooks.once('init', async () => {
 	registerCompendiumCategoryHook()
 	await registerTokenHUDButtons()
 	activateSceneButtonListeners()
-
-	await registerDefaultOracleTrees()
 })
 
 Hooks.once('ready', async () => {
@@ -231,11 +229,11 @@ Hooks.once('ready', async () => {
 
 	registerDragAndDropHooks()
 	registerChatAlertHooks()
-	runStartupMacro()
+
+	await registerDefaultOracleTrees()
 
 	await FirstStartDialog.maybeShow()
 	await registerTours()
 
-	// Pre-load all the oracles
-	await primeCommonPackCaches()
+	runStartupMacro()
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import { registerTours } from './module/features/tours'
 import { CompactPCSheet } from './module/actor/sheets/compact-pc-sheet'
 
 import 'virtual:svg-icons-register'
+import { registerDefaultOracleTrees } from './module/features/customoracles'
 
 declare global {
 	interface LenientGlobalVariableTypes {
@@ -221,6 +222,8 @@ Hooks.once('init', async () => {
 	registerCompendiumCategoryHook()
 	await registerTokenHUDButtons()
 	activateSceneButtonListeners()
+
+	await registerDefaultOracleTrees()
 })
 
 Hooks.once('ready', async () => {

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -5,7 +5,7 @@ import type {
 	Ironsworn
 } from 'dataforged'
 import { starforged, ironsworn } from 'dataforged'
-import { compact } from 'lodash-es'
+import { cloneDeep, compact } from 'lodash-es'
 import { getFoundryTableByDfId } from '../dataforged'
 import { cachedDocumentsForPack } from './pack-cache'
 
@@ -257,5 +257,5 @@ export function registerOracleTree(
 }
 
 export function getOracleTree(category: OracleCategory): IOracleTreeNode {
-	return ORACLES[category]
+	return cloneDeep(ORACLES[category])
 }

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -11,7 +11,7 @@ import { cachedDocumentsForPack } from './pack-cache'
 
 export interface IOracleTreeNode {
 	dataforgedNode?: IOracle | IOracleCategory
-	tables: Array<() => RollTable>
+	tables: string[] // UUIDs
 	displayName: string
 	children: IOracleTreeNode[]
 	forceExpanded?: boolean
@@ -107,9 +107,9 @@ export async function walkOracle(
 	const node: IOracleTreeNode = {
 		...emptyNode(),
 		dataforgedNode: oracle,
-		tables: compact([table != null ? () => table : undefined]),
+		tables: compact([table?.uuid]),
 		displayName:
-			table?.name ||
+			table?.name ??
 			game.i18n.localize(`IRONSWORN.OracleCategories.${oracle.Name}`)
 	}
 
@@ -127,7 +127,7 @@ export async function walkOracle(
 				node.children.push({
 					...emptyNode(),
 					displayName: name,
-					tables: [() => subtable]
+					tables: [subtable.uuid]
 				})
 			}
 		}
@@ -155,7 +155,7 @@ async function augmentWithFolderContents(node: IOracleTreeNode) {
 		// Add this folder
 		const newNode: IOracleTreeNode = {
 			...emptyNode(),
-			displayName: folder.name || '(folder)'
+			displayName: folder.name ?? '(folder)'
 		}
 		parent.children.push(newNode)
 
@@ -168,7 +168,7 @@ async function augmentWithFolderContents(node: IOracleTreeNode) {
 		for (const table of folder.contents) {
 			newNode.children.push({
 				...emptyNode(),
-				tables: [() => table as RollTable],
+				tables: [table.uuid],
 				displayName: table.name ?? '(table)'
 			})
 		}
@@ -177,14 +177,14 @@ async function augmentWithFolderContents(node: IOracleTreeNode) {
 	walkFolder(node, rootFolder)
 }
 
-export function findPathToNodeByTableId(
+export function findPathToNodeByTableUuid(
 	rootNode: IOracleTreeNode,
-	tableId: string
+	tableUuid: string
 ): IOracleTreeNode[] {
 	const ret: IOracleTreeNode[] = []
 	function walk(node: IOracleTreeNode) {
 		ret.push(node)
-		const foundTable = node.tables.find((x) => x().id === tableId)
+		const foundTable = node.tables.find((x) => x === tableUuid)
 		if (foundTable != null) return true
 		for (const child of node.children) {
 			if (walk(child)) return true

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -46,13 +46,6 @@ async function createOracleTree(
 		rootNode.children.push(await walkOracleCategory(category))
 	}
 
-	// Add in custom oracles from a well-known directory
-	await augmentWithFolderContents(rootNode)
-
-	// Fire the hook and allow extensions to modify the tree
-	// TODO: deprecate this, warning if something is registered
-	Hooks.call('ironswornOracles', rootNode)
-
 	return rootNode
 }
 
@@ -258,4 +251,19 @@ export function registerOracleTree(
 
 export function getOracleTree(category: OracleCategory): IOracleTreeNode {
 	return cloneDeep(ORACLES[category])
+}
+
+export async function getOracleTreeWithCustomOracles(
+	category: OracleCategory
+): Promise<IOracleTreeNode> {
+	const rootNode = getOracleTree(category)
+
+	// Add in custom oracles from a well-known directory
+	await augmentWithFolderContents(rootNode)
+
+	// Fire the hook and allow extensions to modify the tree
+	// TODO: deprecate this, warning if something is registered
+	Hooks.call('ironswornOracles', rootNode)
+
+	return rootNode
 }

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -262,7 +262,6 @@ export async function getOracleTreeWithCustomOracles(
 	await augmentWithFolderContents(rootNode)
 
 	// Fire the hook and allow extensions to modify the tree
-	// TODO: deprecate this, warning if something is registered
 	Hooks.call('ironswornOracles', rootNode)
 
 	return rootNode

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -237,7 +237,6 @@ export async function registerDefaultOracleTrees() {
 	registerOracleTreeInternal('starforged', starforgedOracles)
 
 	defaultTreesInitialized = true
-	console.log({ ORACLES })
 }
 
 // Available in browser

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -50,19 +50,20 @@ async function createOracleTree(
 	await augmentWithFolderContents(rootNode)
 
 	// Fire the hook and allow extensions to modify the tree
-	await Hooks.call('ironswornOracles', rootNode)
+	// TODO: deprecate this, warning if something is registered
+	Hooks.call('ironswornOracles', rootNode)
 
 	return rootNode
 }
 
-export async function createIronswornOracleTree(): Promise<IOracleTreeNode> {
+async function createIronswornOracleTree(): Promise<IOracleTreeNode> {
 	return await createOracleTree(
 		'foundry-ironsworn.ironswornoracles',
 		ISOracleCategories
 	)
 }
 
-export async function createStarforgedOracleTree(): Promise<IOracleTreeNode> {
+async function createStarforgedOracleTree(): Promise<IOracleTreeNode> {
 	return await createOracleTree(
 		'foundry-ironsworn.starforgedoracles',
 		SFOracleCategories

--- a/src/module/rolls/oracle-roll-message.ts
+++ b/src/module/rolls/oracle-roll-message.ts
@@ -5,7 +5,7 @@ import { getFoundryTableByDfId } from '../dataforged'
 import {
 	findPathToNodeByDfId,
 	findPathToNodeByTableUuid,
-	getOracleTree
+	getOracleTreeWithCustomOracles
 } from '../features/customoracles'
 
 export interface TableRow {
@@ -67,7 +67,7 @@ export class OracleRollMessage {
 
 	static async fromDfOracleId(dfOracleId: string): Promise<OracleRollMessage> {
 		// Subtitle can be inferred from the structure of the DF ID
-		const oracleTreeRoot = getOracleTree(
+		const oracleTreeRoot = await getOracleTreeWithCustomOracles(
 			dfOracleId.startsWith('Ironsworn/') ? 'ironsworn' : 'starforged'
 		)
 		const pathElements = findPathToNodeByDfId(oracleTreeRoot, dfOracleId)
@@ -173,8 +173,8 @@ export class OracleRollMessage {
 	private async oraclePath(): Promise<string | undefined> {
 		if (this.tableUuid == null) return undefined
 
-		const starforgedRoot = getOracleTree('starforged')
-		const ironswornRoot = getOracleTree('ironsworn')
+		const starforgedRoot = await getOracleTreeWithCustomOracles('starforged')
+		const ironswornRoot = await getOracleTreeWithCustomOracles('ironsworn')
 
 		const pathElements =
 			findPathToNodeByTableUuid(starforgedRoot, this.tableUuid) ??

--- a/src/module/rolls/oracle-roll-message.ts
+++ b/src/module/rolls/oracle-roll-message.ts
@@ -6,7 +6,7 @@ import {
 	createIronswornOracleTree,
 	createStarforgedOracleTree,
 	findPathToNodeByDfId,
-	findPathToNodeByTableId
+	findPathToNodeByTableUuid
 } from '../features/customoracles'
 
 export interface TableRow {
@@ -172,16 +172,15 @@ export class OracleRollMessage {
 	}
 
 	private async oraclePath(): Promise<string | undefined> {
-		if (!this.tableUuid) return undefined
-		const uuid = _parseUuid(this.tableUuid)
+		if (this.tableUuid == null) return undefined
 
 		const [starforgedRoot, ironswornRooot] = await Promise.all([
 			createStarforgedOracleTree(),
 			createIronswornOracleTree()
 		])
 		const pathElements =
-			findPathToNodeByTableId(starforgedRoot, uuid.documentId!) ??
-			findPathToNodeByTableId(ironswornRooot, uuid.documentId!)
+			findPathToNodeByTableUuid(starforgedRoot, this.tableUuid) ??
+			findPathToNodeByTableUuid(ironswornRooot, this.tableUuid)
 		pathElements.shift() // no display name for root node
 		pathElements.pop() // last node is the table we rolled
 		return pathElements.map((x) => x.displayName).join(' / ')

--- a/src/module/vue/components/buttons/btn-oracle.vue
+++ b/src/module/vue/components/buttons/btn-oracle.vue
@@ -39,7 +39,7 @@ async function rollOracle() {
 	if (props.overrideClick && props.onClick) return $emit('click')
 
 	const randomTable = sample(props.node.tables)
-	const orm = await OracleRollMessage.fromTableUuid(randomTable?.()?.uuid ?? '')
+	const orm = await OracleRollMessage.fromTableUuid(randomTable ?? '')
 	orm.createOrUpdate()
 }
 </script>

--- a/src/module/vue/components/oracle-tree-node.vue
+++ b/src/module/vue/components/oracle-tree-node.vue
@@ -24,7 +24,7 @@
 				<RulesTextOracle
 					v-if="state.descriptionExpanded"
 					:class="$style.content"
-					:oracle-table="node.tables[0]"
+					:oracle-table-uuid="node.tables[0]"
 					:source="node.dataforgedNode?.Source"
 					@moveclick="moveclick"
 					@oracleclick="oracleclick" />

--- a/src/module/vue/components/oracle-tree-node.vue
+++ b/src/module/vue/components/oracle-tree-node.vue
@@ -24,7 +24,8 @@
 				<RulesTextOracle
 					v-if="state.descriptionExpanded"
 					:class="$style.content"
-					:oracle-table-uuid="node.tables[0]"
+					:table-rows="state.tableRows"
+					:table-description="state.tableDescription"
 					:source="node.dataforgedNode?.Source"
 					@moveclick="moveclick"
 					@oracleclick="oracleclick" />
@@ -65,7 +66,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue'
+import { computed, nextTick, reactive, ref } from 'vue'
 import type { IOracleTreeNode } from '../../features/customoracles'
 import { FontAwesome } from './icon/icon-common'
 import BtnOracle from './buttons/btn-oracle.vue'
@@ -78,9 +79,19 @@ import IronIcon from './icon/iron-icon.vue'
 
 const props = defineProps<{ node: IOracleTreeNode }>()
 
+// FIXME: use v10 types when available, or hack some together for tables
+type TableRowData = {
+	low: number
+	high: number
+	text: string
+	selected: boolean
+}
+
 const state = reactive({
 	manuallyExpanded: props.node.forceExpanded ?? false,
 	descriptionExpanded: false,
+	tableRows: [] as Array<TableRowData>,
+	tableDescription: '',
 	highlighted: false
 })
 
@@ -90,7 +101,18 @@ const isLeaf = computed(() => {
 	return props.node.tables.length > 0
 })
 
-function toggleDescription() {
+async function toggleDescription() {
+	if (!state.tableDescription) {
+		const table = (await fromUuid(props.node.tables[0])) as RollTable
+		state.tableRows = table.results.map((row: any) => ({
+			low: row.range[0],
+			high: row.range[1],
+			text: row.text,
+			selected: false
+		}))
+		state.tableDescription = (table as any).description ?? ''
+		await nextTick()
+	}
 	state.descriptionExpanded = !state.descriptionExpanded
 }
 function toggleManually() {

--- a/src/module/vue/components/rules-text/oracle-table.vue
+++ b/src/module/vue/components/rules-text/oracle-table.vue
@@ -1,8 +1,8 @@
 <template>
 	<table class="oracle-table">
 		<caption
-			v-if="!noCaption && rollTable?.description"
-			v-html="enrichMarkdown(rollTable?.description ?? '')" />
+			v-if="!noCaption && tableDescription"
+			v-html="enrichMarkdown(tableDescription ?? '')" />
 		<thead>
 			<tr>
 				<th scope="col" class="oracle-table-column-roll-range">
@@ -25,19 +25,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { sortBy } from 'lodash-es'
 import { enrichMarkdown } from '../../vue-plugin.js'
-
-// FIXME: use v10 types when available, or hack some together for tables
-const props = defineProps<{
-	oracleTableUuid: string
-	noCaption?: boolean
-}>()
-
-const rollTable = (await fromUuid(props.oracleTableUuid)) as
-	| (RollTable & { description?: string })
-	| undefined
 
 type TableRowData = {
 	low: number
@@ -46,26 +34,19 @@ type TableRowData = {
 	selected: boolean
 }
 
+// FIXME: use v10 types when available, or hack some together for tables
+const props = defineProps<{
+	tableRows: TableRowData[]
+	tableDescription: string
+	noCaption?: boolean
+}>()
+
 function rangeString({ low, high }: TableRowData) {
 	if (low === high) {
 		return low.toString()
 	}
 	return `${low}-${high}`
 }
-const tableRows = computed(() =>
-	sortBy(
-		(rollTable?.results?.contents ?? []).map(
-			(row: any) =>
-				({
-					low: row.range[0],
-					high: row.range[1],
-					text: row.text,
-					selected: false
-				} as TableRowData)
-		),
-		'low'
-	)
-)
 </script>
 
 <style lang="scss" scoped>

--- a/src/module/vue/components/rules-text/oracle-table.vue
+++ b/src/module/vue/components/rules-text/oracle-table.vue
@@ -1,8 +1,8 @@
 <template>
 	<table class="oracle-table">
 		<caption
-			v-if="!noCaption && oracleTable().description"
-			v-html="enrichMarkdown(oracleTable().description ?? '')" />
+			v-if="!noCaption && rollTable?.description"
+			v-html="enrichMarkdown(rollTable?.description ?? '')" />
 		<thead>
 			<tr>
 				<th scope="col" class="oracle-table-column-roll-range">
@@ -31,9 +31,13 @@ import { enrichMarkdown } from '../../vue-plugin.js'
 
 // FIXME: use v10 types when available, or hack some together for tables
 const props = defineProps<{
-	oracleTable: () => any
+	oracleTableUuid: string
 	noCaption?: boolean
 }>()
+
+const rollTable = (await fromUuid(props.oracleTableUuid)) as
+	| (RollTable & { description?: string })
+	| undefined
 
 type TableRowData = {
 	low: number
@@ -50,7 +54,7 @@ function rangeString({ low, high }: TableRowData) {
 }
 const tableRows = computed(() =>
 	sortBy(
-		props.oracleTable().results.contents.map(
+		(rollTable?.results?.contents ?? []).map(
 			(row: any) =>
 				({
 					low: row.range[0],

--- a/src/module/vue/components/rules-text/rules-text-oracle.vue
+++ b/src/module/vue/components/rules-text/rules-text-oracle.vue
@@ -1,7 +1,9 @@
 <template>
 	<RulesText class="rules-text-oracle" :source="source" type="slot">
 		<template #default>
-			<OracleTable :oracle-table-uuid="oracleTableUuid" />
+			<OracleTable
+				:table-description="tableDescription"
+				:table-rows="tableRows" />
 		</template>
 		<template #before-main>
 			<slot name="before-main"></slot>
@@ -20,8 +22,16 @@ import RulesText from './rules-text.vue'
 import OracleTable from './oracle-table.vue'
 import type { ISource } from 'dataforged'
 
+type TableRowData = {
+	low: number
+	high: number
+	text: string
+	selected: boolean
+}
+
 const props = defineProps<{
-	oracleTableUuid: string
+	tableRows: TableRowData[]
+	tableDescription: string
 	source?: ISource
 }>()
 </script>

--- a/src/module/vue/components/rules-text/rules-text-oracle.vue
+++ b/src/module/vue/components/rules-text/rules-text-oracle.vue
@@ -1,7 +1,7 @@
 <template>
 	<RulesText class="rules-text-oracle" :source="source" type="slot">
 		<template #default>
-			<OracleTable :oracle-table="oracleTable" />
+			<OracleTable :oracle-table-uuid="oracleTableUuid" />
 		</template>
 		<template #before-main>
 			<slot name="before-main"></slot>
@@ -20,5 +20,8 @@ import RulesText from './rules-text.vue'
 import OracleTable from './oracle-table.vue'
 import type { ISource } from 'dataforged'
 
-const props = defineProps<{ oracleTable: () => RollTable; source?: ISource }>()
+const props = defineProps<{
+	oracleTableUuid: string
+	source?: ISource
+}>()
 </script>

--- a/src/module/vue/components/sf-movesheetoracles.vue
+++ b/src/module/vue/components/sf-movesheetoracles.vue
@@ -33,23 +33,17 @@
 </template>
 
 <script setup lang="ts">
-import { inject, nextTick, provide, reactive, ref, watch } from 'vue'
+import { nextTick, provide, reactive, ref, watch } from 'vue'
 import { findOracleWithIntermediateNodes } from '../../dataforged'
 import type { IOracleTreeNode } from '../../features/customoracles'
-import {
-	createIronswornOracleTree,
-	createStarforgedOracleTree
-} from '../../features/customoracles'
+import { getOracleTree } from '../../features/customoracles'
 import IronBtn from './buttons/iron-btn.vue'
 import OracleTreeNode from './oracle-tree-node.vue'
 
 const props = defineProps<{ toolset: 'ironsworn' | 'starforged' }>()
 provide('toolset', props.toolset)
 
-const tempTreeRoot =
-	props.toolset === 'ironsworn'
-		? await createIronswornOracleTree()
-		: await createStarforgedOracleTree()
+const tempTreeRoot = getOracleTree(props.toolset)
 
 const treeRoot = reactive<IOracleTreeNode>(tempTreeRoot)
 type ReactiveNode = typeof treeRoot

--- a/src/module/vue/components/sf-movesheetoracles.vue
+++ b/src/module/vue/components/sf-movesheetoracles.vue
@@ -36,14 +36,14 @@
 import { nextTick, provide, reactive, ref, watch } from 'vue'
 import { findOracleWithIntermediateNodes } from '../../dataforged'
 import type { IOracleTreeNode } from '../../features/customoracles'
-import { getOracleTree } from '../../features/customoracles'
+import { getOracleTreeWithCustomOracles } from '../../features/customoracles'
 import IronBtn from './buttons/iron-btn.vue'
 import OracleTreeNode from './oracle-tree-node.vue'
 
 const props = defineProps<{ toolset: 'ironsworn' | 'starforged' }>()
 provide('toolset', props.toolset)
 
-const tempTreeRoot = getOracleTree(props.toolset)
+const tempTreeRoot = await getOracleTreeWithCustomOracles(props.toolset)
 
 const treeRoot = reactive<IOracleTreeNode>(tempTreeRoot)
 type ReactiveNode = typeof treeRoot


### PR DESCRIPTION
Proposed in [Discord](https://discord.com/channels/437120373436186625/1083031805705334814). This updates the custom-oracle logic to allow a module or hook to register the entire oracle tree on a `ready` hook, rather than needing to provide an expensive hook body that runs whenever an oracle window is opened, or an oracle roll is called for. 

The fundamental change is that the oracle tree node doesn't have an array of async table getters, it has an array of table UUIDs, which is a lot easier to work with, and is easier to get right.

- [x] Update the custom-oracles types with `tables: string[]`
  - [x] Update built-in widgets to match
- [x] Provide a new `registerOracleTree` function, which can be called on a `ready` hook
- [x] Update the wiki with information about this new method
- [x] Update CHANGELOG.md
