### PR TITLE
Complete typings for FVTT v11 `primitives`

### DIFF
--- a/src/types/primitives/array.ts
+++ b/src/types/primitives/array.ts
@@ -1,0 +1,68 @@
+// common/primitives/array.mjs v11.301
+
+type ArrayTestPredicate<T, S extends T> = (
+	value: T,
+	index: number,
+	arr: T[]
+) => value is S
+
+declare global {
+	interface Array<T> {
+		/**
+		 * Flatten nested arrays by concatenating their contents
+		 * @returns - An array containing the concatenated inner values
+		 */
+		deepFlatten<
+			U = T extends Array<infer U> ? ReturnType<U[]['deepFlatten']> : T
+		>(): U[]
+
+		/**
+		 * Test element-wise equality of the values of this array against the values of another array
+		 * @param other - Some other array against which to test equality
+		 * @returns Are the two arrays element-wise equal?
+		 */
+		equals(other: unknown[]): other is this
+
+		/**
+		 * Partition an original array into two children array based on a logical test
+		 * Elements which test as false go into the first result while elements testing as true appear in the second
+		 * @returns An Array of length two whose elements are the partitioned pieces of the original
+		 */
+		partition<S extends T>(rule: (acc: S[], val: T) => val is S): [T[], S[]]
+
+		/**
+		 * Join an Array using a string separator, first filtering out any parts which return a false-y value
+		 * @param sep - The separator string
+		 * @returns The joined string, filtered of any false values
+		 */
+		filterJoin(sep: string): string
+
+		/**
+		 * Find an element within the Array and remove it from the array
+		 * @param find - A function to use as input to findIndex
+		 * @param replace - A replacement for the spliced element
+		 * @returns The replacement element, the removed element, or null if no element was found.
+		 */
+		findSplice<S extends T>(
+			find: ArrayTestPredicate<T, S>,
+			replace: S
+		): S | null
+		findSplice(find: ArrayTestPredicate<T, T>): T | null
+		findSplice<S extends T>(
+			find: ArrayTestPredicate<T, S>,
+			replace?: T
+		): S | T | null
+	}
+	interface ArrayConstructor {
+		/**
+		 * Create and initialize an array of length n with integers from 0 to n-1
+		 * @memberof Array
+		 * @param n - The desired array length
+		 * @param min - A desired minimum number from which the created array starts (default: 0)
+		 * @returns An array of integers from min to min+n
+		 */
+		fromRange(n: number, min?: number): number[]
+	}
+}
+
+export {}

--- a/src/types/primitives/date.ts
+++ b/src/types/primitives/date.ts
@@ -11,12 +11,12 @@ declare global {
 		 * Return a standard YYYY-MM-DD string for the Date instance.
 		 * @returns The date in YYYY-MM-DD format
 		 */
-		toDateInputString(): string
+		toDateInputString(): `${number}-${number}-${number}`
 		/**
 		 * Return a standard H:M:S.Z string for the Date instance.
 		 * @returns The time in H:M:S format
 		 */
-		toTimeInputString(): string
+		toTimeInputString(): `${number}:${number}:${number}.${number}`
 	}
 }
 

--- a/src/types/primitives/date.ts
+++ b/src/types/primitives/date.ts
@@ -1,0 +1,21 @@
+// common/primitives/date.mjs v11.301
+declare global {
+	interface Data {
+		/**
+		 * Test whether a Date instance is valid.
+		 * A valid date returns a number for its timestamp, and NaN otherwise.
+		 * NaN is never equal to itself.
+		 */
+		isValid(): boolean
+		/**
+		 * Return a standard YYYY-MM-DD string for the Date instance.
+		 * @returns The date in YYYY-MM-DD format
+		 */
+		toDateInputString(): string
+		/**
+		 * Return a standard H:M:S.Z string for the Date instance.
+		 * @returns The time in H:M:S format
+		 */
+		toTimeInputString(): string
+	}
+}

--- a/src/types/primitives/date.ts
+++ b/src/types/primitives/date.ts
@@ -1,6 +1,6 @@
 // common/primitives/date.mjs v11.301
 declare global {
-	interface Data {
+	interface Date {
 		/**
 		 * Test whether a Date instance is valid.
 		 * A valid date returns a number for its timestamp, and NaN otherwise.
@@ -19,3 +19,5 @@ declare global {
 		toTimeInputString(): string
 	}
 }
+
+export {}

--- a/src/types/primitives/math.ts
+++ b/src/types/primitives/math.ts
@@ -1,3 +1,4 @@
+// common/primitives/math.mjs
 declare module 'Math' {
 	/**
 	 * Bound a number between some minimum and maximum value, inclusively.

--- a/src/types/primitives/math.ts
+++ b/src/types/primitives/math.ts
@@ -1,4 +1,4 @@
-// common/primitives/math.mjs
+// common/primitives/math.mjs v11.301
 declare module 'Math' {
 	/**
 	 * Bound a number between some minimum and maximum value, inclusively.

--- a/src/types/primitives/math.ts
+++ b/src/types/primitives/math.ts
@@ -16,7 +16,7 @@ declare module 'Math' {
 	 * @param w   A weight between 0 and 1.
 	 * @return    The interpolated value between a and b with weight w.
 	 */
-	export function mix(a: number, b: number, w): number
+	export function mix(a: number, b: number, w: number): number
 
 	/**
 	 * Transform an angle in degrees to be bounded within the domain [0, 360]

--- a/src/types/primitives/math.ts
+++ b/src/types/primitives/math.ts
@@ -1,72 +1,76 @@
 // common/primitives/math.mjs v11.301
-declare module 'Math' {
-	/**
-	 * Bound a number between some minimum and maximum value, inclusively.
-	 * @param num    The current value
-	 * @param min    The minimum allowed value
-	 * @param max    The maximum allowed value
-	 * @return       The clamped number
-	 */
-	export function clamped(num: number, min: number, max: number): number
+declare global {
+	interface Math {
+		/**
+		 * Bound a number between some minimum and maximum value, inclusively.
+		 * @param num    The current value
+		 * @param min    The minimum allowed value
+		 * @param max    The maximum allowed value
+		 * @return       The clamped number
+		 */
+		clamped(num: number, min: number, max: number): number
 
-	/**
-	 * Linear interpolation function
-	 * @param a   An initial value when weight is 0.
-	 * @param b   A terminal value when weight is 1.
-	 * @param w   A weight between 0 and 1.
-	 * @return    The interpolated value between a and b with weight w.
-	 */
-	export function mix(a: number, b: number, w: number): number
+		/**
+		 * Linear interpolation function
+		 * @param a   An initial value when weight is 0.
+		 * @param b   A terminal value when weight is 1.
+		 * @param w   A weight between 0 and 1.
+		 * @return    The interpolated value between a and b with weight w.
+		 */
+		mix(a: number, b: number, w: number): number
 
-	/**
-	 * Transform an angle in degrees to be bounded within the domain [0, 360]
-	 * @param degrees - An angle in degrees
-	 * @param base - The base angle to normalize to, either 0 for [0, 360) or 360 for (0, 360]
-	 * @return The same angle on the range [0, 360) or (0, 360]
-	 */
-	export function normalizeDegrees(degrees: number, base?: number): number
-	/**
-	 * Transform an angle in radians to be bounded within the domain [-PI, PI]
-	 * @param radians  An angle in degrees
-	 * @return         The same angle on the range [-PI, PI]
-	 */
-	export function normalizeRadians(radians: number): number
+		/**
+		 * Transform an angle in degrees to be bounded within the domain [0, 360]
+		 * @param degrees - An angle in degrees
+		 * @param base - The base angle to normalize to, either 0 for [0, 360) or 360 for (0, 360]
+		 * @return The same angle on the range [0, 360) or (0, 360]
+		 */
+		normalizeDegrees(degrees: number, base?: number): number
+		/**
+		 * Transform an angle in radians to be bounded within the domain [-PI, PI]
+		 * @param radians  An angle in degrees
+		 * @return         The same angle on the range [-PI, PI]
+		 */
+		normalizeRadians(radians: number): number
 
-	/**
-	 * Round a floating point number to a certain number of decimal places
-	 * @param number - A floating point number
-	 * @param places - An integer number of decimal places
-	 */
-	export function roundDecimals(number: number, places: number): number
+		/**
+		 * Round a floating point number to a certain number of decimal places
+		 * @param number - A floating point number
+		 * @param places - An integer number of decimal places
+		 */
+		roundDecimals(number: number, places: number): number
 
-	/**
-	 * Transform an angle in radians to a number in degrees
-	 * @param angle - An angle in radians
-	 * @return An angle in degrees
-	 */
-	export function toDegrees(angle: number): number
+		/**
+		 * Transform an angle in radians to a number in degrees
+		 * @param angle - An angle in radians
+		 * @return An angle in degrees
+		 */
+		toDegrees(angle: number): number
 
-	/**
-	 * Transform an angle in degrees to an angle in radians
-	 * @param angle - An angle in degrees
-	 * @return An angle in radians
-	 */
-	export function toRadians(angle: number): number
+		/**
+		 * Transform an angle in degrees to an angle in radians
+		 * @param angle - An angle in degrees
+		 * @return An angle in radians
+		 */
+		toRadians(angle: number): number
 
-	/**
-	 * Get an oscillation between lVal and hVal according to t
-	 * @param minVal - The minimal value of the oscillation.
-	 * @param maxVal - The maximum value of the oscillation.
-	 * @param t - The time value.
-	 * @param p - The period (can't be equal to 0). (default: `1`)
-	 * @param func - The optional math function to use for oscillation. (default: `Math.cos`)
-	 * @return The oscillation according to t.
-	 */
-	export function oscillation(
-		minVal: number,
-		maxVal: number,
-		t: number,
-		p: number,
-		func?: (x: number) => number
-	): number
+		/**
+		 * Get an oscillation between lVal and hVal according to t
+		 * @param minVal - The minimal value of the oscillation.
+		 * @param maxVal - The maximum value of the oscillation.
+		 * @param t - The time value.
+		 * @param p - The period (can't be equal to 0). (default: `1`)
+		 * @param func - The optional math function to use for oscillation. (default: `Math.cos`)
+		 * @return The oscillation according to t.
+		 */
+		oscillation(
+			minVal: number,
+			maxVal: number,
+			t: number,
+			p: number,
+			func?: (x: number) => number
+		): number
+	}
 }
+
+export {}

--- a/src/types/primitives/math.ts
+++ b/src/types/primitives/math.ts
@@ -67,7 +67,7 @@ declare global {
 			minVal: number,
 			maxVal: number,
 			t: number,
-			p: number,
+			p?: number,
 			func?: (x: number) => number
 		): number
 	}

--- a/src/types/primitives/number.ts
+++ b/src/types/primitives/number.ts
@@ -1,0 +1,73 @@
+declare global {
+	interface Number {
+		/**
+		 * Test for near-equivalence of two numbers within some permitted epsilon
+		 * @param n - Some other number
+		 * @param e - Some permitted epsilon, by default 1e-8
+		 * @returns Are the numbers almost equal?
+		 */
+		almostEqual(n: number, e?: number): boolean
+		/**
+		 * A faster numeric between check which avoids type coercion to the Number object.
+		 * Since this avoids coercion, if non-numbers are passed in unpredictable results will occur. Use with caution.
+		 * @param a - The lower-bound
+		 * @param b - The upper-bound
+		 * @param inclusive - Include the bounding values as a true result? (default: true)
+		 * @return Is the number between the two bounds?
+		 */
+		between(a: number, b: number, inclusive?: boolean): boolean
+		/**
+		 * Transform a number to an ordinal string representation. i.e.
+		 * 1 => 1st
+		 * 2 => 2nd
+		 * 3 => 3rd
+		 */
+		ordinalString(): string
+		/**
+		 * Return a string front-padded by zeroes to reach a certain number of numeral characters
+		 * @param digits - The number of characters desired
+		 * @returns The zero-padded number
+		 */
+		paddedString(digits: number): string
+		/**
+		 * Return a string prefaced by the sign of the number (+) or (-)
+		 * @returns The signed number as a string
+		 */
+		signedString(): string
+
+		/**
+		 * Round a number to the nearest number which is a multiple of a given interval
+		 * @param interval - The interval to round the number to the nearest multiple of (default: 1)
+		 * @param method - The rounding method in: round, ceil, floor (default: 'round')
+		 * @returns The rounded number
+		 *
+		 * @example Round a number to the nearest step interval
+		 * ```js
+		 * let n = 17.18;
+		 * n.toNearest(5); // 15
+		 * n.toNearest(10); // 20
+		 * n.toNearest(10, "floor"); // 10
+		 * n.toNearest(10, "ceil"); // 20
+		 * n.toNearest(0.25); // 17.25
+		 * ```
+		 */
+		toNearest(interval?: number, method?: 'round' | 'ceil' | 'floor'): number
+	}
+	interface NumberConstructor {
+		/**
+		 * Test whether a value is numeric.
+		 * This is the highest performing algorithm currently available, per https://jsperf.com/isnan-vs-typeof/5
+		 * @param n - A value to test
+		 * @return Is it a number?
+		 */
+		isNumeric(n: unknown): n is number
+		/**
+		 * Attempt to create a number from a user-provided string.
+		 * @param n - The value to convert; typically a string, but may already be a number.
+		 * @return The number that the string represents, or NaN if no number could be determined.
+		 */
+		fromString(n: string | number): number
+	}
+}
+
+export {}

--- a/src/types/primitives/regexp.ts
+++ b/src/types/primitives/regexp.ts
@@ -1,10 +1,14 @@
 // common/primitives/regexp.mjs v11.301
 
-declare module 'RegExp' {
-	/**
-	 * Escape a given input string, prefacing special characters with backslashes for use in a regular expression
-	 * @param  string     The un-escaped input string
-	 * @returns           The escaped string, suitable for use in regular expression
-	 */
-	export function escape(string: string): string
+declare global {
+	interface RegExpConstructor {
+		/**
+		 * Escape a given input string, prefacing special characters with backslashes for use in a regular expression
+		 * @param  string     The un-escaped input string
+		 * @returns           The escaped string, suitable for use in regular expression
+		 */
+		escape(string: string): string
+	}
 }
+
+export {}

--- a/src/types/primitives/regexp.ts
+++ b/src/types/primitives/regexp.ts
@@ -1,0 +1,10 @@
+// common/primitives/regexp.mjs v11.301
+
+declare module 'RegExp' {
+	/**
+	 * Escape a given input string, prefacing special characters with backslashes for use in a regular expression
+	 * @param  string     The un-escaped input string
+	 * @returns           The escaped string, suitable for use in regular expression
+	 */
+	export function escape(string: string): string
+}

--- a/src/types/primitives/set.ts
+++ b/src/types/primitives/set.ts
@@ -139,4 +139,5 @@ declare global {
 		): boolean
 	}
 }
+
 export {}

--- a/src/types/primitives/set.ts
+++ b/src/types/primitives/set.ts
@@ -1,3 +1,4 @@
+// common/primitives/set.mjs
 declare global {
 	interface Set<T> {
 		/**

--- a/src/types/primitives/set.ts
+++ b/src/types/primitives/set.ts
@@ -1,4 +1,4 @@
-// common/primitives/set.mjs
+// common/primitives/set.mjs v11.301
 declare global {
 	interface Set<T> {
 		/**

--- a/src/types/primitives/set.ts
+++ b/src/types/primitives/set.ts
@@ -10,60 +10,59 @@ declare global {
 	interface Set<T> {
 		/**
 		 * Return the difference of two sets.
-		 * @param {Set} other       Some other set to compare against
-		 * @returns {Set}           The difference defined as objects in this which are not present in other
+		 * @param other - Some other set to compare against
+		 * @returns The difference defined as objects in this which are not present in other
 		 */
 		difference<U>(other: Set<U>): this
 
 		/**
 		 * Return the symmetric difference of two sets.
-		 * @param {Set} other  Another set.
-		 * @returns {Set}      The set of elements that exist in this or other, but not both.
+		 * @param other - Another set.
+		 * @returns The set of elements that exist in this or other, but not both.
 		 */
 		symmetricDifference<U>(other: Set<U>): Set<U | T>
 
 		/**
 		 * Test whether this set is equal to some other set.
 		 * Sets are equal if they share the same members, independent of order
-		 * @param {Set} other       Some other set to compare against
-		 * @returns {boolean}       Are the sets equal?
+		 * @param other - Some other set to compare against
+		 * @returns Are the sets equal?
 		 */
-		equals<U>(other: Set<U>): boolean
+		equals<U>(other: Set<U>): this is typeof other
 
 		/**
 		 * Return the first value from the set.
-		 * @returns {*}             The first element in the set, or undefined
+		 * @returns The first element in the set, or undefined
 		 */
 		first(): T | undefined
 
 		/**
 		 * Return the intersection of two sets.
-		 * @param {Set} other       Some other set to compare against
-		 * @returns {Set}           The intersection of both sets
+		 * @param other - Some other set to compare against
+		 * @returns The intersection of both sets
 		 */
 		intersection<U>(other: Set<U>): Set<T & U>
 
 		/**
 		 * Test whether this set has an intersection with another set.
-		 * @param {Set} other       Another set to compare against
-		 * @returns {boolean}       Do the sets intersect?
+		 * @param other Another set to compare against
+		 * @returns Do the sets intersect?
 		 */
-		intersects<U>(other: Set<U>): boolean
+		intersects<U>(other: Set<U>): this is Set<T | U>
 
 		/**
 		 * Return the union of two sets.
-		 * @param {Set} other  The other set.
-		 * @returns {Set}
+		 * @param other - The other set.
 		 */
 		union<U>(other: Set<U>): Set<U | T>
 
 		/**
 		 * Test whether this set is a subset of some other set.
 		 * A set is a subset if all its members are also present in the other set.
-		 * @param {Set} other       Some other set that may be a subset of this one
-		 * @returns {boolean}       Is the other set a subset of this one?
+		 * @param other - Some other set that may be a subset of this one
+		 * @returns Is the other set a subset of this one?
 		 */
-		isSubset<U>(other: Set<U>): boolean
+		isSubset<U>(other: Set<U>): this is Set<U>
 
 		/**
 		 * Convert a set to a JSON object by mapping its contents to an array
@@ -74,11 +73,11 @@ declare global {
 		/**
 		 * Test whether every element in this Set satisfies a certain test criterion.
 		 * @see Array#every
-		 * @param {function(*,number,Set): boolean} test   The test criterion to apply. Positional arguments are the value,
+		 * @param test - The test criterion to apply. Positional arguments are the value,
 		 * the index of iteration, and the set being tested.
-		 * @returns {boolean}  Does every element in the set satisfy the test criterion?
+		 * @returns Does every element in the set satisfy the test criterion?
 		 */
-		every(test: (item: T, index: number, set: this) => boolean): boolean
+		every<S extends T>(test: SetTestPredicate<T, S>): this is Set<S>
 
 		/**
 		 * Filter this set to create a subset of elements which satisfy a certain test criterion.
@@ -112,10 +111,11 @@ declare global {
 		/**
 		 * Create a new Set with elements that are filtered and transformed by a provided reducer function.
 		 * @see Array#reduce
-		 * @param reducer  A reducer function applied to each value. Positional arguments are the accumulator, the value, the index of iteration, and the set being reduced.
-		 * @param accumulator The initial value of the returned accumulator.
+		 * @param reducer - A reducer function applied to each value. Positional arguments are the accumulator, the value, the index of iteration, and the set being reduced.
+		 * @param accumulator - The initial value of the returned accumulator.
 		 * @returns The final value of the accumulator.
 		 */
+
 		reduce(
 			reducer: (
 				previousValue: T,
@@ -131,19 +131,28 @@ declare global {
 				currentIndex: number,
 				set: Set<T>
 			) => T,
-			accumulator: T
+			accumulator?: T
 		): T
+		reduce<S extends T>(
+			reducer: (
+				previousValue: T,
+				currentValue: T,
+				currentIndex: number,
+				set: Set<T>
+			) => Partial<S> | S,
+			accumulator?: Partial<S> | S
+		): S
 
 		/**
 		 * Test whether any element in this Set satisfies a certain test criterion.
 		 * @see Array#some
-		 * @param test The test criterion to apply. Positional arguments are the value, the index of iteration, and the set being tested.
+		 * @param test - The test criterion to apply. Positional arguments are the value, the index of iteration, and the set being tested.
 		 * @returns Does any element in the set satisfy the test criterion?
 		 */
-		some(
-			test: (value: T, index: number, array: Set<T>) => unknown,
+		some<S extends T>(
+			test: SetTestPredicate<T, S>,
 			thisArg?: any
-		): boolean
+		): this is Set<T | S>
 	}
 }
 

--- a/src/types/primitives/set.ts
+++ b/src/types/primitives/set.ts
@@ -1,4 +1,11 @@
 // common/primitives/set.mjs v11.301
+
+type SetTestPredicate<T, S extends T> = (
+	value: T,
+	index: number,
+	set: Set<T>
+) => value is S
+
 declare global {
 	interface Set<T> {
 		/**
@@ -76,20 +83,19 @@ declare global {
 		/**
 		 * Filter this set to create a subset of elements which satisfy a certain test criterion.
 		 * @see Array#filter
-		 * @param {function(*,number,Set): boolean} test  The test criterion to apply. Positional arguments are the value,
-		 * the index of iteration, and the set being filtered.
-		 * @returns {Set}  A new Set containing only elements which satisfy the test criterion.
+		 * @param test - The test criterion to apply. Positional arguments are the value, the index of iteration, and the set being filtered.
+		 * @returns A new Set containing only elements which satisfy the test criterion.
 		 */
-		filter(test: (item: T, index: number, set: this) => boolean): Set<T>
+		filter<S extends T>(test: SetTestPredicate<T, S>): Set<S>
 
 		/**
 		 * Find the first element in this set which satisfies a certain test criterion.
 		 * @see Array#find
-		 * @param {function(*,number,Set): boolean} test  The test criterion to apply. Positional arguments are the value,
+		 * @param test - The test criterion to apply. Positional arguments are the value,
 		 * the index of iteration, and the set being searched.
-		 * @returns {*|undefined}  The first element in the set which satisfies the test criterion, or undefined.
+		 * @returns The first element in the set which satisfies the test criterion, or undefined.
 		 */
-		find(test: (item: T, index: number, set: this) => boolean): T | undefined
+		find<S extends T>(test: SetTestPredicate<T, S>): S | undefined
 
 		/**
 		 * Create a new Set where every element is modified by a provided transformation function.
@@ -98,15 +104,17 @@ declare global {
 		 * the value, the index of iteration, and the set being transformed.
 		 * @returns A new Set of equal size containing transformed elements.
 		 */
-		map<U>(transform: (item: T, index: number, set: this) => U): Set<U>
+		map<U>(
+			transform: (value: T, index: number, set: Set<T>) => U,
+			thisArg?: any
+		): Set<U>
 
 		/**
 		 * Create a new Set with elements that are filtered and transformed by a provided reducer function.
 		 * @see Array#reduce
-		 * @param {function(*,*,number,Set): *} reducer  A reducer function applied to each value. Positional
-		 * arguments are the accumulator, the value, the index of iteration, and the set being reduced.
-		 * @param {*} accumulator       The initial value of the returned accumulator.
-		 * @returns {*}                 The final value of the accumulator.
+		 * @param reducer  A reducer function applied to each value. Positional arguments are the accumulator, the value, the index of iteration, and the set being reduced.
+		 * @param accumulator The initial value of the returned accumulator.
+		 * @returns The final value of the accumulator.
 		 */
 		reduce(
 			reducer: (
@@ -129,12 +137,11 @@ declare global {
 		/**
 		 * Test whether any element in this Set satisfies a certain test criterion.
 		 * @see Array#some
-		 * @param test   The test criterion to apply. Positional arguments are the value,
-		 * the index of iteration, and the set being tested.
-		 * @returns     Does any element in the set satisfy the test criterion?
+		 * @param test The test criterion to apply. Positional arguments are the value, the index of iteration, and the set being tested.
+		 * @returns Does any element in the set satisfy the test criterion?
 		 */
 		some(
-			test: (value: T, index: number, set: this) => unknown,
+			test: (value: T, index: number, array: Set<T>) => unknown,
 			thisArg?: any
 		): boolean
 	}

--- a/src/types/primitives/string.ts
+++ b/src/types/primitives/string.ts
@@ -1,0 +1,27 @@
+// from common/primitives/string.mjs
+declare global {
+	interface String {
+		/**
+		 * Capitalize a string, transforming it's first character to a capital letter.
+		 */
+		capitalize(): string
+		/**
+		 * Convert a string to Title Case where the first letter of each word is capitalized.
+		 */
+		titleCase(): string
+		/**
+		 * Strip any script tags which were included within a provided string.
+		 */
+		stripScripts(): string
+		/**
+		 * Transform any string into an url-viable slug string
+		 * @param options      Optional arguments which customize how the slugify operation is performed
+		 * @param replacement  The replacement character to separate terms, default is '-'
+		 * @param strict    Replace all non-alphanumeric characters, or allow them? Default false
+		 * @returns               The slugified input string
+		 */
+		slugify(options?: { replacement?: string; strict?: boolean }): string
+	}
+}
+
+export {}

--- a/src/types/primitives/string.ts
+++ b/src/types/primitives/string.ts
@@ -1,4 +1,4 @@
-// from common/primitives/string.mjs
+// from common/primitives/string.mjs v11.301
 declare global {
 	interface String {
 		/**

--- a/src/types/primitives/url.ts
+++ b/src/types/primitives/url.ts
@@ -1,0 +1,10 @@
+// common/primitives/url.mjs v11.301
+
+declare module 'URL' {
+	/**
+	 * Attempt to parse a URL without throwing an error.
+	 * @param  url  The string to parse.
+	 * @returns  The parsed URL if successful, otherwise null.
+	 */
+	export function parseSafe(url: string): URL | null
+}

--- a/src/types/primitives/url.ts
+++ b/src/types/primitives/url.ts
@@ -1,10 +1,14 @@
 // common/primitives/url.mjs v11.301
 
-declare module 'URL' {
-	/**
-	 * Attempt to parse a URL without throwing an error.
-	 * @param  url  The string to parse.
-	 * @returns  The parsed URL if successful, otherwise null.
-	 */
-	export function parseSafe(url: string): URL | null
+declare global {
+	interface URL {
+		/**
+		 * Attempt to parse a URL without throwing an error.
+		 * @param  url  The string to parse.
+		 * @returns  The parsed URL if successful, otherwise null.
+		 */
+		parseSafe(url: string): URL | null
+	}
 }
+
+export {}


### PR DESCRIPTION
These are global declarations, so we can easily take advantage of the added methods. Some, like `Array#fromRange` and `Math.clamped` can probably replace certain lodash utilities. The LoFD types packages covers many of these, but only for v9. In addition to bringing them up to date with v11, my version attempts to be a bit more assertive about typeguarding.

Gonna merge this once it passes CI since it doesn't add any runtime code.