### PR TITLE
Prefer references to ironsworn classes + static methods

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ import {
 	getOracleTree,
 	registerOracleTree
 } from './module/features/customoracles'
+import { OracleTable } from './module/roll-table/oracle-table'
 
 export interface EmitterEvents extends Record<EventType, unknown> {
 	highlightMove: string // Foundry UUID
@@ -31,6 +32,7 @@ export type IronswornEmitter = Emitter<EmitterEvents>
 
 export interface IronswornConfig {
 	actorClass: typeof IronswornActor
+	OracleTable: typeof OracleTable
 
 	applications: {
 		// Dialogs
@@ -60,6 +62,7 @@ export interface IronswornConfig {
 
 export const IRONSWORN: IronswornConfig = {
 	actorClass: IronswornActor,
+	OracleTable,
 
 	applications: {
 		FirstStartDialog,

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,9 +77,12 @@ Hooks.once('init', async () => {
 	// Define custom Entity classes
 	CONFIG.Actor.documentClass = IronswornActor
 	CONFIG.Item.documentClass = IronswornItem
+
 	CONFIG.JournalEntry.documentClass = IronswornJournalEntry
 	CONFIG.JournalEntryPage.documentClass = IronswornJournalPage
+
 	CONFIG.RollTable.documentClass = OracleTable
+	CONFIG.RollTable.resultIcon = 'icons/dice/d10black.svg'
 	CONFIG.TableResult.documentClass = OracleTableResult
 
 	// CONFIG.RollTable.resultTemplate =

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,10 +42,24 @@ import { registerDefaultOracleTrees } from './module/features/customoracles'
 import { OracleTable } from './module/roll-table/oracle-table'
 import { OracleTableResult } from './module/roll-table/oracle-table-result'
 import { IronswornJournalEntry } from './module/journal/journal-entry'
+import type {
+	DocumentSubTypes,
+	DocumentType
+} from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes'
 
 declare global {
 	interface LenientGlobalVariableTypes {
 		game: never // the type doesn't matter
+	}
+
+	// fix missing LoFD type inference
+	interface Game {
+		documentTypes: {
+			[P in DocumentType as Omit<DocumentType, 'JournalEntryPage'> &
+				DocumentType]: Array<DocumentSubTypes<P>>
+		} & {
+			JournalEntryPage: JournalEntryPageType[]
+		}
 	}
 }
 

--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -30,6 +30,9 @@ export class IronswornActor extends Actor {
 				{
 					const denizens = (this.system as SiteDataPropertiesData).denizens.map(
 						(denizen) => {
+							if (denizen.flags == null) denizen.flags = {}
+							if (denizen.flags['foundry-ironsworn'] == null)
+								denizen.flags['foundry-ironsworn'] = {}
 							denizen.flags['foundry-ironsworn'].sourceId = this.id
 							return denizen
 						}

--- a/src/module/actor/actortypes.ts
+++ b/src/module/actor/actortypes.ts
@@ -121,17 +121,7 @@ export interface FoeDataProperties {
 /**
  * Represents an entry in the delve site denizen matrix.
  */
-export interface DelveSiteDenizen extends TableResultDataConstructorData {
-	flags: {
-		'foundry-ironsworn': {
-			type: 'delve-site-denizen'
-			/**
-			 * The ID of the originating Actor.
-			 */
-			sourceId: Actor['id']
-		}
-	}
-}
+export interface DelveSiteDenizen extends TableResultDataConstructorData {}
 
 export interface SiteDataSourceData {
 	objective: string

--- a/src/module/applications/createActorDialog.ts
+++ b/src/module/applications/createActorDialog.ts
@@ -1,9 +1,8 @@
 import type { ActorDataConstructorData } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/actorData'
 import { sample } from 'lodash-es'
 import { IronswornActor } from '../actor/actor'
-import { getFoundryTableByDfId } from '../dataforged'
 import { IronswornSettings } from '../helpers/settings'
-import type { OracleTable } from '../roll-table/oracle-table'
+import { OracleTable } from '../roll-table/oracle-table'
 
 interface CreateActorDialogOptions extends FormApplicationOptions {
 	folder: string
@@ -159,10 +158,10 @@ export class CreateActorDialog extends FormApplication<CreateActorDialogOptions>
 	}
 
 	async _ironlanderNameTables(): Promise<OracleTable[] | undefined> {
-		const tableA = (await getFoundryTableByDfId(
+		const tableA = (await OracleTable.getByDfId(
 			'Ironsworn/Oracles/Name/Ironlander/A'
 		)) as any
-		const tableB = (await getFoundryTableByDfId(
+		const tableB = (await OracleTable.getByDfId(
 			'Ironsworn/Oracles/Name/Ironlander/B'
 		)) as any
 		if (tableA && tableB) return [tableA, tableB]
@@ -170,10 +169,10 @@ export class CreateActorDialog extends FormApplication<CreateActorDialogOptions>
 	}
 
 	async _randomStarforgedName(): Promise<string | undefined> {
-		const firstTable = (await getFoundryTableByDfId(
+		const firstTable = (await OracleTable.getByDfId(
 			'Starforged/Oracles/Characters/Name/Given_Name'
 		)) as any
-		const lastTable = (await getFoundryTableByDfId(
+		const lastTable = (await OracleTable.getByDfId(
 			'Starforged/Oracles/Characters/Name/Family_Name'
 		)) as any
 		if (!firstTable || !lastTable) return undefined

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -71,7 +71,7 @@ export class IronswornChatCard {
 			.find('.ironsworn-roll-burn-momentum')
 			.on('click', async (ev) => await this._burnMomentum.call(this, ev))
 		html
-			.find('.oracle-roll .oracle-reroll')
+			.find('[data-iron-action="oracleReroll"]')
 			.on('click', async (ev) => await this._oracleReroll.call(this, ev))
 		if (!navigator.clipboard) {
 			html
@@ -88,7 +88,7 @@ export class IronswornChatCard {
 		html.find('.ironsworn-roll-resolve').on('click', async (ev) => {
 			await this._resolveChallenge.call(this, ev)
 		})
-		html.find('.starforged__oracle__roll').on('click', async (ev) => {
+		html.find('[data-iron-action="oracleRoll"]').on('click', async (ev) => {
 			await this._oracleRoll.call(this, ev)
 		})
 	}

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -3,8 +3,7 @@ import type { SFMoveDataPropertiesData } from '../item/itemtypes'
 import type { IronswornItem } from '../item/item'
 import { IronswornRollMessage, OracleRollMessage } from '../rolls'
 import { ChallengeResolutionDialog } from '../rolls/challenge-resolution-dialog'
-import { getFoundryTableByDfId } from '../dataforged'
-import type { OracleTable } from '../roll-table/oracle-table'
+import { OracleTable } from '../roll-table/oracle-table'
 
 export class IronswornChatCard {
 	id?: string | null
@@ -30,7 +29,7 @@ export class IronswornChatCard {
 
 			const system = fItem.system as SFMoveDataPropertiesData
 			const oracleIds = system.Oracles ?? []
-			return await Promise.all(oracleIds.map(getFoundryTableByDfId))
+			return await Promise.all(oracleIds.map(OracleTable.getByDfId))
 		})
 		const tables = compact(flatten(await Promise.all(maybeTablePromises)))
 		if (tables.length === 0) return

--- a/src/module/chat/sf-move-chat-message.ts
+++ b/src/module/chat/sf-move-chat-message.ts
@@ -1,14 +1,15 @@
 import { compact } from 'lodash-es'
-import { getDFMoveByDfId, getFoundryTableByDfId } from '../dataforged'
+import { getDFMoveByDfId } from '../dataforged'
 import type { IronswornItem } from '../item/item'
 import type { SFMoveDataPropertiesData } from '../item/itemtypes'
+import { OracleTable } from '../roll-table/oracle-table'
 
 export async function createSfMoveChatMessage(move: IronswornItem) {
 	const { dfid, Oracles } = move.system as SFMoveDataPropertiesData
 	const dfMove = await getDFMoveByDfId(dfid)
 	const dfids = Oracles ?? dfMove?.Oracles ?? []
 	const nextOracles = compact(
-		await Promise.all(dfids.map(getFoundryTableByDfId))
+		await Promise.all(dfids.map(OracleTable.getByDfId))
 	)
 
 	const params = { move, nextOracles }

--- a/src/module/dataforged/finding.ts
+++ b/src/module/dataforged/finding.ts
@@ -7,20 +7,6 @@ import {
 	ISOracleCategories
 } from './data'
 import { hashLookup } from './import'
-import type { OracleTable } from '../roll-table/oracle-table'
-
-export async function getFoundryTableByDfId(
-	dfid: string
-): Promise<StoredDocument<OracleTable> | undefined> {
-	const isd = await cachedDocumentsForPack('foundry-ironsworn.ironswornoracles')
-	const sfd = await cachedDocumentsForPack(
-		'foundry-ironsworn.starforgedoracles'
-	)
-	const matcher = (x) => x.id === hashLookup(dfid)
-	return (isd?.find(matcher) ?? sfd?.find(matcher)) as
-		| StoredDocument<OracleTable>
-		| undefined
-}
 
 export async function getFoundryMoveByDfId(
 	dfid: string

--- a/src/module/dataforged/finding.ts
+++ b/src/module/dataforged/finding.ts
@@ -1,11 +1,7 @@
-import type { IMove, IOracle, IOracleCategory } from 'dataforged'
+import type { IMove } from 'dataforged'
 import type { IronswornItem } from '../item/item'
 import { cachedDocumentsForPack } from '../features/pack-cache'
-import {
-	SFMoveCategories,
-	SFOracleCategories,
-	ISOracleCategories
-} from './data'
+import { SFMoveCategories } from './data'
 import { hashLookup } from './import'
 
 export async function getFoundryMoveByDfId(
@@ -29,49 +25,4 @@ export async function getDFMoveByDfId(
 		}
 	}
 	return undefined
-}
-
-export function getDFOracleByDfId(
-	dfid: string
-): IOracle | IOracleCategory | undefined {
-	const nodes = findOracleWithIntermediateNodes(dfid)
-	return nodes[nodes.length - 1]
-}
-
-export function findOracleWithIntermediateNodes(
-	dfid: string
-): Array<IOracle | IOracleCategory> {
-	const ret: Array<IOracle | IOracleCategory> = []
-
-	function walkCategory(cat: IOracleCategory): boolean {
-		ret.push(cat)
-
-		if (cat.$id === dfid) return true
-		for (const oracle of cat.Oracles ?? []) {
-			if (walkOracle(oracle)) return true
-		}
-		for (const childCat of cat.Categories ?? []) {
-			if (walkCategory(childCat)) return true
-		}
-
-		ret.pop()
-		return false
-	}
-
-	function walkOracle(oracle: IOracle): boolean {
-		ret.push(oracle)
-
-		if (oracle.$id === dfid) return true
-		for (const childOracle of oracle.Oracles ?? []) {
-			if (walkOracle(childOracle)) return true
-		}
-
-		ret.pop()
-		return false
-	}
-
-	for (const cat of [...SFOracleCategories, ...ISOracleCategories]) {
-		walkCategory(cat)
-	}
-	return ret
 }

--- a/src/module/features/compendium-categories.ts
+++ b/src/module/features/compendium-categories.ts
@@ -1,3 +1,5 @@
+import type { OracleTable } from '../roll-table/oracle-table'
+
 export function registerCompendiumCategoryHook() {
 	Hooks.on('renderCompendium', async (_app, html: JQuery, opts) => {
 		if (opts.documentCls !== 'rolltable') return
@@ -6,7 +8,7 @@ export function registerCompendiumCategoryHook() {
 		for (const el of html.find('.directory-item')) {
 			const table = (await collection.getDocument(
 				el.dataset.documentId
-			)) as RollTable
+			)) as OracleTable
 			if ((table as any)?.flags?.category) {
 				const cat = ((table as any).flags.category as string)
 					.replace(/(Starforged|Ironsworn)\/Oracles\//, '')

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -6,7 +6,7 @@ import type {
 } from 'dataforged'
 import { starforged, ironsworn } from 'dataforged'
 import { cloneDeep, compact } from 'lodash-es'
-import { getFoundryTableByDfId } from '../dataforged'
+import { OracleTable } from '../roll-table/oracle-table'
 import { cachedDocumentsForPack } from './pack-cache'
 
 export interface IOracleTreeNode {
@@ -95,7 +95,7 @@ export async function walkOracle(
 ): Promise<IOracleTreeNode> {
 	if (oracle == null) return emptyNode()
 
-	const table = await getFoundryTableByDfId(oracle.$id)
+	const table = await OracleTable.getByDfId(oracle.$id)
 
 	const node: IOracleTreeNode = {
 		...emptyNode(),
@@ -115,7 +115,7 @@ export async function walkOracle(
 	for (const entry of oracle.Table ?? []) {
 		const name = entry.Result
 		if (entry.Subtable != null) {
-			const subtable = await getFoundryTableByDfId(`${oracle.$id}/${name}`)
+			const subtable = await OracleTable.getByDfId(`${oracle.$id}/${name}`)
 			if (subtable != null) {
 				node.children.push({
 					...emptyNode(),

--- a/src/module/features/pack-cache.ts
+++ b/src/module/features/pack-cache.ts
@@ -1,6 +1,7 @@
 import type { BaseAdventure } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/documents.mjs/baseAdventure.js'
 import type { IronswornActor } from '../actor/actor'
 import type { IronswornItem } from '../item/item'
+import type { IronswornJournalEntry } from '../journal/journal-entry'
 
 const ONE_MINUTE_IN_MS = 60 * 1000
 
@@ -10,7 +11,7 @@ type PackContents = Array<
 		| IronswornActor
 		| Cards
 		| IronswornItem
-		| JournalEntry
+		| IronswornJournalEntry
 		| Macro
 		| Playlist
 		| RollTable

--- a/src/module/features/pack-cache.ts
+++ b/src/module/features/pack-cache.ts
@@ -2,6 +2,7 @@ import type { BaseAdventure } from '@league-of-foundry-developers/foundry-vtt-ty
 import type { IronswornActor } from '../actor/actor'
 import type { IronswornItem } from '../item/item'
 import type { IronswornJournalEntry } from '../journal/journal-entry'
+import type { OracleTable } from '../roll-table/oracle-table'
 
 const ONE_MINUTE_IN_MS = 60 * 1000
 
@@ -14,7 +15,7 @@ type PackContents = Array<
 		| IronswornJournalEntry
 		| Macro
 		| Playlist
-		| RollTable
+		| OracleTable
 		| BaseAdventure
 	>
 >

--- a/src/module/helpers/items.ts
+++ b/src/module/helpers/items.ts
@@ -1,5 +1,5 @@
 import type { TableResultDataConstructorData } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/tableResultData'
-import type { LegacyFeatureOrDanger } from '../item/itemtypes'
+import type { LegacyTableRow } from '../item/itemtypes'
 import type { TableRow } from '../rolls'
 
 /**
@@ -14,9 +14,7 @@ export function normalizeTableRows(
 	key: string,
 	type: string
 ): TableResultDataConstructorData[] {
-	const oldRows = getProperty(document, key) as Array<
-		TableRow | LegacyFeatureOrDanger
-	>
+	const oldRows = getProperty(document, key) as Array<TableRow | LegacyTableRow>
 	if (!Array.isArray(oldRows)) {
 		console.log(
 			`Unable to migrate because this document lacks a "${key}" key `,
@@ -39,12 +37,11 @@ export function normalizeTableRows(
 }
 
 export function toTableResult(
-	tableRow: TableRow | LegacyFeatureOrDanger,
+	tableRow: TableRow | LegacyTableRow,
 	flags?: Record<string, unknown>
 ): TableResultDataConstructorData {
 	const text =
-		(tableRow as LegacyFeatureOrDanger).description ??
-		(tableRow as TableRow).text
+		(tableRow as LegacyTableRow).description ?? (tableRow as TableRow).text
 	return {
 		range: (tableRow as any).range ?? [tableRow.low, tableRow.high],
 		text,

--- a/src/module/item/itemtypes.ts
+++ b/src/module/item/itemtypes.ts
@@ -57,11 +57,13 @@ export interface AssetDataPropertiesData extends AssetDataSourceData {}
 export interface AssetDataSource {
 	type: 'asset'
 	data: AssetDataSourceData
+	system: AssetDataSourceData
 }
 
 export interface AssetDataProperties {
 	type: 'asset'
 	data: AssetDataPropertiesData
+	system: AssetDataPropertiesData
 }
 
 /// ////////////////////////////
@@ -79,10 +81,12 @@ export interface ProgressDataPropertiesData extends ProgressDataSourceData {}
 export interface ProgressDataSource {
 	type: 'progress'
 	data: ProgressDataSourceData
+	system: ProgressDataSourceData
 }
 export interface ProgressDataProperties {
 	type: 'progress'
 	data: ProgressDataPropertiesData
+	system: ProgressDataPropertiesData
 }
 
 /// ////////////////////////////
@@ -100,18 +104,21 @@ export interface BondsetDataPropertiesData extends BondsetDataSourceData {}
 export interface BondsetDataSource {
 	type: 'bondset'
 	data: BondsetDataSourceData
+	system: BondsetDataSourceData
 }
 export interface BondsetDataProperties {
 	type: 'bondset'
 	data: BondsetDataPropertiesData
+	system: BondsetDataPropertiesData
 }
 
 /// ////////////////////////////
 
-export interface LegacyFeatureOrDanger {
+export interface LegacyTableRow {
 	low: number
 	high: number
-	description: string
+	description?: string
+	text?: string
 }
 
 export interface DelveSiteFeatureOrDanger<
@@ -121,14 +128,8 @@ export interface DelveSiteFeatureOrDanger<
 > extends TableResultDataConstructorData {
 	flags: {
 		'foundry-ironsworn': {
-			/**
-			 * Whether this is a site danger or a site feature.
-			 */
 			type: T
-			/**
-			 * The ID of the originating Item.
-			 */
-			sourceId: Item['id']
+			sourceId: string
 		}
 	}
 }
@@ -151,10 +152,12 @@ export interface DelveThemeDataPropertiesData
 export interface DelveThemeDataSource {
 	type: 'delve-theme'
 	data: DelveThemeDataSourceData
+	system: DelveThemeDataSourceData
 }
 export interface DelveThemeDataProperties {
 	type: 'delve-theme'
 	data: DelveThemeDataPropertiesData
+	system: DelveThemeDataPropertiesData
 }
 /// ////////////////////////////
 
@@ -170,10 +173,12 @@ export interface DelveDomainDataPropertiesData
 export interface DelveDomainDataSource {
 	type: 'delve-domain'
 	data: DelveDomainDataSourceData
+	system: DelveDomainDataSourceData
 }
 export interface DelveDomainDataProperties {
 	type: 'delve-domain'
 	data: DelveDomainDataPropertiesData
+	system: DelveDomainDataPropertiesData
 }
 
 /// ////////////////////////////
@@ -185,10 +190,12 @@ export interface SFMoveDataPropertiesData extends IMove {
 export interface SFMoveDataSource {
 	type: 'sfmove'
 	data: SFMoveDataPropertiesData
+	system: SFMoveDataPropertiesData
 }
 export interface SFMoveDataProperties {
 	type: 'sfmove'
 	data: SFMoveDataPropertiesData
+	system: SFMoveDataPropertiesData
 }
 
 /// ////////////////////////////

--- a/src/module/item/itemtypes.ts
+++ b/src/module/item/itemtypes.ts
@@ -129,7 +129,7 @@ export interface DelveSiteFeatureOrDanger<
 	flags: {
 		'foundry-ironsworn': {
 			type: T
-			sourceId: string
+			sourceId?: string | null
 		}
 	}
 }

--- a/src/module/roll-table/oracle-table.ts
+++ b/src/module/roll-table/oracle-table.ts
@@ -29,7 +29,7 @@ export class OracleTable extends RollTable {
 	static getDFOracleByDfId(
 		dfid: string
 	): IOracle | IOracleCategory | undefined {
-		const nodes = this.findOracleWithIntermediateNodes(dfid)
+		const nodes = OracleTable.findOracleWithIntermediateNodes(dfid)
 		return nodes[nodes.length - 1]
 	}
 

--- a/src/module/roll-table/oracle-table.ts
+++ b/src/module/roll-table/oracle-table.ts
@@ -1,10 +1,11 @@
 import type { RollTableDataConstructorData } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/rollTableData'
 import type { ConfiguredFlags } from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes'
-import type { IOracle, IRow } from 'dataforged'
+import type { IOracle, IOracleCategory, IRow } from 'dataforged'
 import { max } from 'lodash-es'
 import { marked } from 'marked'
 import type { IronswornActor } from '../actor/actor'
 import { hashLookup, renderLinksInStr } from '../dataforged'
+import { ISOracleCategories, SFOracleCategories } from '../dataforged/data'
 import {
 	findPathToNodeByTableUuid,
 	getOracleTreeWithCustomOracles
@@ -24,6 +25,51 @@ export class OracleTable extends RollTable {
 	/** The custom template used for rendering oracle results */
 	static resultTemplate =
 		'systems/foundry-ironsworn/templates/rolls/oracle-roll-message.hbs'
+
+	static getDFOracleByDfId(
+		dfid: string
+	): IOracle | IOracleCategory | undefined {
+		const nodes = this.findOracleWithIntermediateNodes(dfid)
+		return nodes[nodes.length - 1]
+	}
+
+	static findOracleWithIntermediateNodes(
+		dfid: string
+	): Array<IOracle | IOracleCategory> {
+		const ret: Array<IOracle | IOracleCategory> = []
+
+		function walkCategory(cat: IOracleCategory): boolean {
+			ret.push(cat)
+
+			if (cat.$id === dfid) return true
+			for (const oracle of cat.Oracles ?? []) {
+				if (walkOracle(oracle)) return true
+			}
+			for (const childCat of cat.Categories ?? []) {
+				if (walkCategory(childCat)) return true
+			}
+
+			ret.pop()
+			return false
+		}
+
+		function walkOracle(oracle: IOracle): boolean {
+			ret.push(oracle)
+
+			if (oracle.$id === dfid) return true
+			for (const childOracle of oracle.Oracles ?? []) {
+				if (walkOracle(childOracle)) return true
+			}
+
+			ret.pop()
+			return false
+		}
+
+		for (const cat of [...SFOracleCategories, ...ISOracleCategories]) {
+			walkCategory(cat)
+		}
+		return ret
+	}
 
 	static async getByDfId(
 		dfid: string

--- a/src/module/rolls/ironsworn-roll-message.ts
+++ b/src/module/rolls/ironsworn-roll-message.ts
@@ -9,12 +9,11 @@ import {
 import { IronswornRoll } from '.'
 import type { IronswornActor } from '../actor/actor'
 import type { CharacterDataPropertiesData } from '../actor/actortypes'
-import { getFoundryTableByDfId } from '../dataforged'
 import type { SFMoveDataPropertiesData } from '../item/itemtypes'
-import { SFMoveDataProperties } from '../item/itemtypes'
 import { enrichMarkdown } from '../vue/vue-plugin'
 import { DfRollOutcome, RollOutcome } from './ironsworn-roll'
 import { renderRollGraphic } from './roll-graphic'
+import { OracleTable } from '../roll-table/oracle-table'
 
 interface MoveTemplateData {
 	outcomeClass?: string
@@ -324,7 +323,7 @@ export class IronswornRollMessage {
 		const system = move.system as SFMoveDataPropertiesData
 		const dfids = system.Oracles ?? []
 		const nextOracles = compact(
-			await Promise.all(dfids.map(getFoundryTableByDfId))
+			await Promise.all(dfids.map(OracleTable.getByDfId))
 		)
 		return { nextOracles }
 	}

--- a/src/module/rolls/oracle-roll-message.ts
+++ b/src/module/rolls/oracle-roll-message.ts
@@ -114,7 +114,7 @@ export class OracleRollMessage {
 		}
 
 		if (this.tableUuid) {
-			return (await fromUuid(this.tableUuid)) as RollTable
+			return (await fromUuid(this.tableUuid)) as OracleTable
 		}
 
 		return undefined

--- a/src/module/rolls/oracle-roll-message.ts
+++ b/src/module/rolls/oracle-roll-message.ts
@@ -1,12 +1,12 @@
 import type { TableResultDataConstructorData } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/tableResultData'
 import { compact, pick, sortBy } from 'lodash-es'
 import { marked } from 'marked'
-import { getFoundryTableByDfId } from '../dataforged'
 import {
 	findPathToNodeByDfId,
 	findPathToNodeByTableUuid,
 	getOracleTreeWithCustomOracles
 } from '../features/customoracles'
+import { OracleTable } from '../roll-table/oracle-table'
 
 export interface TableRow {
 	low: number
@@ -110,7 +110,7 @@ export class OracleRollMessage {
 		if (this.tableRows != null) return undefined
 
 		if (this.dfOracleId) {
-			return await getFoundryTableByDfId(this.dfOracleId)
+			return await OracleTable.getByDfId(this.dfOracleId)
 		}
 
 		if (this.tableUuid) {

--- a/src/module/vue/components/oracle-tree-node.vue
+++ b/src/module/vue/components/oracle-tree-node.vue
@@ -76,6 +76,7 @@ import CollapseTransition from './transition/collapse-transition.vue'
 import IronBtn from './buttons/iron-btn.vue'
 import FontIcon from './icon/font-icon.vue'
 import IronIcon from './icon/iron-icon.vue'
+import type { OracleTable } from '../../roll-table/oracle-table'
 
 const props = defineProps<{ node: IOracleTreeNode }>()
 
@@ -103,7 +104,7 @@ const isLeaf = computed(() => {
 
 async function toggleDescription() {
 	if (!state.tableDescription) {
-		const table = (await fromUuid(props.node.tables[0])) as RollTable
+		const table = (await fromUuid(props.node.tables[0])) as OracleTable
 		state.tableRows = table.results.map((row: any) => ({
 			low: row.range[0],
 			high: row.range[1],
@@ -141,7 +142,7 @@ function expand() {
 	state.manuallyExpanded = true
 }
 
-let $el = ref<HTMLElement>()
+const $el = ref<HTMLElement>()
 CONFIG.IRONSWORN.emitter.on('highlightOracle', (dfid) => {
 	if (props.node.dataforgedNode?.$id === dfid) {
 		state.highlighted = true

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -57,7 +57,6 @@
 <script setup lang="ts">
 import type { ExtractPropTypes } from 'vue'
 import { computed, provide, reactive, ref } from 'vue'
-import { getDFOracleByDfId } from '../../dataforged'
 import type { Move } from '../../features/custommoves'
 import type { IOracleTreeNode } from '../../features/customoracles'
 import { walkOracle } from '../../features/customoracles'
@@ -73,6 +72,7 @@ import { ItemKey, $ItemKey } from '../provisions.js'
 import { enrichMarkdown } from '../vue-plugin.js'
 import type { SFMoveDataPropertiesData } from '../../item/itemtypes'
 import { uniq } from 'lodash-es'
+import { OracleTable } from '../../roll-table/oracle-table'
 
 const props = withDefaults(
 	defineProps<{
@@ -153,10 +153,12 @@ const oracleIds = uniq([
 	...($itemSystem.value?.Oracles ?? []),
 	...(props.move.dataforgedMove?.Oracles ?? [])
 ])
-Promise.all(oracleIds.map(getDFOracleByDfId)).then(async (dfOracles) => {
-	const nodes = await Promise.all(dfOracles.map(walkOracle))
-	data.oracles.push(...nodes)
-})
+Promise.all(oracleIds.map(OracleTable.getDFOracleByDfId)).then(
+	async (dfOracles) => {
+		const nodes = await Promise.all(dfOracles.map(walkOracle))
+		data.oracles.push(...nodes)
+	}
+)
 
 // Outbound link clicks: broadcast events
 function moveClick(move: IronswornItem) {

--- a/src/module/vue/components/sf-movesheetoracles.vue
+++ b/src/module/vue/components/sf-movesheetoracles.vue
@@ -34,9 +34,9 @@
 
 <script setup lang="ts">
 import { nextTick, provide, reactive, ref, watch } from 'vue'
-import { findOracleWithIntermediateNodes } from '../../dataforged'
 import type { IOracleTreeNode } from '../../features/customoracles'
 import { getOracleTreeWithCustomOracles } from '../../features/customoracles'
+import { OracleTable } from '../../roll-table/oracle-table'
 import IronBtn from './buttons/iron-btn.vue'
 import OracleTreeNode from './oracle-tree-node.vue'
 
@@ -106,7 +106,7 @@ CONFIG.IRONSWORN.emitter.on('highlightOracle', async (dfid) => {
 	clearSearch()
 
 	// Find the path in the data tree
-	const dfOraclePath = findOracleWithIntermediateNodes(dfid)
+	const dfOraclePath = OracleTable.findOracleWithIntermediateNodes(dfid)
 
 	// Wait for children to be present
 	while (!oracles.value) {

--- a/src/module/vue/components/site/site-moves.vue
+++ b/src/module/vue/components/site/site-moves.vue
@@ -58,10 +58,10 @@
 import type { TableResultDataConstructorData } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/tableResultData'
 import { computed, inject, reactive } from 'vue'
 import type { SiteDataPropertiesData } from '../../../actor/actortypes'
-import { getFoundryTableByDfId } from '../../../dataforged'
 import type { Move } from '../../../features/custommoves'
 import { createIronswornMoveTree } from '../../../features/custommoves'
 import type { DelveThemeDataSourceData } from '../../../item/itemtypes'
+import { OracleTable } from '../../../roll-table/oracle-table'
 import { OracleRollMessage, IronswornPrerollDialog } from '../../../rolls'
 import { $ActorKey, ActorKey } from '../../provisions'
 
@@ -111,7 +111,7 @@ Promise.resolve().then(async () => {
 async function revealADanger() {
 	if (!hasThemeAndDomain.value) return
 
-	const oracle = await getFoundryTableByDfId(
+	const oracle = await OracleTable.getByDfId(
 		'Ironsworn/Oracles/Moves/Reveal_a_Danger'
 	)
 	if (!oracle) return

--- a/src/module/vue/components/truth/truth-category.vue
+++ b/src/module/vue/components/truth/truth-category.vue
@@ -29,6 +29,7 @@
 <script lang="ts" setup>
 import type { ISettingTruth, ISettingTruthOption } from 'dataforged'
 import { reactive, ref } from 'vue'
+import type { IronswornJournalEntry } from '../../../journal/journal-entry'
 import type { TableRow } from '../../../rolls'
 import { OracleRollMessage } from '../../../rolls'
 import { enrichMarkdown } from '../../vue-plugin'
@@ -38,7 +39,7 @@ import TruthSelectable from './truth-selectable.vue'
 
 const props = defineProps<{
 	df: ISettingTruth
-	je: () => JournalEntry
+	je: () => IronswornJournalEntry
 }>()
 
 const jePages = (props.je() as any | undefined)?.pages ?? []

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -146,6 +146,7 @@ import { OracleRollMessage } from '../rolls'
 import type { LocationDataProperties } from '../actor/actortypes'
 import SheetBasic from './sheet-basic.vue'
 import IronBtn from './components/buttons/iron-btn.vue'
+import { OracleTable } from '../roll-table/oracle-table'
 
 const props = defineProps<{
 	data: { actor: any }
@@ -589,10 +590,9 @@ async function randomizeName() {
 		)
 		name = sample(json?.['Sample Names'] ?? [])
 	} else if (subtype === 'settlement') {
-		const table =
-			await CONFIG.IRONSWORN.dataforgedHelpers.getFoundryTableByDfId(
-				'Starforged/Oracles/Settlements/Name'
-			)
+		const table = await OracleTable.getByDfId(
+			'Starforged/Oracles/Settlements/Name'
+		)
 		name = await drawAndReturnResult(table)
 	}
 
@@ -616,9 +616,7 @@ async function randomizeKlass() {
 		tableKey = 'Starforged/Oracles/Vaults/Location'
 	}
 
-	const table = await CONFIG.IRONSWORN.dataforgedHelpers.getFoundryTableByDfId(
-		tableKey
-	)
+	const table = await OracleTable.getByDfId(tableKey)
 	const rawText = await drawAndReturnResult(table)
 	if (!rawText) return
 
@@ -640,9 +638,7 @@ async function rollFirstLook() {
 }
 
 async function rollOracle(oracle) {
-	const table = await CONFIG.IRONSWORN.dataforgedHelpers.getFoundryTableByDfId(
-		oracle.dfid
-	)
+	const table = await OracleTable.getByDfId(oracle.dfid)
 	const drawText = await drawAndReturnResult(table)
 	if (!drawText) return
 

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -570,7 +570,7 @@ async function saveKlass(klass) {
 }
 
 async function drawAndReturnResult(
-	table?: RollTable
+	table?: OracleTable
 ): Promise<string | undefined> {
 	if (!table) return undefined
 

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -490,7 +490,7 @@ const canRandomizeName = computed(() => {
 
 	if (subtype === 'planet') {
 		const kc = capitalize(klass)
-		const json = CONFIG.IRONSWORN.dataforgedHelpers.getDFOracleByDfId(
+		const json = OracleTable.getDFOracleByDfId(
 			`Starforged/Oracles/Planets/${kc}`
 		)
 		if (json) return true
@@ -585,7 +585,7 @@ async function randomizeName() {
 	let name
 	if (subtype === 'planet') {
 		const kc = capitalize(klass)
-		const json = await CONFIG.IRONSWORN.dataforgedHelpers.getDFOracleByDfId(
+		const json = await OracleTable.getDFOracleByDfId(
 			`Starforged/Oracles/Planets/${kc}`
 		)
 		name = sample(json?.['Sample Names'] ?? [])

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -47,7 +47,7 @@ const props = defineProps<{
 	data: {
 		truths: {
 			df: ISettingTruth
-			je: () => JournalEntry
+			je: () => IronswornJournalEntry
 		}[]
 	}
 }>()

--- a/src/styles/tables.less
+++ b/src/styles/tables.less
@@ -13,8 +13,15 @@ table {
 		border-color: var(--ironsworn-color-border-muted);
 	}
 
-	tr:nth-child(even) {
-		background-color: var(--ironsworn-color-fg-10);
+	&:not(.oracle-table-partial) {
+		tr:nth-child(even) {
+			background-color: var(--ironsworn-color-fg-10);
+		}
+	}
+	&.oracle-table-partial {
+		tr:nth-child(even) {
+			background-color: transparent;
+		}
 	}
 }
 
@@ -44,7 +51,7 @@ table {
 	.oracle-result-row {
 		&.selected,
 		&[aria-selected='true'] {
-			.staticHighlightMixin(20);
+			.staticHighlightMixin(30);
 		}
 	}
 }

--- a/src/styles/tables.scss
+++ b/src/styles/tables.scss
@@ -14,8 +14,15 @@ table {
 		border-color: var(--ironsworn-color-border-muted);
 	}
 
-	tr:nth-child(even) {
-		background-color: var(--ironsworn-color-fg-10);
+	&:not(.oracle-table-partial) {
+		tr:nth-child(even) {
+			background-color: var(--ironsworn-color-fg-10);
+		}
+	}
+	&.oracle-table-partial {
+		tr:nth-child(even) {
+			background-color: transparent;
+		}
 	}
 }
 
@@ -32,7 +39,7 @@ table {
 
 	td,
 	th {
-		// hack that forces the roll range column to its minimum size
+		// HACK: forces the roll range column to its minimum size
 		width: auto;
 
 		&.oracle-table-column-roll-range {
@@ -45,7 +52,7 @@ table {
 	.oracle-result-row {
 		&.selected,
 		&[aria-selected='true'] {
-			@include fx.accentGradient(20);
+			@include fx.accentGradient(30);
 		}
 	}
 }

--- a/system/template.json
+++ b/system/template.json
@@ -63,84 +63,84 @@
 					"range": [1, 27],
 					"text": "",
 					"flags": {
-						"type": "delve-site-denizen"
+						"foundry-ironsworn": { "type": "delve-site-denizen" }
 					}
 				},
 				{
 					"range": [28, 41],
 					"text": "",
 					"flags": {
-						"type": "delve-site-denizen"
+						"foundry-ironsworn": { "type": "delve-site-denizen" }
 					}
 				},
 				{
 					"range": [42, 55],
 					"text": "",
 					"flags": {
-						"type": "delve-site-denizen"
+						"foundry-ironsworn": { "type": "delve-site-denizen" }
 					}
 				},
 				{
 					"range": [56, 69],
 					"text": "",
 					"flags": {
-						"type": "delve-site-denizen"
+						"foundry-ironsworn": { "type": "delve-site-denizen" }
 					}
 				},
 				{
 					"range": [70, 75],
 					"text": "",
 					"flags": {
-						"type": "delve-site-denizen"
+						"foundry-ironsworn": { "type": "delve-site-denizen" }
 					}
 				},
 				{
 					"range": [76, 81],
 					"text": "",
 					"flags": {
-						"type": "delve-site-denizen"
+						"foundry-ironsworn": { "type": "delve-site-denizen" }
 					}
 				},
 				{
 					"range": [82, 87],
 					"text": "",
 					"flags": {
-						"type": "delve-site-denizen"
+						"foundry-ironsworn": { "type": "delve-site-denizen" }
 					}
 				},
 				{
 					"range": [88, 93],
 					"text": "",
 					"flags": {
-						"type": "delve-site-denizen"
+						"foundry-ironsworn": { "type": "delve-site-denizen" }
 					}
 				},
 				{
 					"range": [94, 95],
 					"text": "",
 					"flags": {
-						"type": "delve-site-denizen"
+						"foundry-ironsworn": { "type": "delve-site-denizen" }
 					}
 				},
 				{
 					"range": [96, 97],
 					"text": "",
 					"flags": {
-						"type": "delve-site-denizen"
+						"foundry-ironsworn": { "type": "delve-site-denizen" }
 					}
 				},
 				{
 					"range": [98, 99],
 					"text": "",
 					"flags": {
-						"type": "delve-site-denizen"
+						"foundry-ironsworn": { "type": "delve-site-denizen" }
 					}
 				},
 				{
 					"range": [100, 100],
 					"text": "",
 					"flags": {
-						"type": "delve-site-denizen"
+						"foundry-ironsworn": { "type": "delve-site-denizen" }
 					}
 				}
 			]
@@ -269,28 +269,36 @@
 					"range": [1, 4],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [5, 8],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [9, 12],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [13, 16],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
@@ -303,84 +311,108 @@
 					"range": [1, 5],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [6, 10],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [11, 12],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [13, 14],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [15, 16],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [17, 18],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [19, 20],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [21, 22],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [23, 24],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [25, 26],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [27, 28],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [29, 30],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				}
 			]
@@ -393,84 +425,108 @@
 					"range": [21, 43],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [44, 56],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [57, 64],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [65, 68],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [69, 72],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [73, 76],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [77, 80],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [81, 84],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [85, 88],
 					"text": "",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [89, 98],
 					"description": "Something unusual or unexpected",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [99, 99],
 					"description": "You transition into a new theme",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				},
 				{
 					"range": [100, 100],
 					"description": "You transition into a new domain",
 					"flags": {
-						"type": "delve-site-feature"
+						"foundry-ironsworn": {
+							"type": "delve-site-feature"
+						}
 					}
 				}
 			],
@@ -479,35 +535,45 @@
 					"range": [31, 33],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [34, 36],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [37, 39],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [40, 42],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				},
 				{
 					"range": [43, 45],
 					"text": "",
 					"flags": {
-						"type": "delve-site-danger"
+						"foundry-ironsworn": {
+							"type": "delve-site-danger"
+						}
 					}
 				}
 			]

--- a/system/templates/chat/sf-move.hbs
+++ b/system/templates/chat/sf-move.hbs
@@ -21,7 +21,8 @@
 		<section class='move-oracle-buttons flexrow'>
 			{{#each nextOracles}}
 				<button
-					class='starforged__oracle__roll icon-button clickable isicon-oracle'
+					class='icon-button clickable isicon-oracle'
+					data-iron-action='oracleRoll'
 					data-tooltip='{{{localize "IRONSWORN.RollOracleTable" title=name}}}'
 					data-tableid='{{id}}'
 					type='button'

--- a/system/templates/rolls/ironsworn-roll-message.hbs
+++ b/system/templates/rolls/ironsworn-roll-message.hbs
@@ -58,7 +58,8 @@
 			<section class='move-oracle-buttons flexrow'>
 				{{#each nextOracles}}
 					<button
-						class='starforged__oracle__roll icon-button clickable isicon-oracle'
+						class='icon-button clickable isicon-oracle'
+						data-iron-action='oracleRoll'
 						data-tooltip='{{{localize "IRONSWORN.RollOracleTable" title=name}}}'
 						data-tableid='{{id}}'
 						type='button'

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -31,7 +31,8 @@
             {{../oracleRoll.roll.total}}
           </span>
           <button type='button'
-            class="oracle-result-control oracle-reroll clickable text"
+            data-iron-action="oracleReroll"
+            class="oracle-result-control clickable text"
             data-tooltip="{{localize 'IRONSWORN.Reroll'}}"
             aria-label="{{{localize 'IRONSWORN.OracleTable.ColumnLabel.DiceRollResult' dice='d100'}}}"
             >


### PR DESCRIPTION
required for #715

* moves two oracle traversal functions to live as static methods on `OracleTable`, and updates references to them
* points references to foundry default classes, e.g. "RollTable", "JournalEntry" to our extended classes
* applies "oracleRoll" and "oracleReroll" listeners to e.g. `data-iron-action="oracleRoll"`, and updates all oracle buttons in HBS buttons to match
  * these aren't a strict requirement, but oracle roll chat buttons will be broken anyways by other changes to oracle rolls in #715. I don't *think* we need a deprecation period here, as 1) folks generally update the module between sessions, 2) oracle rolls from last session are unlikely to call for a reroll, and 3) the workaround is pretty simple
* update `template.json` to reflect previous changes to flags on features, dangers, and denizens (they now get assigned `flags['foundry-ironsworn'].type` automatically)
* adjust chat message table CSS to remove alternating row colours, which just made the highlighted row look weird sometimes