### PR TITLE
organize compendium packs into folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- Organize compendium packs into folders
 - Improve appearance of v11 compendium sidebar and popouts with the "Phosphor" theme
 - Under the hood: refactor all `RollTable`s and oracle rolls to use a single standardized pipeline (with `foundry-ironsworn`-style table roll messages) by default; certain kinds of results will fall back to FVTT-style messages instead.
 - Include most of Starforged's oracle icons in the `foundry-ironsworn/assets` directory -- use them as symbolic tokens, map pins, etc

--- a/system/system.json
+++ b/system/system.json
@@ -79,6 +79,39 @@
 			}
 		]
   },
+  "packFolders": [
+		{
+			"name": "Ironsworn Core Rulebook",
+			"packs": [
+        "ironswornfoes",
+				"foeactorsis",
+				"ironswornoracles",
+				"ironswornmoves",
+				"ironswornassets",
+				"ironswornfoes",
+				"ironswornscenes"
+			]
+		},
+		{
+			"name": "Ironsworn: Delve",
+			"packs": [
+				"ironsworndelvethemes",
+				"ironsworndelvedomains"
+			]
+		},
+		{
+			"name": "Starforged Core Rulebook",
+			"packs": [
+				"foeactorssf",
+				"starforgedencounters",
+				"starforged-sectors",
+				"starforgedassets",
+				"starforgedmoves",
+				"starforgedoracles",
+				"starforgedtruths"
+			]
+		}
+	],
   "packs": [
     {
       "name": "foeactorsis",


### PR DESCRIPTION
The basic idea is 1 top-level folder = 1 sourcebook. Currently, that doesn't *quite* apply for e.g. delve moves and delve oracles, which live with the other Classic moves. I'm working on changing that, but it'll require some link migrations, which will be its own PR. This ought to be fine for now.