### PR TITLE
Prefer FVTT builtin `String#capitalize`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -55,7 +55,18 @@ module.exports = {
 					{
 						name: 'lodash-es',
 						importNames: ['clamp'],
-						message: "Please use FVTT's Math.clamped instead."
+						message: 'Please use FVTT Math.clamped instead.'
+					},
+					{
+						name: 'lodash-es',
+						importNames: ['capitalize'],
+						message: 'Please use FVTT String#capitalize instead.'
+					},
+					{
+						name: 'lodash-es',
+						importNames: ['range'],
+						message:
+							'Please use FVTT Array#fromRange instead, where possible. Note that Array#fromRange orders its parameters differently, and its maximum is inclusive rather than exclusive.'
 					}
 				]
 			}

--- a/src/module/features/chat-alert.ts
+++ b/src/module/features/chat-alert.ts
@@ -1,5 +1,5 @@
 import type { ChatMessageDataConstructorData } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/chatMessageData'
-import { capitalize, compact, get } from 'lodash-es'
+import { compact, get } from 'lodash-es'
 import type { DocumentSubTypes } from '../../types/helperTypes'
 import type { IronswornActor } from '../actor/actor'
 import { IronswornSettings } from '../helpers/settings'
@@ -147,7 +147,9 @@ const ACTOR_TYPE_HANDLERS: ActorTypeHandlers = {
 			if (newValue !== undefined) {
 				const oldValue = get(actor.system, resource).value
 				const signPrefix = newValue > oldValue ? '+' : ''
-				const i18nStat = game.i18n.localize(`IRONSWORN.${capitalize(resource)}`)
+				const i18nStat = game.i18n.localize(
+					`IRONSWORN.${resource.capitalize()}`
+				)
 				return game.i18n.format('IRONSWORN.ChatAlert.AdjustedStat', {
 					amt: `${signPrefix}${newValue - oldValue}`,
 					stat: i18nStat,
@@ -184,7 +186,7 @@ const ACTOR_TYPE_HANDLERS: ActorTypeHandlers = {
 				const i18nDebility = `<b class='term ${conditionType}'>${
 					debility.startsWith('custom')
 						? get(actor.system.debility, `${debility}name`)
-						: game.i18n.localize(`${i18nPath}.${capitalize(debility)}`)
+						: game.i18n.localize(`${i18nPath}.${debility.capitalize()}`)
 				}</b>`
 
 				const params = gameIsStarforged
@@ -193,11 +195,11 @@ const ACTOR_TYPE_HANDLERS: ActorTypeHandlers = {
 
 				if (newValue)
 					return game.i18n.format(
-						`IRONSWORN.ChatAlert.Marked${capitalize(conditionType)}`,
+						`IRONSWORN.ChatAlert.Marked${conditionType.capitalize()}`,
 						params
 					)
 				return game.i18n.format(
-					`IRONSWORN.ChatAlert.Cleared${capitalize(conditionType)}`,
+					`IRONSWORN.ChatAlert.Cleared${conditionType.capitalize()}`,
 					params
 				)
 			}
@@ -230,7 +232,7 @@ const ACTOR_TYPE_HANDLERS: ActorTypeHandlers = {
 				const oldValue = actor.system.debility[impact]
 				if (oldValue === newValue) continue
 				const i18nImpact = game.i18n.localize(
-					`IRONSWORN.IMPACT.${capitalize(impact)}`
+					`IRONSWORN.IMPACT.${impact.capitalize()}`
 				)
 				const params = { impact: `<b class'term impact'>${i18nImpact}</b>` }
 				// TODO: use "impact" if this is an SF character

--- a/src/module/features/customassets.ts
+++ b/src/module/features/customassets.ts
@@ -1,5 +1,4 @@
 import type { IAsset, IAssetType } from 'dataforged'
-import { capitalize } from 'vue'
 import { renderLinksInStr, hashLookup } from '../dataforged'
 import { ISAssetTypes, SFAssetTypes } from '../dataforged/data'
 import type { IronswornItem } from '../item/item'
@@ -58,7 +57,7 @@ async function compendiumMoves(
 	if (pack == null) throw new Error(`can't load pack ${compendiumName}`)
 
 	const i18n = (categoryName: string, extension: string) => {
-		const capCat = capitalize(categoryName)
+		const capCat = categoryName.capitalize()
 		return game.i18n.localize(
 			`IRONSWORN.Asset Categories.${i18nkeyslug}.${capCat}.${extension}`
 		)

--- a/src/module/fields/ChallengeRankField.ts
+++ b/src/module/fields/ChallengeRankField.ts
@@ -1,5 +1,4 @@
 import { ChallengeRank } from '../constants'
-import { capitalize } from '../helpers/util'
 import { enumEntries } from '../fields/utils'
 
 export class ChallengeRankField extends foundry.data.fields.NumberField {
@@ -36,7 +35,9 @@ export class ChallengeRankField extends foundry.data.fields.NumberField {
 			// migration: string-based challenge ranks to numeric ones
 			// TODO: use this instead of migration #5
 			case typeof value === 'string':
-				return ChallengeRank[capitalize(value as string) as keyof ChallengeRank]
+				return ChallengeRank[
+					(value as string).capitalize() as keyof ChallengeRank
+				]
 			default: {
 				return super._cast(value)
 			}

--- a/src/module/helpers/handlebars.ts
+++ b/src/module/helpers/handlebars.ts
@@ -1,5 +1,4 @@
 import { range, sum } from 'lodash-es'
-import { capitalize } from './util'
 import { marked } from 'marked'
 import {
 	ACTION_DICE_ROLLED,
@@ -56,12 +55,12 @@ export class IronswornHandlebarsHelpers {
 	static registerHelpers() {
 		Handlebars.registerHelper('concat', (...args) => args.slice(0, -1).join(''))
 
-		Handlebars.registerHelper('sum', (a, b) => a + b)
-		Handlebars.registerHelper('capitalize', localeCapitalize)
+		Handlebars.registerHelper('sum', (a: number, b: number) => a + b)
+		Handlebars.registerHelper('capitalize', (str: string) => str.capitalize())
 		Handlebars.registerHelper('formatRollPlusStat', formatRollPlusStat)
 		Handlebars.registerHelper('formatRollMethod', formatRollMethod)
 		Handlebars.registerHelper('computeOutcomeText', computeOutcomeText)
-		Handlebars.registerHelper('lowercase', (str) => str.toLowerCase())
+		Handlebars.registerHelper('lowercase', (str: string) => str.toLowerCase())
 
 		Handlebars.registerHelper('json', function (context) {
 			return JSON.stringify(context, null, 2)

--- a/src/module/helpers/util.ts
+++ b/src/module/helpers/util.ts
@@ -1,10 +1,5 @@
 import { ChallengeRank } from '../constants'
 
-export function capitalize(txt: string) {
-	const [first, ...rest] = txt
-	return `${first.toUpperCase()}${rest.join('')}`
-}
-
 /**
  * @returns A localized string label for the challenge rank.
  */

--- a/src/module/rolls/ironsworn-roll-message.ts
+++ b/src/module/rolls/ironsworn-roll-message.ts
@@ -1,11 +1,5 @@
 import type { IOutcomeInfo, RollMethod } from 'dataforged'
-import {
-	capitalize,
-	compact,
-	fromPairs,
-	isUndefined,
-	kebabCase
-} from 'lodash-es'
+import { compact, fromPairs, isUndefined, kebabCase } from 'lodash-es'
 import { IronswornRoll } from '.'
 import { IronswornActor } from '../actor/actor'
 import { IronswornItem } from '../item/item'
@@ -53,7 +47,7 @@ export function formatRollMethod(rollMethod: RollMethod, stats: string[]) {
 	}
 	// canonical triggers have 2 stats; there's a good chance a nice string already exists, so we check for that first.
 	const localizedStats = stats.map((stat) =>
-		game.i18n.localize('IRONSWORN.' + capitalize(stat))
+		game.i18n.localize('IRONSWORN.' + stat.capitalize())
 	)
 	const methodKeyRoot = `IRONSWORN.roll method.${rollMethod}`
 	const possibleNiceKey = `${methodKeyRoot}.${stats.length}`
@@ -236,7 +230,7 @@ export class IronswornRollMessage {
 			return { title: `${move.name} +${stat.source}` }
 		}
 		let localizedStat = game.i18n.localize(
-			'IRONSWORN.' + capitalize(stat.source)
+			'IRONSWORN.' + stat.source.capitalize()
 		)
 		if (localizedStat.startsWith('IRONSWORN.')) localizedStat = stat.source
 		return {

--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -6,7 +6,7 @@ import type {
 	RollType,
 	Stat
 } from 'dataforged'
-import { capitalize, cloneDeep, maxBy, minBy, sortBy } from 'lodash-es'
+import { cloneDeep, maxBy, minBy, sortBy } from 'lodash-es'
 import { IronswornActor } from '../actor/actor'
 import { getFoundryMoveByDfId } from '../dataforged'
 import { IronswornItem } from '../item/item'
@@ -401,13 +401,13 @@ export class IronswornPrerollDialog extends Dialog<
 		const buttons = {}
 		const addButton = (i: number, mode: RollMethod, stats: string[]) => {
 			const localizedStats = stats.map((s) =>
-				game.i18n.localize(`IRONSWORN.${capitalize(s)}`)
+				game.i18n.localize(`IRONSWORN.${s.capitalize()}`)
 			)
 
 			let label = localizedStats[0]
 			if (mode !== 'Any') {
 				label = game.i18n.format(
-					`IRONSWORN.PreRollMethod.${capitalize(mode)}`,
+					`IRONSWORN.PreRollMethod.${mode.capitalize()}`,
 					{
 						statList: localizedStats.join(', ')
 					}

--- a/src/module/vue/components/attr-box.vue
+++ b/src/module/vue/components/attr-box.vue
@@ -19,7 +19,7 @@
 
 <script lang="ts" setup>
 import type { Ref } from 'vue'
-import { inject, computed, capitalize } from 'vue'
+import { inject, computed } from 'vue'
 import type { IronswornActor } from '../../actor/actor'
 import { IronswornPrerollDialog } from '../../rolls'
 import { formatRollPlusStat } from '../../rolls/ironsworn-roll-message'
@@ -36,7 +36,7 @@ const classes = computed(() => ({
 	clickable: !editMode.value,
 	'isiconbg-d10-tilt': !editMode.value
 }))
-const i18nKey = computed(() => `IRONSWORN.${capitalize(props.attr)}`)
+const i18nKey = computed(() => `IRONSWORN.${props.attr.capitalize()}`)
 const editMode = computed(
 	() => !!(actor.value.flags as any)['foundry-ironsworn']?.['edit-mode']
 )

--- a/src/module/vue/components/buttons/iron-btn.vue
+++ b/src/module/vue/components/buttons/iron-btn.vue
@@ -8,7 +8,7 @@
 			[$style.iconOnly]: !hasText,
 			[$style.block]: block,
 			[$style.noBlock]: !block,
-			[$style[`flex${capitalize(justify)}`]]: true,
+			[$style[`flex${justify.capitalize()}`]]: true,
 			nogrow
 		}"
 		type="button"
@@ -36,7 +36,6 @@
 	</button>
 </template>
 <script setup lang="ts">
-import { capitalize } from 'lodash-es'
 import { computed, onMounted, ref, useCssModule, useSlots } from 'vue'
 import FontIcon from '../icon/font-icon.vue'
 import type { IconId } from '../icon/icon-common'

--- a/src/module/vue/components/compact-character-sheet-button.vue
+++ b/src/module/vue/components/compact-character-sheet-button.vue
@@ -22,7 +22,7 @@
 
 <script setup lang="ts">
 import type { Ref } from 'vue'
-import { capitalize, computed, inject } from 'vue'
+import { computed, inject } from 'vue'
 import type { IronswornActor } from '../../actor/actor'
 import { IronswornPrerollDialog } from '../../rolls'
 import { $ActorKey, ActorKey } from '../provisions'
@@ -34,7 +34,7 @@ const props = defineProps<{
 }>()
 
 const isMomentum = props.propKey === 'momentum'
-const i18nKey = `IRONSWORN.${capitalize(props.propKey)}`
+const i18nKey = `IRONSWORN.${props.propKey.capitalize()}`
 const i18nStat = game.i18n.localize(i18nKey)
 const tooltip = computed(() =>
 	isMomentum

--- a/src/module/vue/components/impact/impact-category.vue
+++ b/src/module/vue/components/impact/impact-category.vue
@@ -17,7 +17,6 @@
 <script lang="ts" setup>
 import type { Ref } from 'vue'
 import { computed, inject } from 'vue'
-import { capitalize } from '../../../helpers/util'
 import { ActorKey } from '../../provisions'
 import ImpactCheckbox from './impact-checkbox.vue'
 
@@ -37,7 +36,7 @@ const actor = inject(ActorKey) as Ref
 
 const label = computed(() =>
 	game.i18n.localize(
-		`IRONSWORN.${props.type.toUpperCase()}.CATEGORY.${capitalize(props.name)}`
+		`IRONSWORN.${props.type.toUpperCase()}.CATEGORY.${props.name.capitalize()}`
 	)
 )
 

--- a/src/module/vue/components/impact/impact-checkbox.vue
+++ b/src/module/vue/components/impact/impact-checkbox.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, capitalize, inject, nextTick, reactive } from 'vue'
+import { computed, inject, nextTick, reactive } from 'vue'
 import type { Ref } from 'vue'
 import { actorsOrAssetsWithConditionEnabled } from '../../../helpers/globalConditions'
 import { IronswornSettings } from '../../../helpers/settings'
@@ -97,7 +97,7 @@ CONFIG.IRONSWORN.emitter.on('globalConditionChanged', ({ name }) => {
 
 const label = computed(() =>
 	game.i18n.localize(
-		`IRONSWORN.${props.type.toUpperCase()}.${capitalize(props.name)}`
+		`IRONSWORN.${props.type.toUpperCase()}.${props.name.capitalize()}`
 	)
 )
 function refreshGlobalHint() {
@@ -120,14 +120,14 @@ function refreshGlobalHint() {
 	} else if (names.length == 1) {
 		// Condition only set on one other actor
 		state.hintText = game.i18n.format('IRONSWORN.ConditionMarkedOnOne', {
-			condition: capitalize(label.value),
+			condition: label.value.capitalize(),
 			name: names[0]
 		})
 	} else {
 		// This condition is marked on several other actors, display them as a list
 		state.hintText = `
     <p>${game.i18n.format('IRONSWORN.ConditionMarkedOnMany', {
-			condition: capitalize(label.value)
+			condition: label.value.capitalize()
 		})}</p>
     <ul>
       ${names.map((x) => `<li>${x}</li>`).join('\n')}

--- a/src/module/vue/components/legacy-track.vue
+++ b/src/module/vue/components/legacy-track.vue
@@ -1,7 +1,7 @@
 <template>
 	<article ref="legacyTrack" class="legacy-track flexcol" :data-legacy="legacy">
 		<h4 class="legacy-track-title">
-			{{ $t(`IRONSWORN.LEGACY.${capitalize(legacy)}`) }}
+			{{ $t(`IRONSWORN.LEGACY.${legacy.capitalize()}`) }}
 		</h4>
 
 		<section class="legacy-track-controls flexrow" data-tooltip-direction="UP">
@@ -42,7 +42,7 @@ import type { Ref } from 'vue'
 import { computed, inject } from 'vue'
 import { $ActorKey, ActorKey } from '../provisions'
 import IronBtn from './buttons/iron-btn.vue'
-import { capitalize, clamp } from 'lodash-es'
+import { clamp } from 'lodash-es'
 import XpTrack from './xp-track.vue'
 import ProgressTrack from './progress/progress-track.vue'
 
@@ -94,7 +94,7 @@ const xpSpent = computed(
 
 const markTooltip = computed(() => {
 	let legacy = game.i18n.localize(
-		`IRONSWORN.LEGACY.${capitalize(props.legacy)}`
+		`IRONSWORN.LEGACY.${props.legacy.capitalize()}`
 	)
 	let amount = game.i18n.localize(`IRONSWORN.PROGRESS.TICK.1`)
 	return game.i18n.format(`IRONSWORN.MarkLegacy`, { amount, legacy })

--- a/src/module/vue/components/progress/progress-controls.vue
+++ b/src/module/vue/components/progress/progress-controls.vue
@@ -20,7 +20,7 @@
 	</div>
 </template>
 <script setup lang="ts">
-import { capitalize, inject } from 'vue'
+import { inject } from 'vue'
 import { $ActorKey } from '../../provisions'
 import IronBtn from 'component:buttons/iron-btn.vue'
 import BtnCompendium from 'component:buttons/btn-compendium.vue'
@@ -31,7 +31,7 @@ const $actor = inject($ActorKey)
 
 async function addProgressItem(subtype) {
 	const itemData = {
-		name: capitalize(subtype),
+		name: subtype.capitalize(),
 		type: 'progress',
 		data: { subtype },
 		sort: 9000000

--- a/src/module/vue/components/progress/progress-list-item.vue
+++ b/src/module/vue/components/progress/progress-list-item.vue
@@ -81,7 +81,7 @@
 </template>
 
 <script lang="ts" setup>
-import { capitalize, computed, inject, provide } from 'vue'
+import { computed, inject, provide } from 'vue'
 import { $ActorKey, $ItemKey, ActorKey, ItemKey } from '../../provisions'
 import Clock from '../clock.vue'
 import BtnRollprogress from '../buttons/btn-rollprogress.vue'
@@ -116,7 +116,7 @@ const editMode = computed(() => {
 	return (actor?.value.flags as any)['foundry-ironsworn']?.['edit-mode']
 })
 const subtitle = computed(() => {
-	let subtype = capitalize(props.item.system.subtype)
+	let subtype = props.item.system.subtype.capitalize()
 	if (subtype === 'Bond') subtype = 'Connection' // translate name
 	return game.i18n.localize(`IRONSWORN.ITEM.Subtype${subtype}`)
 })

--- a/src/module/vue/sf-locationsheet.vue
+++ b/src/module/vue/sf-locationsheet.vue
@@ -137,7 +137,7 @@
 
 <script setup lang="ts">
 import SheetHeaderBasic from './sheet-header-basic.vue'
-import { camelCase, capitalize, flatten, sample } from 'lodash-es'
+import { camelCase, flatten, sample } from 'lodash-es'
 import { provide, computed, reactive, inject } from 'vue'
 import { $ActorKey, ActorKey } from './provisions'
 
@@ -165,7 +165,7 @@ const state = reactive({
 
 function randomImage(subtype, klass): string | void {
 	if (subtype === 'planet') {
-		const name = capitalize(klass)
+		const name = klass.capitalize()
 		const i = Math.floor(Math.random() * 2) + 1
 		return `systems/foundry-ironsworn/assets/planets/Starforged-Planet-Token-${name}-0${i}.webp`
 	}
@@ -276,9 +276,9 @@ const oracles = computed((): OracleSpec[][] => {
 	const { subtype, klass } = props.data.actor.system
 	const kc = klass
 		?.split(' ')
-		.map((x) => capitalize(x))
+		.map((x) => x.capitalize())
 		.join(' ')
-	const rc = capitalize(state.region)
+	const rc = state.region.capitalize()
 	switch (subtype) {
 		case 'planet':
 			return [
@@ -488,7 +488,7 @@ const canRandomizeName = computed(() => {
 	const { subtype, klass } = props.data.actor.system
 
 	if (subtype === 'planet') {
-		const kc = capitalize(klass ?? '')
+		const kc = (klass ?? '').capitalize()
 		const json = OracleTable.getDFOracleByDfId(
 			`Starforged/Oracles/Planets/${kc}`
 		)
@@ -505,7 +505,7 @@ const firstLookWillRandomizeName = computed(() => {
 	// No klass? We only randomize names for settlements and planets
 	if (!klass) return ['settlement', 'planet'].includes(subtype)
 
-	const i18nKey = `ACTOR.Subtype${capitalize(subtype)}`
+	const i18nKey = `ACTOR.Subtype${subtype.capitalize()}`
 	const newThingName = game.i18n.format('DOCUMENT.New', {
 		type: game.i18n.localize(`IRONSWORN.${i18nKey}`)
 	})
@@ -516,12 +516,12 @@ const firstLookWillRandomizeName = computed(() => {
 
 const randomKlassTooltip = computed(() => {
 	const { subtype } = props.data.actor.system
-	return game.i18n.localize(`IRONSWORN.Random${capitalize(subtype)}Type`)
+	return game.i18n.localize(`IRONSWORN.Random${subtype.capitalize()}Type`)
 })
 
 const subtypeSelectText = computed(() => {
 	const { subtype } = props.data.actor.system
-	return game.i18n.localize(`IRONSWORN.${capitalize(subtype)}Type`)
+	return game.i18n.localize(`IRONSWORN.${subtype.capitalize()}Type`)
 })
 
 const klassIsNotValid = computed(() => {
@@ -584,7 +584,7 @@ async function randomizeName() {
 	const { subtype, klass } = props.data.actor.system
 	let name
 	if (subtype === 'planet') {
-		const kc = capitalize(klass ?? '')
+		const kc = (klass ?? '').capitalize()
 		const json = await OracleTable.getDFOracleByDfId(
 			`Starforged/Oracles/Planets/${kc}`
 		)

--- a/src/module/vue/vue-plugin.ts
+++ b/src/module/vue/vue-plugin.ts
@@ -1,6 +1,5 @@
 import { marked } from 'marked'
 import type { Plugin } from 'vue'
-import { capitalize } from '../helpers/util'
 import { formatRollPlusStat } from '../rolls/ironsworn-roll-message.js'
 import { $EnrichHtmlKey, $EnrichMarkdownKey } from './provisions'
 
@@ -11,7 +10,6 @@ declare module '@vue/runtime-core' {
 		 * With a `data` parameter: shortcut for {@link game.i18n.format}.
 		 */
 		$t: (stringId: string, data?: Record<string, unknown>) => string
-		$capitalize: (string) => string
 		$concat: (...args: any[]) => string
 		$enrichMarkdown: (string) => string
 		$enrichHtml: (string) => string
@@ -47,7 +45,6 @@ export const IronswornVuePlugin: Plugin = {
 				? game.i18n.format(stringId, data)
 				: game.i18n.localize(stringId)
 		app.config.globalProperties.$concat = (...args) => args.join('')
-		app.config.globalProperties.$capitalize = capitalize
 		app.config.globalProperties.$enrichHtml = enrichHtml
 		app.provide($EnrichHtmlKey, enrichHtml)
 


### PR DESCRIPTION
We have a few different ways of doing this internally, but FVTT has a method for this on the string prototype. Might as well use their version to avoid some redundant code.

Also adds some complementary eslint rules, to provide hints when importing certain similar `lodash-es` functions.

This isn't an especially complicated change, and the locale strings appeared to be fine when I tested. I'm going to go ahead and merge this once it passes CI.