### PR TITLE
<select> <option> style fixes for "Phosphor" colorway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Expand Spanish translation to be on par with the English language file ([#749](https://github.com/ben/foundry-ironsworn/pull/749), thanks [@erizocosmico](https://github.com/erizocosmico)!)
+- Improved dropdown menu styling for the "Phosphor" colorway
 
 ## 1.21.6
 

--- a/src/styles/inputs.less
+++ b/src/styles/inputs.less
@@ -8,8 +8,24 @@
 
 select {
 	.inputFieldMixin();
-
 	border-style: outset;
+	::selection {
+		background: var(--ironsworn-color-clickable-block-bg-hover);
+		color: var(--ironsworn-color-clickable-block-fg-hover);
+	}
+	option,
+	optgroup {
+		font-family: inherit;
+		background: var(--ironsworn-color-input-bg-opaque);
+		color: var(--ironsworn-color-clickable-block-fg);
+
+		&:hover,
+		&:focus,
+		&::selection {
+			background: var(--ironsworn-color-clickable-block-bg-hover);
+			color: var(--ironsworn-color-clickable-block-fg-hover);
+		}
+	}
 }
 
 textarea {

--- a/src/styles/inputs.scss
+++ b/src/styles/inputs.scss
@@ -12,6 +12,23 @@ select {
 
 	border: var(--ironsworn-border-width-md) outset
 		var(--ironsworn-color-input-border);
+	::selection {
+		background: var(--ironsworn-color-clickable-block-bg-hover);
+		color: var(--ironsworn-color-clickable-block-fg-hover);
+	}
+	option,
+	optgroup {
+		font-family: inherit;
+		background: var(--ironsworn-color-input-bg-opaque);
+		color: var(--ironsworn-color-clickable-block-fg);
+
+		&:hover,
+		&:focus,
+		&::selection {
+			background: var(--ironsworn-color-clickable-block-bg-hover);
+			color: var(--ironsworn-color-clickable-block-fg-hover);
+		}
+	}
 }
 
 textarea {

--- a/src/styles/mixins/color.scss
+++ b/src/styles/mixins/color.scss
@@ -41,7 +41,9 @@
 
 	// INPUT
 	--#{$prefix}-input-bg: var(--#{$prefix}-#{$fg-type}-10);
+	--#{$prefix}-input-bg-opaque: var(--#{$prefix}-midtone-10);
 	--#{$prefix}-input-border: var(--#{$prefix}-#{$fg-type}-10);
+	--#{$prefix}-input-border-opaque: var(--#{$prefix}-midtone-10);
 
 	// CLICKABLE TEXT
 	--#{$prefix}-clickable-text: inherit;


### PR DESCRIPTION
Still not consistent across platforms, but it *should* at least be legible with dark themes, now. I've tested this against both Chromium and Firefox on Fedora linux. Some OSs force different styles on browser forms (which I don't really have a way of testing at this time), but I don't think it'll make things *worse*. :shrug: 

The trick is that on some platforms, `<option>`s are overlaid against an opaque white background on some browser/platform combos by default. However, this background doesn't appear to be associated with any particular element.

So, `<option>` was inheriting the select background... but we use 10% transparent colors for inputs, so it was just tinting the white background instead of rendering a dark ground. I've set an opaque background (and provided some CSS variables for the color). `<option>` also inherits `font-family` now.