### PR TITLE
Recommend "Dice So Nice" package in system manifest

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 .github/pull_request_template.md
+system/system.json
+system/template.json

--- a/system/system.json
+++ b/system/system.json
@@ -67,7 +67,17 @@
   ],
   "dependencies": [],
   "relationships": {
-    "requires": []
+    "requires": [],
+    "recommends": [
+			{
+				"id": "dice-so-nice",
+				"type": "module",
+				"compatibility": {
+					"verified": "4.6.8"
+				},
+				"reason": "Makes rolling oracles even more fun. 🎲 Make sure you check the 'Enable 3D dice on Roll Tables' option!"
+			}
+		]
   },
   "packs": [
     {


### PR DESCRIPTION
This is basically just to give people a hint to enable `RollTable` animations in DSN's settings, which are disabled by default.

Might be worth including the same information in `README`? It'd be good to have a SSoT for that. by which i mean the build process could look at `system.json` and generates a `README` section from the `relationships` field.