### PR TITLE
Common document delete dialog + button, button prop type fixes

### DIFF
--- a/src/module/actor/actor.ts
+++ b/src/module/actor/actor.ts
@@ -1,6 +1,7 @@
 import type { ConfiguredData } from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes'
 import type { DocumentSubTypes } from '../../types/helperTypes'
 import { CreateActorDialog } from '../applications/createActorDialog'
+import { typedDeleteDialog } from '../helpers/util'
 import type { IronswornItem } from '../item/item'
 import type { ActorDataProperties } from './config'
 import type { SFCharacterMoveSheet } from './sheets/sf-charactermovesheet'
@@ -72,6 +73,10 @@ export class IronswornActor<
 			'ironsworn.StarforgedCharacterSheet'
 			? 'starforged'
 			: 'ironsworn'
+	}
+
+	override async deleteDialog(options?: Partial<DialogOptions>) {
+		return await typedDeleteDialog(this, options)
 	}
 }
 export interface IronswornActor<T extends DocumentSubTypes<'Actor'> = any>

--- a/src/module/helpers/util.ts
+++ b/src/module/helpers/util.ts
@@ -12,7 +12,7 @@ export function localizeRank(rank: ChallengeRank | keyof typeof ChallengeRank) {
 
 /**
  * @remarks A document-subtype-sensitive replacement for the FVTT document deletion dialog.
- * @see {@link ClientDocumentMixin.deleteDialog}
+ * @see {@link ClientDocumentMixin#deleteDialog}
  */
 export async function typedDeleteDialog<
 	T extends foundry.abstract.Document<any, any, Metadata<any>> & {

--- a/src/module/helpers/util.ts
+++ b/src/module/helpers/util.ts
@@ -1,4 +1,6 @@
 import { ChallengeRank } from '../constants'
+import type { Metadata } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/abstract/document.mjs'
+import type { KeysWithValuesOfType } from 'dataforged'
 
 /**
  * @returns A localized string label for the challenge rank.
@@ -6,4 +8,39 @@ import { ChallengeRank } from '../constants'
 export function localizeRank(rank: ChallengeRank | keyof typeof ChallengeRank) {
 	const key = typeof rank === 'string' ? rank : ChallengeRank[rank]
 	return game.i18n.localize(`IRONSWORN.CHALLENGERANK.${key}`)
+}
+
+/**
+ * @remarks A document-subtype-sensitive replacement for the FVTT document deletion dialog.
+ * @see {@link ClientDocumentMixin.deleteDialog}
+ */
+export async function typedDeleteDialog<
+	T extends foundry.abstract.Document<any, any, Metadata<any>> & {
+		type: string
+	}
+>(document: T, options: Partial<DialogOptions> = {}): Promise<T> {
+	const docType = document.documentName as T['documentName'] &
+		KeysWithValuesOfType<
+			typeof CONFIG,
+			{ typeLabels: Record<T['type'], string> }
+		>
+	const typeLabelKey = CONFIG[docType]?.typeLabels?.[document.type]
+
+	if (typeLabelKey == null)
+		// no available label key -- fall back to the standard dialog
+		return (document as any).deleteDialog(options)
+
+	const type = game.i18n.localize(typeLabelKey)
+
+	return (await Dialog.confirm({
+		title: `${game.i18n.format('DOCUMENT.Delete', { type })}: ${
+			document.name as string
+		}`,
+		content: `<h4>${game.i18n.localize('AreYouSure')}</h4><p>${game.i18n.format(
+			'SIDEBAR.DeleteWarning',
+			{ type }
+		)}</p>`,
+		yes: document.delete.bind(document) as any,
+		options
+	})) as any
 }

--- a/src/module/item/item.ts
+++ b/src/module/item/item.ts
@@ -1,5 +1,6 @@
 import type { ConfiguredData } from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes'
 import type { DocumentSubTypes } from '../../types/helperTypes'
+import { typedDeleteDialog } from '../helpers/util'
 import type { ItemDataProperties } from './config'
 
 /**
@@ -40,6 +41,10 @@ export class IronswornItem<
 			data.type = 'progress'
 		}
 		return super.migrateData(data)
+	}
+
+	override async deleteDialog(options?: Partial<DialogOptions>) {
+		return await typedDeleteDialog(this, options)
 	}
 }
 export interface IronswornItem<T extends DocumentSubTypes<'Item'> = any>

--- a/src/module/journal/journal-entry-page.ts
+++ b/src/module/journal/journal-entry-page.ts
@@ -5,6 +5,7 @@ import type { BaseUser } from '@league-of-foundry-developers/foundry-vtt-types/s
 import type { IRow } from 'dataforged'
 import { clamp } from 'lodash-es'
 import { ChallengeRank, RANK_INCREMENTS } from '../constants'
+import { typedDeleteDialog } from '../helpers/util'
 import { OracleTable } from '../roll-table/oracle-table'
 import { OracleTableResult } from '../roll-table/oracle-table-result'
 import type {
@@ -93,5 +94,9 @@ export class IronswornJournalPage<
 		const increment = RANK_INCREMENTS[legacyRank] * progressUnits
 		const newValue = clamp(oldTicks + increment, minTicks, maxTicks)
 		return await this.update({ 'system.ticks': newValue })
+	}
+
+	override async deleteDialog(options?: Partial<DialogOptions>) {
+		return await typedDeleteDialog(this, options)
 	}
 }

--- a/src/module/vue/components/asset/asset-compact.vue
+++ b/src/module/vue/components/asset/asset-compact.vue
@@ -6,12 +6,7 @@
 		@toggle-expand="toggle">
 		<template #headerEnd>
 			<div class="flexrow nogrow" :class="$style.controls">
-				<IronBtn
-					v-if="editMode"
-					block
-					nogrow
-					icon="fa:trash"
-					@click="destroy" />
+				<IronBtn v-if="editMode" block nogrow :document="$asset" />
 				<IronBtn block nogrow icon="fa:pen-to-square" @click="edit" />
 			</div>
 		</template>
@@ -56,15 +51,6 @@ function toggle() {
 function edit() {
 	$asset?.sheet?.render(true)
 	return false
-}
-function destroy() {
-	Dialog.confirm({
-		title: game.i18n.format('DOCUMENT.Delete', {
-			type: game.i18n.localize('IRONSWORN.ITEM.TypeAsset')
-		}),
-		yes: () => $asset?.delete(),
-		defaultYes: false
-	})
 }
 </script>
 

--- a/src/module/vue/components/asset/asset-compact.vue
+++ b/src/module/vue/components/asset/asset-compact.vue
@@ -6,7 +6,7 @@
 		@toggle-expand="toggle">
 		<template #headerEnd>
 			<div class="flexrow nogrow" :class="$style.controls">
-				<IronBtn v-if="editMode" block nogrow :document="$asset" />
+				<BtnDocDelete v-if="editMode" block nogrow :document="$asset" />
 				<IronBtn block nogrow icon="fa:pen-to-square" @click="edit" />
 			</div>
 		</template>
@@ -19,14 +19,18 @@ import { computed, inject, provide } from 'vue'
 import { $ActorKey, $ItemKey, ActorKey, ItemKey } from '../../provisions'
 import IronBtn from 'component:buttons/iron-btn.vue'
 import AssetCard from 'component:asset/asset-card.vue'
+import BtnDocDelete from '../buttons/btn-doc-delete.vue'
+import type { IronswornItem } from '../../../item/item'
 
-const props = defineProps<{ asset: any }>()
+const props = defineProps<{ asset: ItemSource<'asset'> }>()
 const actor = inject(ActorKey) as Ref
 
 const $actor = inject($ActorKey)
-const $asset = $actor
-	? $actor?.items.find((x) => x.id === props.asset._id)
-	: game.items?.get(props.asset._id)
+const $asset = (
+	$actor
+		? $actor?.items.find((x) => x.id === props.asset._id)
+		: game.items?.get(props.asset._id as string)
+) as IronswornItem<'asset'>
 
 provide($ItemKey, $asset)
 provide(

--- a/src/module/vue/components/buttons/btn-compendium.vue
+++ b/src/module/vue/components/buttons/btn-compendium.vue
@@ -12,10 +12,9 @@
 </template>
 
 <script lang="ts" setup>
-import type { ExtractPropTypes } from 'vue'
 import IronBtn from './iron-btn.vue'
 
-interface Props extends ExtractPropTypes<typeof IronBtn> {
+interface Props extends PropsOf<typeof IronBtn> {
 	compendium: string
 }
 

--- a/src/module/vue/components/buttons/btn-delete.vue
+++ b/src/module/vue/components/buttons/btn-delete.vue
@@ -26,7 +26,7 @@ interface Props extends PropsOf<typeof IronBtn> {
 
 const props = withDefaults(defineProps<Props>(), {
 	icon: 'fa:trash',
-	dialogOptions: {}
+	dialogOptions: {} as any
 })
 
 const typeLabel = computed<string>(() => {

--- a/src/module/vue/components/buttons/btn-delete.vue
+++ b/src/module/vue/components/buttons/btn-delete.vue
@@ -1,0 +1,61 @@
+<template>
+	<IronBtn
+		:class="$style.wrapper"
+		aria-haspopup="dialog"
+		:tooltip="text"
+		v-bind="($props, $attrs)"
+		@click=";(document as any).deleteDialog(dialogOptions)">
+		<template v-for="(_, slot) of $slots" #[slot]="scope">
+			<slot :name="slot" v-bind="scope" />
+		</template>
+	</IronBtn>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+import IronBtn from './iron-btn.vue'
+import type {
+	ConfiguredDocumentClassForName,
+	DocumentType
+} from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes'
+
+interface Props extends PropsOf<typeof IronBtn> {
+	document: InstanceType<ConfiguredDocumentClassForName<DocumentType>>
+	dialogOptions?: Partial<DialogOptions>
+}
+
+const props = withDefaults(defineProps<Props>(), {
+	icon: 'fa:trash',
+	dialogOptions: {}
+})
+
+const typeLabel = computed<string>(() => {
+	const type =
+		(props.document as any).type ??
+		props.document.getFlag('foundry-ironsworn', 'type')
+	const docConfig = CONFIG[props.document.documentName]
+	if ('typeLabels' in docConfig)
+		return game.i18n.localize(docConfig.typeLabels?.[type])
+
+	return game.i18n.localize(
+		(
+			props.document.constructor as typeof foundry.abstract.Document<
+				any,
+				any,
+				any
+			>
+		).metadata.label
+	)
+})
+
+const text = computed(() =>
+	game.i18n.format(`DOCUMENT.Delete`, {
+		type: typeLabel.value
+	})
+)
+</script>
+
+<style lang="scss" module>
+.wrapper {
+}
+</style>

--- a/src/module/vue/components/buttons/btn-doc-delete.vue
+++ b/src/module/vue/components/buttons/btn-doc-delete.vue
@@ -2,7 +2,9 @@
 	<IronBtn
 		:class="$style.wrapper"
 		aria-haspopup="dialog"
-		:tooltip="text"
+		:tooltip="btnText ? undefined : text"
+		:text="btnText ? text : undefined"
+		:icon="'fa:trash'"
 		v-bind="($props, $attrs)"
 		@click=";(document as any).deleteDialog(dialogOptions)">
 		<template v-for="(_, slot) of $slots" #[slot]="scope">
@@ -19,21 +21,23 @@ import type {
 	DocumentType
 } from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes'
 
-interface Props extends PropsOf<typeof IronBtn> {
+interface Props extends Omit<PropsOf<typeof IronBtn>, 'text' | 'icon'> {
 	document: InstanceType<ConfiguredDocumentClassForName<DocumentType>>
 	dialogOptions?: Partial<DialogOptions>
+	/** @default `false` */
+	btnText?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
-	icon: 'fa:trash',
-	dialogOptions: {} as any
+	dialogOptions: {} as any,
+	btnText: false
 })
 
 const typeLabel = computed<string>(() => {
 	const type =
 		(props.document as any).type ??
 		props.document.getFlag('foundry-ironsworn', 'type')
-	const docConfig = CONFIG[props.document.documentName]
+	const docConfig = CONFIG[(props.document as any).documentName]
 	if ('typeLabels' in docConfig)
 		return game.i18n.localize(docConfig.typeLabels?.[type])
 

--- a/src/module/vue/components/buttons/btn-doc-delete.vue
+++ b/src/module/vue/components/buttons/btn-doc-delete.vue
@@ -6,7 +6,7 @@
 		:text="btnText ? text : undefined"
 		:icon="'fa:trash'"
 		v-bind="($props, $attrs)"
-		@click=";(document as any).deleteDialog(dialogOptions)">
+		@click="document.deleteDialog(dialogOptions)">
 		<template v-for="(_, slot) of $slots" #[slot]="scope">
 			<slot :name="slot" v-bind="scope" />
 		</template>
@@ -16,13 +16,9 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 import IronBtn from './iron-btn.vue'
-import type {
-	ConfiguredDocumentClassForName,
-	DocumentType
-} from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes'
 
 interface Props extends Omit<PropsOf<typeof IronBtn>, 'text' | 'icon'> {
-	document: InstanceType<ConfiguredDocumentClassForName<DocumentType>>
+	document: ClientDocument
 	dialogOptions?: Partial<DialogOptions>
 	/** @default `false` */
 	btnText?: boolean

--- a/src/module/vue/components/buttons/btn-momentumburn.vue
+++ b/src/module/vue/components/buttons/btn-momentumburn.vue
@@ -13,14 +13,13 @@
 
 <script lang="ts" setup>
 import { computed, inject } from 'vue'
-
 import { $ActorKey } from '../../provisions'
 import IronBtn from './iron-btn.vue'
 import type { IronswornActor } from '../../../actor/actor'
 
 interface Props extends Omit<PropsOf<typeof IronBtn>, 'tooltip'> {}
-
 defineProps<Props>()
+
 const $actor = inject($ActorKey) as IronswornActor<'character'>
 
 const tooltip = computed(() => {

--- a/src/module/vue/components/buttons/btn-momentumburn.vue
+++ b/src/module/vue/components/buttons/btn-momentumburn.vue
@@ -13,12 +13,12 @@
 
 <script lang="ts" setup>
 import { computed, inject } from 'vue'
-import type { ExtractPropTypes } from 'vue'
+
 import { $ActorKey } from '../../provisions'
 import IronBtn from './iron-btn.vue'
 import type { IronswornActor } from '../../../actor/actor'
 
-interface Props extends Omit<ExtractPropTypes<typeof IronBtn>, 'tooltip'> {}
+interface Props extends Omit<PropsOf<typeof IronBtn>, 'tooltip'> {}
 
 defineProps<Props>()
 const $actor = inject($ActorKey) as IronswornActor<'character'>

--- a/src/module/vue/components/buttons/btn-oracle.vue
+++ b/src/module/vue/components/buttons/btn-oracle.vue
@@ -15,24 +15,21 @@
 
 <script setup lang="ts">
 import { sample } from 'lodash-es'
-
-import { inject } from 'vue'
 import type { IOracleTreeNode } from '../../../features/customoracles.js'
 import { OracleTable } from '../../../roll-table/oracle-table'
 import IronBtn from './iron-btn.vue'
 
-interface Props extends Omit<PropsOf<typeof IronBtn>, 'tooltip'> {}
-
-const props = defineProps<{
+interface Props extends Omit<PropsOf<typeof IronBtn>, 'tooltip'> {
 	node: IOracleTreeNode
 	overrideClick?: boolean
 	// Hack: if we declare `click` in the emits, there's no $attrs['onClick']
 	// This allows us to check for presence and still use $emit('click')
 	// https://github.com/vuejs/core/issues/4736#issuecomment-934156497
 	onClick?: Function
-}>()
+}
 
-const toolset = inject<'ironsworn' | 'starforged'>('toolset')
+const props = defineProps<Props>()
+
 const $emit = defineEmits(['click'])
 
 async function rollOracle() {

--- a/src/module/vue/components/buttons/btn-oracle.vue
+++ b/src/module/vue/components/buttons/btn-oracle.vue
@@ -15,13 +15,13 @@
 
 <script setup lang="ts">
 import { sample } from 'lodash-es'
-import type { ExtractPropTypes } from 'vue'
+
 import { inject } from 'vue'
 import type { IOracleTreeNode } from '../../../features/customoracles.js'
 import { OracleTable } from '../../../roll-table/oracle-table'
 import IronBtn from './iron-btn.vue'
 
-interface Props extends Omit<ExtractPropTypes<typeof IronBtn>, 'tooltip'> {}
+interface Props extends Omit<PropsOf<typeof IronBtn>, 'tooltip'> {}
 
 const props = defineProps<{
 	node: IOracleTreeNode

--- a/src/module/vue/components/buttons/btn-rollmove.vue
+++ b/src/module/vue/components/buttons/btn-rollmove.vue
@@ -17,14 +17,13 @@
 </template>
 
 <script setup lang="ts">
-import type { ExtractPropTypes } from 'vue'
 import { inject } from 'vue'
 import type { Move } from '../../../features/custommoves.js'
 import { IronswornPrerollDialog } from '../../../rolls'
 import { $ActorKey } from '../../provisions'
 import IronBtn from './iron-btn.vue'
 
-interface Props extends Omit<ExtractPropTypes<typeof IronBtn>, 'tooltip'> {
+interface Props extends Omit<PropsOf<typeof IronBtn>, 'tooltip'> {
 	move?: Move
 	overrideClick?: boolean
 

--- a/src/module/vue/components/buttons/btn-rollprogress.vue
+++ b/src/module/vue/components/buttons/btn-rollprogress.vue
@@ -12,13 +12,12 @@
 </template>
 
 <script setup lang="ts">
-import type { ExtractPropTypes } from 'vue'
 import { inject } from 'vue'
 import type { IronswornItem } from '../../../item/item'
 import { $ItemKey } from '../../provisions'
 import IronBtn from './iron-btn.vue'
 
-interface Props extends ExtractPropTypes<typeof IronBtn> {
+interface Props extends PropsOf<typeof IronBtn> {
 	item: ItemSource<'progress'>
 }
 

--- a/src/module/vue/components/buttons/btn-rollstat.vue
+++ b/src/module/vue/components/buttons/btn-rollstat.vue
@@ -14,13 +14,11 @@
 
 <script lang="ts" setup>
 import type { DocumentType } from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes.js'
-import { computed } from '@vue/reactivity'
-
-import { inject } from 'vue'
+import { computed, inject } from 'vue'
 import type { IronswornActor } from '../../../actor/actor'
-import { MeterField } from '../../../fields/MeterField'
+import type { MeterField } from '../../../fields/MeterField'
 import type { IronswornItem } from '../../../item/item'
-import { AssetConditionMeterField } from '../../../item/subtypes/asset'
+import type { AssetConditionMeterField } from '../../../item/subtypes/asset'
 import { IronswornPrerollDialog } from '../../../rolls'
 import { formatRollPlusStat } from '../../../rolls/ironsworn-roll-message'
 import { pickInjectedDocument } from '../../composable/pickInjectedDocument'
@@ -43,7 +41,6 @@ const field = computed(
 		$document?.system.schema.getField(props.attr) as
 			| AssetConditionMeterField
 			| MeterField
-			| foundry.data.fields.NumberField
 )
 
 const statLabel = computed(() => {

--- a/src/module/vue/components/buttons/btn-rollstat.vue
+++ b/src/module/vue/components/buttons/btn-rollstat.vue
@@ -15,7 +15,7 @@
 <script lang="ts" setup>
 import type { DocumentType } from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes.js'
 import { computed } from '@vue/reactivity'
-import type { ExtractPropTypes } from 'vue'
+
 import { inject } from 'vue'
 import type { IronswornActor } from '../../../actor/actor'
 import { MeterField } from '../../../fields/MeterField'
@@ -27,7 +27,7 @@ import { pickInjectedDocument } from '../../composable/pickInjectedDocument'
 import { $ActorKey, $ItemKey } from '../../provisions'
 import IronBtn from './iron-btn.vue'
 
-interface Props extends Omit<ExtractPropTypes<typeof IronBtn>, 'tooltip'> {
+interface Props extends Omit<PropsOf<typeof IronBtn>, 'tooltip'> {
 	documentType: DocumentType
 	/**
 	 * The key of the stat value within `system`

--- a/src/module/vue/components/buttons/btn-sendmovetochat.vue
+++ b/src/module/vue/components/buttons/btn-sendmovetochat.vue
@@ -12,14 +12,13 @@
 </template>
 
 <script setup lang="ts">
-import type { ExtractPropTypes } from 'vue'
 import { inject } from 'vue'
 import { createSfMoveChatMessage } from '../../../chat/sf-move-chat-message'
 import type { Move } from '../../../features/custommoves'
 import { $ItemKey } from '../../provisions.js'
 import IronBtn from './iron-btn.vue'
 
-interface Props extends Omit<ExtractPropTypes<typeof IronBtn>, 'tooltip'> {
+interface Props extends Omit<PropsOf<typeof IronBtn>, 'tooltip'> {
 	move: Move
 }
 

--- a/src/module/vue/components/collapsible/collapsible.vue
+++ b/src/module/vue/components/collapsible/collapsible.vue
@@ -70,7 +70,6 @@
 </template>
 
 <script setup lang="ts">
-import type { ExtractPropTypes } from 'vue'
 import { reactive } from 'vue'
 import CollapseTransition from '../transition/collapse-transition.vue'
 import { computed, ref } from 'vue'
@@ -82,7 +81,7 @@ import FontIcon from '../icon/font-icon.vue'
 
 const props = withDefaults(
 	defineProps<{
-		duration?: ExtractPropTypes<typeof CollapseTransition>['duration']
+		duration?: PropsOf<typeof CollapseTransition>['duration']
 		/**
 		 * The text displayed on the button element that controls the expand/collapse toggle.
 		 */
@@ -129,7 +128,7 @@ const props = withDefaults(
 		 * @inheritdoc
 		 */
 		collapseTransition?: Omit<
-			ExtractPropTypes<typeof CollapseTransition>,
+			PropsOf<typeof CollapseTransition>,
 			'dimension' | 'duration'
 		>
 		/**

--- a/src/module/vue/components/icon/font-icon-stack.vue
+++ b/src/module/vue/components/icon/font-icon-stack.vue
@@ -13,16 +13,15 @@
 </template>
 
 <script lang="ts" setup>
-import type { ExtractPropTypes } from 'vue'
 import type FontIcon from './font-icon.vue'
 import Icon from './icon-helpers.vue'
 
 interface IconStackLayerOptions
-	extends Omit<ExtractPropTypes<typeof FontIcon>, 'size' | 'label'> {}
+	extends Omit<PropsOf<typeof FontIcon>, 'size' | 'label'> {}
 
 interface IconStackOptions
 	extends Omit<
-		ExtractPropTypes<typeof FontIcon>,
+		PropsOf<typeof FontIcon>,
 		'icon' | 'stack' | 'family' | 'style'
 	> {
 	bgOptions?: IconStackLayerOptions

--- a/src/module/vue/components/icon/icon-common.ts
+++ b/src/module/vue/components/icon/icon-common.ts
@@ -17,9 +17,6 @@ import type {
 
 import type ironswornIconNames from 'virtual:svg-icons-names'
 
-import type FontIcon from './font-icon.vue'
-import type IronIcon from './iron-icon.vue'
-
 export function enumHas(enumLike: object, value: string | number) {
 	return Object.values(enumLike).includes(value)
 }
@@ -39,11 +36,11 @@ export interface IconSwitchState {
 	props?: this['icon'] extends IronswornIconId ? IronIconState : FontIconState
 }
 
-export type IronIconState = Omit<PropsOf<typeof IronIcon>, 'name'> & {
+export type IronIconState = Omit<IronIconProps, 'name'> & {
 	class?: string
 }
 
-export type FontIconState = Omit<PropsOf<typeof FontIcon>, 'name'> & {
+export type FontIconState = Omit<FontAwesomeIconProps, 'name'> & {
 	class?: string
 }
 
@@ -151,34 +148,6 @@ export interface FontAwesomeIconProps extends IconPropsCommon {
 	 * Used with {@link FontIconStack}.
 	 */
 	stack?: 'stack-1x' | 'stack-2x'
-}
-
-/* Parse FontAwesome classes into the corresponding props. this is basically so that a theme's CSS variable can be used to set component properties. */
-// TODO: This could be ditched if Themes are migrated to e.g. a design-token like format, so that we could pass props objects to the icon rather than strings
-export function parseClassesToFaProps(cssClasses: string) {
-	const props: Partial<FontAwesomeIconProps> & { class?: string[] } = {}
-	cssClasses.split(' ').forEach((clsName) => {
-		switch (true) {
-			case enumHas(FontAwesome.Style, clsName):
-				props.style = clsName as FontAwesome.Style
-				break
-			case enumHas(FontAwesome.Family, clsName):
-				props.family = clsName as FontAwesome.Family
-				break
-			case enumHas(FontAwesome.Rotate, clsName):
-				props.rotate = clsName as FontAwesome.Rotate
-				break
-			case enumHas(FontAwesome.Animation, clsName):
-				if (!props.animation) props.animation = []
-				props.animation.push(clsName as FontAwesome.Animation)
-				break
-			default:
-				if (!props.class) props.class = []
-				props.class.push(clsName)
-				break
-		}
-	})
-	return props
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -4154,4 +4123,32 @@ export namespace FontAwesome {
 		| 'korvue'
 		| 'pix'
 		| 'steam-symbol'
+}
+
+/* Parse FontAwesome classes into the corresponding props. this is basically so that a theme's CSS variable can be used to set component properties. */
+// TODO: This could be ditched if Themes are migrated to e.g. a design-token like format, so that we could pass props objects to the icon rather than strings
+export function parseClassesToFaProps(cssClasses: string) {
+	const props: Partial<FontAwesomeIconProps> & { class?: string[] } = {}
+	cssClasses.split(' ').forEach((clsName) => {
+		switch (true) {
+			case enumHas(FontAwesome.Style, clsName):
+				props.style = clsName as FontAwesome.Style
+				break
+			case enumHas(FontAwesome.Family, clsName):
+				props.family = clsName as FontAwesome.Family
+				break
+			case enumHas(FontAwesome.Rotate, clsName):
+				props.rotate = clsName as FontAwesome.Rotate
+				break
+			case enumHas(FontAwesome.Animation, clsName):
+				if (!props.animation) props.animation = []
+				props.animation.push(clsName as FontAwesome.Animation)
+				break
+			default:
+				if (!props.class) props.class = []
+				props.class.push(clsName)
+				break
+		}
+	})
+	return props
 }

--- a/src/module/vue/components/icon/icon-common.ts
+++ b/src/module/vue/components/icon/icon-common.ts
@@ -16,7 +16,7 @@ import type {
 } from 'csstype'
 
 import type ironswornIconNames from 'virtual:svg-icons-names'
-import type { ExtractPropTypes } from 'vue'
+
 import type FontIcon from './font-icon.vue'
 import type IronIcon from './iron-icon.vue'
 
@@ -39,11 +39,11 @@ export interface IconSwitchState {
 	props?: this['icon'] extends IronswornIconId ? IronIconState : FontIconState
 }
 
-export type IronIconState = Omit<ExtractPropTypes<typeof IronIcon>, 'name'> & {
+export type IronIconState = Omit<PropsOf<typeof IronIcon>, 'name'> & {
 	class?: string
 }
 
-export type FontIconState = Omit<ExtractPropTypes<typeof FontIcon>, 'name'> & {
+export type FontIconState = Omit<PropsOf<typeof FontIcon>, 'name'> & {
 	class?: string
 }
 

--- a/src/module/vue/components/icon/icon-switch.vue
+++ b/src/module/vue/components/icon/icon-switch.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts" setup>
-import type IronBtn from 'component:buttons/iron-btn.vue'
+import type IronBtn from '../buttons/iron-btn.vue'
 
 import { TransitionGroup } from 'vue'
 

--- a/src/module/vue/components/icon/icon-switch.vue
+++ b/src/module/vue/components/icon/icon-switch.vue
@@ -17,12 +17,13 @@
 
 <script lang="ts" setup>
 import type IronBtn from '../buttons/iron-btn.vue'
-
 import { TransitionGroup } from 'vue'
 
-type IronBtnProps = PropsOf<typeof IronBtn>
 interface Props
-	extends Omit<IronBtnProps, 'text' | 'icon' | 'vertical' | 'justify'> {
+	extends Omit<
+		PropsOf<typeof IronBtn>,
+		'text' | 'icon' | 'vertical' | 'justify'
+	> {
 	/**
 	 * A list of unique names for the switch's states.
 	 */
@@ -51,15 +52,15 @@ withDefaults(defineProps<Props>(), {
 .wrapper {
 	// use grid to position stacked icons, which is more flexible than absolute positioning
 	display: grid;
-	height: var(--ironsworn-icon-size);
 	width: var(--ironsworn-icon-size);
+	height: var(--ironsworn-icon-size);
 }
 
 .icon {
 	// stacks icons on top of each other by assigning them to the same grid cell
 	grid-row: 1;
 	grid-column: 1;
-	height: inherit;
 	width: inherit;
+	height: inherit;
 }
 </style>

--- a/src/module/vue/components/icon/icon-switch.vue
+++ b/src/module/vue/components/icon/icon-switch.vue
@@ -17,10 +17,10 @@
 
 <script lang="ts" setup>
 import type IronBtn from 'component:buttons/iron-btn.vue'
-import type { ExtractPropTypes } from 'vue'
+
 import { TransitionGroup } from 'vue'
 
-type IronBtnProps = ExtractPropTypes<typeof IronBtn>
+type IronBtnProps = PropsOf<typeof IronBtn>
 interface Props
 	extends Omit<IronBtnProps, 'text' | 'icon' | 'vertical' | 'justify'> {
 	/**

--- a/src/module/vue/components/icon/iron-icon.vue
+++ b/src/module/vue/components/icon/iron-icon.vue
@@ -18,7 +18,7 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue'
-import { IronIconProps } from './icon-common'
+import type { IronIconProps } from './icon-common'
 
 // without this, vue-tsc complains  even though it shouldn't
 

--- a/src/module/vue/components/progress/completed-progress-list.vue
+++ b/src/module/vue/components/progress/completed-progress-list.vue
@@ -26,12 +26,9 @@ import { getProgressItems } from './progress-common'
 import ProgressList from './progress-list.vue'
 
 const props = defineProps<{
-	collapsibleProps?: Omit<
-		ExtractPropTypes<typeof Collapsible>,
-		'toggleLabel' | 'baseId'
-	>
+	collapsibleProps?: Omit<PropsOf<typeof Collapsible>, 'toggleLabel' | 'baseId'>
 	collapsibleAttrs?: Record<string, any>
-	listProps?: Omit<ExtractPropTypes<typeof ProgressList>, 'showCompleted'>
+	listProps?: Omit<PropsOf<typeof ProgressList>, 'showCompleted'>
 	listAttrs?: Record<string, any>
 }>()
 

--- a/src/module/vue/components/progress/progress-list-item.vue
+++ b/src/module/vue/components/progress/progress-list-item.vue
@@ -23,16 +23,7 @@
 			:current="item.system.rank"
 			@change="(rank) => $item.update({ system: { rank } })" />
 		<section class="progress-controls" data-tooltip-direction="UP">
-			<IronBtn
-				v-if="editMode"
-				block
-				icon="fa:trash"
-				:tooltip="
-					$t('DOCUMENT.Delete', {
-						type: $t('IRONSWORN.ITEM.TypeProgressTrack')
-					})
-				"
-				@click="destroy" />
+			<BtnDelete v-if="editMode" block :document="($item as any)" />
 			<IronBtn
 				block
 				icon="fa:pen-to-square"
@@ -92,6 +83,7 @@ import ProgressTrack from './progress-track.vue'
 import FontIcon from '../icon/font-icon.vue'
 import { FontAwesome } from '../icon/icon-common'
 import type { IronswornItem } from '../../../item/item'
+import BtnDelete from '../buttons/btn-delete.vue'
 
 const props = defineProps<{
 	item: ItemSource<'progress'>
@@ -131,18 +123,7 @@ const completedTooltip = computed(() => {
 function edit() {
 	$item?.sheet?.render(true)
 }
-function destroy() {
-	Dialog.confirm({
-		title: game.i18n.format('DOCUMENT.Delete', {
-			type: game.i18n.localize('IRONSWORN.ITEM.TypeProgressTrack')
-		}),
-		content: `<p><strong>${game.i18n.localize(
-			'IRONSWORN.ConfirmDelete'
-		)}</strong></p>`,
-		yes: () => $item?.delete(),
-		defaultYes: false
-	})
-}
+
 const $emit = defineEmits(['completed'])
 
 function toggleComplete() {

--- a/src/module/vue/components/progress/progress-list-item.vue
+++ b/src/module/vue/components/progress/progress-list-item.vue
@@ -23,7 +23,7 @@
 			:current="item.system.rank"
 			@change="(rank) => $item.update({ system: { rank } })" />
 		<section class="progress-controls" data-tooltip-direction="UP">
-			<BtnDocDelete v-if="editMode" block :document="($item as any)" />
+			<BtnDocDelete v-if="editMode" block :document="$item" />
 			<IronBtn
 				block
 				icon="fa:pen-to-square"

--- a/src/module/vue/components/progress/progress-list-item.vue
+++ b/src/module/vue/components/progress/progress-list-item.vue
@@ -23,7 +23,7 @@
 			:current="item.system.rank"
 			@change="(rank) => $item.update({ system: { rank } })" />
 		<section class="progress-controls" data-tooltip-direction="UP">
-			<BtnDelete v-if="editMode" block :document="($item as any)" />
+			<BtnDocDelete v-if="editMode" block :document="($item as any)" />
 			<IronBtn
 				block
 				icon="fa:pen-to-square"
@@ -83,7 +83,7 @@ import ProgressTrack from './progress-track.vue'
 import FontIcon from '../icon/font-icon.vue'
 import { FontAwesome } from '../icon/icon-common'
 import type { IronswornItem } from '../../../item/item'
-import BtnDelete from '../buttons/btn-delete.vue'
+import BtnDocDelete from '../buttons/btn-doc-delete.vue'
 
 const props = defineProps<{
 	item: ItemSource<'progress'>

--- a/src/module/vue/components/sf-move-category-rows.vue
+++ b/src/module/vue/components/sf-move-category-rows.vue
@@ -32,7 +32,6 @@
 </template>
 
 <script setup lang="ts">
-import type { ExtractPropTypes } from 'vue'
 import { computed, nextTick, ref } from 'vue'
 import type { MoveCategory } from '../../features/custommoves.js'
 import SfMoverow from './sf-moverow.vue'
@@ -49,7 +48,7 @@ const props = withDefaults(
 		highlightDuration?: number
 		headingLevel?: number
 		collapsible?: Omit<
-			ExtractPropTypes<typeof Collapsible>,
+			PropsOf<typeof Collapsible>,
 			| 'toggleButtonClass'
 			| 'toggleTooltip'
 			| 'toggleWrapperIs'

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -56,7 +56,6 @@
 </template>
 
 <script setup lang="ts">
-import type { ExtractPropTypes } from 'vue'
 import { computed, provide, reactive, ref } from 'vue'
 import type { Move } from '../../features/custommoves'
 import type { IOracleTreeNode } from '../../features/customoracles'
@@ -91,7 +90,7 @@ const props = withDefaults(
 		 * Props to be passed to the Collapsible component.
 		 */
 		collapsible?: Omit<
-			ExtractPropTypes<typeof Collapsible>,
+			PropsOf<typeof Collapsible>,
 			| 'contentWrapperClass'
 			| 'toggleWrapperIs'
 			| 'toggleSectionClass'

--- a/src/module/vue/components/site/site-droparea.vue
+++ b/src/module/vue/components/site/site-droparea.vue
@@ -72,7 +72,7 @@ const editMode = computed(() => {
 })
 
 function foundryitem() {
-	return props.item && $actor?.items.get(props.item._id)
+	return props.item && $actor?.items.get(props.item._id as string)
 }
 
 function edit() {

--- a/src/module/vue/components/site/site-droparea.vue
+++ b/src/module/vue/components/site/site-droparea.vue
@@ -23,7 +23,10 @@
 						top: var(--ironsworn-spacer-md);
 						right: var(--ironsworn-spacer-md);
 					">
-					<BtnDocDelete block :document="foundryitem()" />
+					<BtnDocDelete
+						v-if="foundryitem() != null"
+						block
+						:document="(foundryitem() as IronswornItem)" />
 					<IronBtn block icon="fa:pen-to-square" @click="edit" />
 				</div>
 			</div>
@@ -52,9 +55,10 @@ import IronBtn from '../buttons/iron-btn.vue'
 import BtnCompendium from '../buttons/btn-compendium.vue'
 import DropTarget from '../../drop-target.vue'
 import BtnDocDelete from '../buttons/btn-doc-delete.vue'
+import type { IronswornItem } from '../../../item/item'
 
 const props = defineProps<{
-	item: any
+	item: ItemSource<'delve-domain'> | ItemSource<'delve-theme'>
 	itemType: string
 	titleKey: string
 	compendiumKey: string

--- a/src/module/vue/components/site/site-droparea.vue
+++ b/src/module/vue/components/site/site-droparea.vue
@@ -23,7 +23,7 @@
 						top: var(--ironsworn-spacer-md);
 						right: var(--ironsworn-spacer-md);
 					">
-					<BtnDelete block :document="foundryitem()" />
+					<BtnDocDelete block :document="foundryitem()" />
 					<IronBtn block icon="fa:pen-to-square" @click="edit" />
 				</div>
 			</div>
@@ -45,14 +45,13 @@
 
 <script setup lang="ts">
 import type { Ref } from 'vue'
-import { inject } from 'vue'
+import { inject, computed } from 'vue'
 import { $ActorKey, ActorKey } from '../../provisions'
-import { computed } from 'vue'
 import DocumentImg from '../document-img.vue'
 import IronBtn from '../buttons/iron-btn.vue'
 import BtnCompendium from '../buttons/btn-compendium.vue'
 import DropTarget from '../../drop-target.vue'
-import BtnDelete from '../buttons/btn-delete.vue'
+import BtnDocDelete from '../buttons/btn-doc-delete.vue'
 
 const props = defineProps<{
 	item: any

--- a/src/module/vue/components/site/site-droparea.vue
+++ b/src/module/vue/components/site/site-droparea.vue
@@ -23,7 +23,7 @@
 						top: var(--ironsworn-spacer-md);
 						right: var(--ironsworn-spacer-md);
 					">
-					<IronBtn block icon="fa:trash" @click="destroy" />
+					<BtnDelete block :document="foundryitem()" />
 					<IronBtn block icon="fa:pen-to-square" @click="edit" />
 				</div>
 			</div>
@@ -52,6 +52,7 @@ import DocumentImg from '../document-img.vue'
 import IronBtn from '../buttons/iron-btn.vue'
 import BtnCompendium from '../buttons/btn-compendium.vue'
 import DropTarget from '../../drop-target.vue'
+import BtnDelete from '../buttons/btn-delete.vue'
 
 const props = defineProps<{
 	item: any
@@ -69,19 +70,6 @@ const editMode = computed(() => {
 
 function foundryitem() {
 	return props.item && $actor?.items.get(props.item._id)
-}
-
-function destroy() {
-	Dialog.confirm({
-		title: game.i18n.format('DOCUMENT.Delete', {
-			type: game.i18n.localize('DOCUMENT.Item')
-		}),
-		content: `<p><strong>${game.i18n.localize(
-			'IRONSWORN.ConfirmDelete'
-		)}</strong></p>`,
-		yes: () => foundryitem()?.delete(),
-		defaultYes: false
-	})
 }
 
 function edit() {

--- a/src/module/vue/components/tabs/tab.vue
+++ b/src/module/vue/components/tabs/tab.vue
@@ -20,8 +20,7 @@
 </template>
 <script lang="ts" setup>
 import { omit } from 'lodash-es'
-
-import { computed, inject, nextTick, ref, watch } from 'vue'
+import { computed, inject, ref } from 'vue'
 import IronBtn from '../buttons/iron-btn.vue'
 import type {
 	FocusActivePanel,
@@ -81,17 +80,21 @@ function handleKeydown(event: KeyboardEvent) {
 	switch (true) {
 		case horizontal && event.key === 'ArrowRight':
 		case vertical && event.key === 'ArrowDown':
-			event.preventDefault()
-			const nextTabIndex = Math.min(currentTabIndex + 1, lastTabIndex)
-			const nextTabKey = tabState.tabKeys[nextTabIndex]
-			setActiveTab(nextTabKey)
+			{
+				event.preventDefault()
+				const nextTabIndex = Math.min(currentTabIndex + 1, lastTabIndex)
+				const nextTabKey = tabState.tabKeys[nextTabIndex]
+				setActiveTab(nextTabKey)
+			}
 			break
 		case horizontal && event.key === 'ArrowLeft':
 		case vertical && event.key === 'ArrowUp':
-			event.preventDefault()
-			const previousTabIndex = Math.max(currentTabIndex - 1, 0)
-			const previousTabKey = tabState.tabKeys[previousTabIndex]
-			setActiveTab(previousTabKey)
+			{
+				event.preventDefault()
+				const previousTabIndex = Math.max(currentTabIndex - 1, 0)
+				const previousTabKey = tabState.tabKeys[previousTabIndex]
+				setActiveTab(previousTabKey)
+			}
 			break
 		// If in horizontal mode, focus the active panel on ArrowDown, for screenreaders
 		case horizontal && event.key === 'ArrowDown':

--- a/src/module/vue/components/tabs/tab.vue
+++ b/src/module/vue/components/tabs/tab.vue
@@ -20,7 +20,7 @@
 </template>
 <script lang="ts" setup>
 import { omit } from 'lodash-es'
-import type { ExtractPropTypes } from 'vue'
+
 import { computed, inject, nextTick, ref, watch } from 'vue'
 import IronBtn from '../buttons/iron-btn.vue'
 import type {
@@ -37,7 +37,7 @@ import {
 	TabStateKey
 } from './tab-helpers.js'
 
-interface Props extends ExtractPropTypes<typeof IronBtn> {
+interface Props extends PropsOf<typeof IronBtn> {
 	/**
 	 * The tab's key must match the key of a {@link TabPanel}.
 	 */

--- a/src/module/vue/progress-sheet.vue
+++ b/src/module/vue/progress-sheet.vue
@@ -127,7 +127,7 @@
 			block
 			:class="$style.danger"
 			:btn-text="true"
-			:document="($item as any)" />
+			:document="$item" />
 	</div>
 </template>
 
@@ -145,7 +145,7 @@ import type { IronswornItem } from '../item/item'
 import BtnDocDelete from './components/buttons/btn-doc-delete.vue'
 
 const props = defineProps<{ data: { item: ItemSource<'progress'> } }>()
-const $item = inject<IronswornItem<'progress'>>($ItemKey)
+const $item = inject($ItemKey) as IronswornItem<'progress'>
 
 provide(
 	ItemKey,

--- a/src/module/vue/progress-sheet.vue
+++ b/src/module/vue/progress-sheet.vue
@@ -122,15 +122,14 @@
 		<hr class="nogrow" />
 		<!-- DESCRIPTION -->
 		<MceEditor v-model="data.item.system.description" @save="saveDescription" />
-		<IronBtn
+		<BtnDelete
 			nogrow
 			block
 			:class="$style.danger"
-			icon="fa:trash"
 			:text="
 				$t(`DOCUMENT.Delete`, { type: $t('IRONSWORN.ITEM.TypeProgressTrack') })
 			"
-			@click="destroy" />
+			:document="($item as any)" />
 	</div>
 </template>
 
@@ -145,6 +144,7 @@ import ProgressTrack from './components/progress/progress-track.vue'
 import CollapseTransition from './components/transition/collapse-transition.vue'
 import IronBtn from './components/buttons/iron-btn.vue'
 import type { IronswornItem } from '../item/item'
+import BtnDelete from './components/buttons/btn-delete.vue'
 
 const props = defineProps<{ data: { item: ItemSource<'progress'> } }>()
 const $item = inject<IronswornItem<'progress'>>($ItemKey)
@@ -184,19 +184,6 @@ function setClock(num) {
 
 function saveDescription() {
 	$item?.update({ system: { description: props.data.item.system.description } })
-}
-
-function destroy() {
-	Dialog.confirm({
-		title: game.i18n.format('DOCUMENT.Delete', {
-			type: game.i18n.localize('IRONSWORN.ITEM.TypeProgressTrack')
-		}),
-		content: `<p><strong>${game.i18n.localize(
-			'IRONSWORN.ConfirmDelete'
-		)}</strong></p>`,
-		yes: () => $item?.delete(),
-		defaultYes: false
-	})
 }
 </script>
 

--- a/src/module/vue/progress-sheet.vue
+++ b/src/module/vue/progress-sheet.vue
@@ -122,13 +122,11 @@
 		<hr class="nogrow" />
 		<!-- DESCRIPTION -->
 		<MceEditor v-model="data.item.system.description" @save="saveDescription" />
-		<BtnDelete
+		<BtnDocDelete
 			nogrow
 			block
 			:class="$style.danger"
-			:text="
-				$t(`DOCUMENT.Delete`, { type: $t('IRONSWORN.ITEM.TypeProgressTrack') })
-			"
+			:btn-text="true"
 			:document="($item as any)" />
 	</div>
 </template>
@@ -144,7 +142,7 @@ import ProgressTrack from './components/progress/progress-track.vue'
 import CollapseTransition from './components/transition/collapse-transition.vue'
 import IronBtn from './components/buttons/iron-btn.vue'
 import type { IronswornItem } from '../item/item'
-import BtnDelete from './components/buttons/btn-delete.vue'
+import BtnDocDelete from './components/buttons/btn-doc-delete.vue'
 
 const props = defineProps<{ data: { item: ItemSource<'progress'> } }>()
 const $item = inject<IronswornItem<'progress'>>($ItemKey)

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -1,4 +1,13 @@
 declare global {
+	/** A type alias for any client document. */
+	export type ClientDocument<
+		T extends foundry.abstract.Document<
+			any,
+			any,
+			any
+		> = foundry.abstract.Document<any, any, any>
+	> = InstanceType<ReturnType<typeof ClientDocumentMixin<ConstructorOf<T>>>>
+
 	export namespace foundry {
 		export namespace abstract {
 			export namespace Document {

--- a/src/types/vue-utils.ts
+++ b/src/types/vue-utils.ts
@@ -1,0 +1,13 @@
+import type { ExtractDefaultPropTypes, ExtractPropTypes } from 'vue'
+
+declare global {
+	/** Shortcut to get Vue props directly from a component's constructor (rather than nesting a bunch of generics). */
+	export type PropsOf<T extends ConstructorOf<{ $props: any }>> =
+		ExtractPropTypes<InstanceType<T>['$props']>
+
+	/** Shortcut to get Vue prop defaults directly from a component's constructor (rather than nesting a bunch of generics). */
+	export type DefaultPropsOf<T extends ConstructorOf<{ $props: any }>> =
+		ExtractDefaultPropTypes<InstanceType<T>['$props']>
+}
+
+export {}

--- a/src/types/vue-utils.ts
+++ b/src/types/vue-utils.ts
@@ -1,9 +1,14 @@
 import type { ExtractDefaultPropTypes, ExtractPropTypes } from 'vue'
 
 declare global {
+	type Mutable<T> = T extends Readonly<infer U>
+		? U
+		: { -readonly [P in keyof T]: T[P] }
+
 	/** Shortcut to get Vue props directly from a component's constructor (rather than nesting a bunch of generics). */
-	export type PropsOf<T extends ConstructorOf<{ $props: any }>> =
+	export type PropsOf<T extends ConstructorOf<{ $props: any }>> = Mutable<
 		ExtractPropTypes<InstanceType<T>['$props']>
+	>
 
 	/** Shortcut to get Vue prop defaults directly from a component's constructor (rather than nesting a bunch of generics). */
 	export type DefaultPropsOf<T extends ConstructorOf<{ $props: any }>> =


### PR DESCRIPTION
* add standardized document deletion dialog function (`typedDeleteDialog`) that provides subtype-sensitive labelling; it now overrides the `deleteDialog` method of `IronswornItem`, `IronswornActor`, and `IronswornJournalPage`
* create a common button component for the dialog above, and implemented it in places where documents are deleted
* fixed inherited prop types weren't showing in VSCode (most prominent in various `IronBtn` descendants). it turns out that I didn't know how to use the `ExtractProps` generic type properly. getting what we want from an imported component requires nesting a few generics and a property lookup, so i've provided a utility type, `PropsOf<T>`, that takes care of all of that. example usage: `PropsOf<typeof MyComponent>`