### PR TITLE
Instant, painless type rename with `document#migrateData`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,6 +22,8 @@ module.exports = {
 	},
 	plugins: ['@typescript-eslint'],
 	rules: {
+		// LoFD, the target of most of our augmentations, uses namespaces. More generally, namespaces are necessary to augment static class members.
+		'@typescript-eslint/no-namespace': 'off',
 		'@typescript-eslint/no-unused-vars': [1, { argsIgnorePattern: '^_' }],
 		'@typescript-eslint/explicit-module-boundary-types': 'off',
 		'@typescript-eslint/ban-ts-comment': 'off',

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ Hooks.once('init', async () => {
 	})
 
 	Items.registerSheet('ironsworn', SFMoveSheet, {
-		types: ['sfmove'],
+		types: ['move'],
 		label: 'IRONSWORN.ITEM.TypeMove'
 	})
 
@@ -175,7 +175,7 @@ Hooks.once('init', async () => {
 		asset: 'IRONSWORN.ITEM.TypeAsset',
 		progress: 'IRONSWORN.ITEM.TypeProgressTrack',
 		bondset: 'IRONSWORN.ITEM.TypeBondset',
-		sfmove: 'IRONSWORN.ITEM.TypeMove',
+		move: 'IRONSWORN.ITEM.TypeMove',
 		'delve-domain': 'IRONSWORN.ITEM.TypeDelveDomain',
 		'delve-theme': 'IRONSWORN.ITEM.TypeDelveTheme'
 	})
@@ -183,7 +183,7 @@ Hooks.once('init', async () => {
 		asset: 'fa-solid fa-cards-blank',
 		progress: 'fa-solid fa-asterisk',
 		bondset: 'fa-solid fa-handshake',
-		sfmove: 'icon isicon-d10-tilt',
+		move: 'icon isicon-d10-tilt',
 		// FIXME ideally, these would be distinct from assets, but all three card types are abstract enough than an icon is tricky
 		'delve-domain': 'fa-duotone fa-cards-blank',
 		'delve-theme': 'fa-duotone fa-cards-blank'

--- a/src/module/chat/cards.ts
+++ b/src/module/chat/cards.ts
@@ -26,7 +26,7 @@ export class IronswornChatCard {
 
 			const fPack = game.packs.get(pack)
 			const fItem = fPack?.get(id) as IronswornItem
-			if (fItem?.type !== 'sfmove') return []
+			if (fItem?.type !== 'move') return []
 
 			const system = fItem.system as SFMoveDataPropertiesData
 			const oracleIds = system.Oracles ?? []
@@ -98,7 +98,7 @@ export class IronswornChatCard {
 		const { uuid } = ev.currentTarget.dataset
 
 		const item = (await fromUuid(uuid)) as IronswornItem
-		if (item?.type !== 'sfmove') {
+		if (item?.type !== 'move') {
 			console.log('falling through')
 			return // (TextEditor as any)._onClickContentLink(ev)
 		}

--- a/src/module/dataforged/import.ts
+++ b/src/module/dataforged/import.ts
@@ -135,7 +135,7 @@ function movesForCategories(
 			console.log(move.Name, move.$id)
 			movesToCreate.push({
 				_id: hashLookup(cleanMove.dfid),
-				type: 'sfmove',
+				type: 'move',
 				name: move.Name,
 				img: 'icons/dice/d10black.svg',
 				system: cleanMove

--- a/src/module/features/custommoves.ts
+++ b/src/module/features/custommoves.ts
@@ -130,7 +130,7 @@ async function augmentWithFolderContents(categories: MoveCategory[]) {
 
 	const customMoves = [] as Move[]
 	for (const moveItem of folder.contents) {
-		if (moveItem.documentName !== 'Item' || moveItem.type !== 'sfmove') continue
+		if (moveItem.documentName !== 'Item' || moveItem.type !== 'move') continue
 		customMoves.push({
 			color,
 			displayName: moveItem.name ?? '(move)',

--- a/src/module/item/itemtypes.ts
+++ b/src/module/item/itemtypes.ts
@@ -183,11 +183,11 @@ export interface SFMoveDataPropertiesData extends IMove {
 }
 
 export interface SFMoveDataSource {
-	type: 'sfmove'
+	type: 'move'
 	data: SFMoveDataPropertiesData
 }
 export interface SFMoveDataProperties {
-	type: 'sfmove'
+	type: 'move'
 	data: SFMoveDataPropertiesData
 }
 

--- a/src/module/rolls/ironsworn-roll-message.ts
+++ b/src/module/rolls/ironsworn-roll-message.ts
@@ -260,7 +260,7 @@ export class IronswornRollMessage {
 				this.roll.postRollOptions.replacedOutcome?.source
 		}
 		const move = await this.roll.moveItem
-		if (move?.type !== 'sfmove') return ret
+		if (move?.type !== 'move') return ret
 
 		const key = DfRollOutcome[theOutcome]
 		const moveSystem = move.system as SFMoveDataPropertiesData
@@ -319,7 +319,7 @@ export class IronswornRollMessage {
 
 	private async oraclesData(): Promise<any> {
 		const move = await this.roll.moveItem
-		if (move?.type !== 'sfmove') return {}
+		if (move?.type !== 'move') return {}
 
 		const system = move.system as SFMoveDataPropertiesData
 		const dfids = system.Oracles ?? []

--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -56,7 +56,7 @@ function rollableOptions(trigger: IMoveTrigger) {
 }
 
 export function moveHasRollableOptions(move: IronswornItem) {
-	if (move.type !== 'sfmove') return false
+	if (move.type !== 'move') return false
 	const data = move.system as SFMoveDataPropertiesData
 	const options = rollableOptions(data.Trigger)
 	return options.length > 0
@@ -285,7 +285,7 @@ export class IronswornPrerollDialog extends Dialog<
 	}
 
 	static async showForMove(move: IronswornItem, opts?: showForMoveOpts) {
-		if (move.type !== 'sfmove') {
+		if (move.type !== 'move') {
 			throw new Error('this only works with SF moves')
 		}
 

--- a/src/module/vue/components/with-rolllisteners.vue
+++ b/src/module/vue/components/with-rolllisteners.vue
@@ -39,7 +39,7 @@ async function click(ev: JQuery.ClickEvent) {
 	const { uuid, dfid } = ev.currentTarget.dataset
 	if (uuid) {
 		const gameItem = (await fromUuid(uuid)) as IronswornItem | IronswornActor
-		if (gameItem?.type === 'sfmove') {
+		if (gameItem?.type === 'move') {
 			$emit('moveclick', gameItem)
 			return !!$attrs['onMoveclick']
 		}

--- a/system/template.json
+++ b/system/template.json
@@ -163,7 +163,7 @@
 			"asset",
 			"progress",
 			"bondset",
-			"sfmove",
+			"move",
 			"delve-theme",
 			"delve-domain"
 		],
@@ -234,7 +234,7 @@
 			],
 			"conditions": []
 		},
-		"sfmove": {
+		"move": {
 			"dfid": "",
 			"Category": "",
 			"Progress Move": false,


### PR DESCRIPTION
simple migration of `sfmove` to `move`. intentionally doesn't update the db files yet to make testing it simple