### PR TITLE
Improve v11 compendium styling with Phosphor colorway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Improve appearance of v11 compendium sidebar and popouts with the "Phosphor" theme
+
 ## 1.21.7
 
 - The system is now officially compatible with v10 and v11 ([#772](https://github.com/ben/foundry-ironsworn/pull/772))

--- a/src/styles/custom-properties.less
+++ b/src/styles/custom-properties.less
@@ -1,4 +1,4 @@
-:root {
+.system-foundry-ironsworn {
 	// typography
 	--ironsworn-word-spacing-sm: 0.02em;
 	--ironsworn-letter-spacing-sm: 0.02em;

--- a/src/styles/fvtt/app.less
+++ b/src/styles/fvtt/app.less
@@ -4,6 +4,11 @@
 .app {
 	border-color: var(--ironsworn-color-midtone-80);
 	background: var(--ironsworn-color-bg-80);
+	&.sidebar-popout {
+		.window-content {
+			color: var(--ironsworn-color-fg);
+		}
+	}
 }
 
 #client-settings {

--- a/src/styles/fvtt/app.scss
+++ b/src/styles/fvtt/app.scss
@@ -3,6 +3,11 @@
 .app {
 	border-color: var(--ironsworn-color-midtone-80);
 	background: var(--ironsworn-color-bg-80);
+	&.sidebar-popout {
+		.window-content {
+			color: var(--ironsworn-color-fg);
+		}
+	}
 }
 
 #client-settings {

--- a/src/styles/fvtt/sidebar.less
+++ b/src/styles/fvtt/sidebar.less
@@ -7,15 +7,6 @@
 		background: var(--ironsworn-color-fg-20);
 	}
 
-	.settings-sidebar,
-	.compendium-sidebar {
-		h2,
-		h3 {
-			border-color: var(--ironsworn-color-midtone-50);
-			background-color: var(--ironsworn-color-light-10);
-		}
-	}
-
 	.combat-sidebar {
 		.combat-tracker-header {
 			a.combat-button {

--- a/src/styles/fvtt/sidebar.scss
+++ b/src/styles/fvtt/sidebar.scss
@@ -8,15 +8,6 @@
 		background: var(--ironsworn-color-fg-20);
 	}
 
-	.settings-sidebar,
-	.compendium-sidebar {
-		h2,
-		h3 {
-			border-color: var(--ironsworn-color-midtone-50);
-			background-color: var(--ironsworn-color-light-10);
-		}
-	}
-
 	.combat-sidebar {
 		.combat-tracker-header {
 			a.combat-button {


### PR DESCRIPTION
The v11 folder sidebar and popout windows for compendia didn't look quite right with Phosphor, so I've adjusted their selectors.