### PR TITLE
Improvements to JE/JEP typing and some DB-related constants

### DIFF
--- a/patches/@league-of-foundry-developers+foundry-vtt-types+9.269.0.patch
+++ b/patches/@league-of-foundry-developers+foundry-vtt-types+9.269.0.patch
@@ -1,26 +1,34 @@
 diff --git a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/client/config.d.ts b/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/client/config.d.ts
-index da561df..740b40e 100644
+index da561df..3665779 100644
 --- a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/client/config.d.ts
 +++ b/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/client/config.d.ts
 @@ -128,6 +128,9 @@ declare global {
- 
+
        /** @defaultValue `{}` */
        typeLabels: Record<string, string>;
 +
 +      /** @defaultValue `{}` */
 +      typeIcons: Record<string, string>;
      };
- 
+
      /**
 @@ -332,6 +335,9 @@ declare global {
- 
+
        /** @defaultValue `{}` */
        typeLabels: Record<string, string>;
 +
 +      /** @defaultValue `{}` */
 +      typeIcons: Record<string, string>;
      };
- 
+
+     /**
+@@ -1485,6 +1491,7 @@ declare global {
+       };
+       defaultType: "text";
+       sidebarIcon: "fas fa-book-open";
++      coreTypes: ["image", "pdf", "text", "video"]
+     };
+
      /**
 diff --git a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/client/data/documents/table.d.ts b/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/client/data/documents/table.d.ts
 index ca6d3f2..34792e6 100644
@@ -32,36 +40,126 @@ index ca6d3f2..34792e6 100644
         */
 -      roll: Roll;
 +      roll?: Roll;
- 
+
        /**
         * Allow drawing recursively from inner RollTable results
         * @defaultValue `true`
         */
 -      recursive: boolean;
 +      recursive?: boolean;
- 
+
        /**
         * One or more table results which have been drawn
         * @defaultValue `[]`
         */
 -      results: foundry.data.TableResultData[];
 +      results?: foundry.data.TableResultData[];
- 
+
        /**
         * Whether to automatically display the results in chat
         * @defaultValue `true`
         */
 -      displayChat: boolean;
 +      displayChat?: boolean;
- 
+
        /**
         * The chat roll mode to use when displaying the result
         */
 -      rollMode: keyof CONFIG.Dice.RollModes | "roll";
 +      rollMode?: keyof CONFIG.Dice.RollModes | "roll";
      }
- 
+
      /**
+diff --git a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/journalEntryPageData.d.ts b/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/journalEntryPageData.d.ts
+index e1da7b2..c865bb4 100644
+--- a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/journalEntryPageData.d.ts
++++ b/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/journalEntryPageData.d.ts
+@@ -165,9 +165,12 @@ declare global {
+      */
+     name: string;
+
++
+     /**
+      * The type of this page, in {@link BaseJournalEntryPage.TYPES}.
+      */
++    type: ValueOf<typeof foundry.documents.BaseJournalEntryPage.TYPES>
++
+     content: ValueOf<typeof foundry.CONST.JOURNAL_ENTRY_PAGE_FORMATS>;
+
+     /**
+@@ -217,6 +220,7 @@ declare global {
+      * @defaultValue `{}`
+      */
+     flags: ConfiguredFlags<"JournalEntryPage">;
++
+   }
+
+   namespace JournalEntryPageDataProperties {
+@@ -315,4 +319,10 @@ export class JournalEntryPageData extends DocumentData<
+ }
+
+ // eslint-disable-next-line @typescript-eslint/no-empty-interface
+-export interface JournalEntryPageData extends JournalEntryPageDataProperties {}
++export interface JournalEntryPageData extends JournalEntryPageDataProperties {
++  /**
++   * An object of optional key/value flags
++   * @defaultValue `{}`
++   */
++  flags: ConfiguredFlags<"JournalEntryPage"> & CoreFlags;
++}
+diff --git a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/documents.mjs/baseJournalEntryPage.d.ts b/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/documents.mjs/baseJournalEntryPage.d.ts
+index 25cb406..ce8ce9b 100644
+--- a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/documents.mjs/baseJournalEntryPage.d.ts
++++ b/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/documents.mjs/baseJournalEntryPage.d.ts
+@@ -15,6 +15,7 @@ type JournalEntryPageMetadata = Merge<
+     label: "DOCUMENT.JournalEntryPage";
+     labelPlural: "DOCUMENT.JournalEntryPages";
+     coreTypes: ["image", "pdf", "text", "video"];
++    isEmbedded: true
+   }
+ >;
+
+@@ -43,4 +44,24 @@ export declare class BaseJournalEntryPage extends Document<
+   static get TYPES(): DocumentSubTypes<"JournalEntryPage">[];
+
+   getUserLevel(user: BaseUser): ValueOf<typeof CONST.DOCUMENT_OWNERSHIP_LEVELS> | null;
++
++  /**
++   * Data that control's the display of this page's title.
++   */
++  title: JournalEntryPageDataProperties.Title;
++
++  /**
++   * Data particular to image journal entry pages.
++   */
++  image: JournalEntryPageDataProperties.Image;
++
++  /**
++   * Data particular to text journal entry pages.
++   */
++  text: JournalEntryPageDataProperties.Text;
++
++  /**
++   * Data particular to video journal entry pages.
++   */
++  video: JournalEntryPageDataProperties.Video;
+ }
+diff --git a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes.d.ts b/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes.d.ts
+index eb3fa4c..f45b1d5 100644
+--- a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes.d.ts
++++ b/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes.d.ts
+@@ -106,7 +106,10 @@ export type PlaceableDocumentType =
+ export type DocumentSubTypes<T extends DocumentType> = "type" extends keyof InstanceType<
+   ConfiguredDocumentClassForName<T>
+ >["data"]
+-  ? InstanceType<ConfiguredDocumentClassForName<T>>["data"]["type"]
++  ? InstanceType<ConfiguredDocumentClassForName<T>>["data"]["type"] : "type" extends keyof InstanceType<
++  ConfiguredDocumentClassForName<T>
++>
++  ? InstanceType<ConfiguredDocumentClassForName<T>>["type"]
+   : typeof foundry.CONST.BASE_DOCUMENT_TYPE;
+
+ export type ConfiguredDocumentClassForName<Name extends DocumentType> = CONFIG[Name]["documentClass"];
 diff --git a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/types/utils.d.ts b/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/types/utils.d.ts
 index 8cc4b52..197c630 100644
 --- a/node_modules/@league-of-foundry-developers/foundry-vtt-types/src/types/utils.d.ts
@@ -90,5 +188,5 @@ index 8cc4b52..197c630 100644
 +    } )
 +  : T[P];
  };
- 
+
  /**

--- a/src/module/datasworn.ts
+++ b/src/module/datasworn.ts
@@ -12,7 +12,7 @@ const THEME_IMAGES = {
 	Infested: 'icons/creatures/eyes/icy-cluster-blue.webp',
 	Ravaged: 'icons/environment/settlement/building-rubble.webp',
 	Wild: 'icons/magic/nature/root-vines-grow-brown.webp'
-}
+} as const
 
 const THEME_IDS = {
 	Ancient: '9RnSqMcrekJoJbXH',
@@ -23,7 +23,7 @@ const THEME_IDS = {
 	Infested: 'H5aJvBKwPrbEnzMe',
 	Ravaged: 'iDOVA8797p4kYar7',
 	Wild: 'v3jYuNrr1Jt4TzNZ'
-}
+} as const
 
 const DOMAIN_IMAGES = {
 	Barrow: 'icons/environment/wilderness/cave-entrance-dwarven-hill.webp',
@@ -38,7 +38,7 @@ const DOMAIN_IMAGES = {
 	Stronghold: 'icons/environment/settlement/castle.webp',
 	Tanglewood: 'icons/environment/wilderness/terrain-forest-gray.webp',
 	Underkeep: 'icons/environment/wilderness/mine-interior-dungeon-door.webp'
-}
+} as const
 
 const DOMAIN_IDS = {
 	Barrow: 'LIoWYBGBBMPlPNam',
@@ -53,7 +53,7 @@ const DOMAIN_IDS = {
 	Stronghold: 'Yy9KkvSOvB2tWxOp',
 	Tanglewood: 'MbJlpR81C4Q4WDV2',
 	Underkeep: 'vyyrG8pPtDQ6FAgG'
-}
+} as const
 
 const FOE_IMAGES = {
 	Broken: 'icons/creatures/mammals/humanoid-fox-cat-archer.webp',
@@ -117,7 +117,7 @@ const FOE_IMAGES = {
 	Gloom: 'icons/magic/perception/silhouette-stealth-shadow.webp',
 	Maelstrom: 'icons/magic/water/vortex-water-whirlpool.webp',
 	Tempest: 'icons/magic/lightning/bolts-salvo-clouds-sky.webp'
-}
+} as const
 
 const PACKS = [
 	'foundry-ironsworn.ironsworndelvethemes',
@@ -125,7 +125,7 @@ const PACKS = [
 	'foundry-ironsworn.ironswornfoes',
 	'foundry-ironsworn.foeactorsis',
 	'foundry-ironsworn.ironswornoracles'
-]
+] as const
 
 interface RawFeatureOrDanger {
 	Chance: number

--- a/src/module/journal/journal-entry-page-types.ts
+++ b/src/module/journal/journal-entry-page-types.ts
@@ -64,9 +64,11 @@ export interface ClockDataProperties {
 }
 
 export type JournalEntryPageDataSource =
+	| { type: ValueOf<typeof CONFIG.JournalEntryPage.coreTypes>; system: object }
 	| ProgressTrackDataSource
 	| ClockDataSource
 export type JournalEntryPageDataProperties =
+	| { type: ValueOf<typeof CONFIG.JournalEntryPage.coreTypes>; system: object }
 	| ProgressTrackDataProperties
 	| ClockDataProperties
 
@@ -76,5 +78,30 @@ declare global {
 	}
 	interface DataConfig {
 		JournalEntryPage: JournalEntryPageDataProperties
+	}
+
+	type JournalEntryPageType = JournalEntryPageDataSource['type']
+
+	interface JournalEntryPageData<
+		T extends JournalEntryPageType = JournalEntryPageType
+	> extends foundry.abstract.DocumentData<
+			JournalEntryPageDataSchema,
+			JournalEntryPageDataProperties,
+			JournalEntryPageDataSource,
+			JournalEntryPageData.ConstructorData,
+			foundry.documents.BaseJournalEntryPage
+		> {
+		type: T
+		system: Extract<JournalEntryPageDataSource, { type: T }>['system']
+	}
+
+	interface JournalEntryPage<
+		T extends JournalEntryPageType = JournalEntryPageType
+	> extends Omit<
+			JournalEntryPageData<T>,
+			'toObject' | 'toJSON' | 'update' | 'system'
+		> {
+		type: T
+		system: Extract<JournalEntryPageDataProperties, { type: T }>['system']
 	}
 }

--- a/src/module/journal/journal-entry-page.ts
+++ b/src/module/journal/journal-entry-page.ts
@@ -20,10 +20,9 @@ export class IronswornJournalPage<
 		// FIXME: JEPs aren't initialized with proper defaults, so we DIY it.
 		// https://github.com/foundryvtt/foundryvtt/issues/8628
 		const defaults = game.system.template.JournalEntryPage?.[
-			// @ts-expect-error
 			data.type
 		] as JournalEntryPageDataSource
-		if (defaults) {
+		if (defaults != null) {
 			const alreadySet = data.system
 			const newSourceData = mergeObject(defaults, alreadySet ?? {}, {
 				recursive: true

--- a/src/module/journal/journal-entry-types.ts
+++ b/src/module/journal/journal-entry-types.ts
@@ -1,0 +1,51 @@
+import type EmbeddedCollection from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/abstract/embedded-collection.mjs'
+
+// Type augments for base JournalEntry class
+
+declare global {
+	interface JournalEntry
+		extends Omit<
+			foundry.data.JournalEntryData,
+			| 'update'
+			| 'toObject'
+			| 'toJSON'
+			| 'permission'
+			| 'name'
+			| 'folder'
+			| '_initializeSource'
+		> {
+		/**
+		 * The pages contained within this JournalEntry document
+		 */
+		pages: EmbeddedCollection<
+			DocumentClassConfig['JournalEntryPage'],
+			// @ts-expect-error
+			DocumentClassConfig['JournalEntry']
+		>
+	}
+}
+
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace Game {
+		interface SystemData<T> extends PackageData<T> {
+			model: {
+				JournalEntryPage: Record<string, Record<string, unknown>>
+			}
+			template: {
+				JournalEntryPage?: {
+					types: string[]
+					templates?: Record<string, unknown>
+				} & Record<string, unknown>
+			}
+		}
+	}
+
+	interface FlagConfig {
+		JournalEntry: {
+			'foundry-ironsworn'?: {
+				dfid?: string
+			}
+		}
+	}
+}


### PR DESCRIPTION
Forwards some type improvements from #715, mainly for journal-related subtypes, in order to reduce the size of that PR.

* makes JEPs accept a generic type parameter for their `type` value, and gives them the corresponding `system`
* adds several missing properties to JE + JEP 
* applies "as const" to several consts used when building from datasworn/dataforged, which makes for more precise typings that derive from them