### PR TITLE
rename type data models: `FooData` => `FooModel`

### DIFF
--- a/src/module/actor/config.ts
+++ b/src/module/actor/config.ts
@@ -70,12 +70,12 @@ const config: Partial<ActorConfig> = {
 export default config
 
 export {
-	CharacterModel as CharacterData,
-	FoeModel as FoeData,
-	LocationModel as LocationData,
-	SharedModel as SharedData,
-	SiteModel as SiteData,
-	StarshipModel as StarshipData
+	CharacterModel,
+	FoeModel,
+	LocationModel,
+	SharedModel,
+	SiteModel,
+	StarshipModel
 }
 
 export type ActorDataSource =

--- a/src/module/actor/config.ts
+++ b/src/module/actor/config.ts
@@ -4,34 +4,34 @@ import type {
 	CharacterDataProperties,
 	CharacterDataSource
 } from './subtypes/character'
-import { CharacterData } from './subtypes/character'
+import { CharacterModel } from './subtypes/character'
 import type { FoeDataProperties, FoeDataSource } from './subtypes/foe'
-import { FoeData } from './subtypes/foe'
+import { FoeModel } from './subtypes/foe'
 import type {
 	LocationDataProperties,
 	LocationDataSource
 } from './subtypes/location'
-import { LocationData } from './subtypes/location'
+import { LocationModel } from './subtypes/location'
 import type { SharedDataProperties, SharedDataSource } from './subtypes/shared'
-import { SharedData } from './subtypes/shared'
+import { SharedModel } from './subtypes/shared'
 import type { SiteDataProperties, SiteDataSource } from './subtypes/site'
-import { SiteData } from './subtypes/site'
+import { SiteModel } from './subtypes/site'
 import type {
 	StarshipDataProperties,
 	StarshipDataSource
 } from './subtypes/starship'
-import { StarshipData } from './subtypes/starship'
+import { StarshipModel } from './subtypes/starship'
 
 const dataModels: Record<
 	ConfiguredData<'Actor'>['type'],
 	typeof foundry.abstract.TypeDataModel<any, any>
 > = {
-	character: CharacterData,
-	foe: FoeData,
-	location: LocationData,
-	shared: SharedData,
-	site: SiteData,
-	starship: StarshipData
+	character: CharacterModel,
+	foe: FoeModel,
+	location: LocationModel,
+	shared: SharedModel,
+	site: SiteModel,
+	starship: StarshipModel
 }
 
 type ActorType = ConfiguredData<'Actor'>['type']
@@ -70,12 +70,12 @@ const config: Partial<ActorConfig> = {
 export default config
 
 export {
-	CharacterData,
-	FoeData,
-	LocationData,
-	SharedData,
-	SiteData,
-	StarshipData
+	CharacterModel as CharacterData,
+	FoeModel as FoeData,
+	LocationModel as LocationData,
+	SharedModel as SharedData,
+	SiteModel as SiteData,
+	StarshipModel as StarshipData
 }
 
 export type ActorDataSource =

--- a/src/module/actor/subtypes/character.ts
+++ b/src/module/actor/subtypes/character.ts
@@ -9,7 +9,7 @@ import type {
 } from '../../fields/MeterField'
 import { ConditionMeterField, MomentumField } from '../../fields/MeterField'
 
-export class CharacterData extends foundry.abstract.TypeDataModel<
+export class CharacterModel extends foundry.abstract.TypeDataModel<
 	CharacterDataSourceData,
 	CharacterDataSourceData,
 	IronswornActor<'character'>
@@ -27,7 +27,7 @@ export class CharacterData extends foundry.abstract.TypeDataModel<
 
 	static _enableV10Validation = true
 
-	async burnMomentum(this: CharacterData) {
+	async burnMomentum(this: CharacterModel) {
 		if (this.canBurnMomentum) {
 			await this.parent.update({
 				system: { 'momentum.value': this.parent.system.momentum.resetValue }
@@ -133,7 +133,7 @@ export class CharacterData extends foundry.abstract.TypeDataModel<
 		}
 	}
 }
-export interface CharacterData extends CharacterDataSourceData {}
+export interface CharacterModel extends CharacterDataSourceData {}
 export interface CharacterDataSourceData {
 	biography: string
 	notes: string
@@ -194,6 +194,6 @@ export interface CharacterDataProperties {
 	/**
 	 * @deprecated
 	 */
-	data: CharacterData
-	system: CharacterData
+	data: CharacterModel
+	system: CharacterModel
 }

--- a/src/module/actor/subtypes/foe.ts
+++ b/src/module/actor/subtypes/foe.ts
@@ -2,7 +2,7 @@ import { DataforgedIDField } from '../../fields/DataforgedIDField'
 import type { DataSchema } from '../../fields/utils'
 import type { IronswornActor } from '../actor'
 
-export class FoeData extends foundry.abstract.TypeDataModel<
+export class FoeModel extends foundry.abstract.TypeDataModel<
 	FoeDataSourceData,
 	FoeDataSourceData,
 	IronswornActor<'foe'>
@@ -15,7 +15,7 @@ export class FoeData extends foundry.abstract.TypeDataModel<
 		}
 	}
 }
-export interface FoeData extends FoeDataSourceData {}
+export interface FoeModel extends FoeDataSourceData {}
 export interface FoeDataSourceData {
 	dfid: string | null
 }
@@ -33,6 +33,6 @@ export interface FoeDataProperties {
 	/**
 	 * @deprecated
 	 */
-	data: FoeData
-	system: FoeData
+	data: FoeModel
+	system: FoeModel
 }

--- a/src/module/actor/subtypes/location.ts
+++ b/src/module/actor/subtypes/location.ts
@@ -1,7 +1,7 @@
 import type { DataSchema } from '../../fields/utils'
 import type { IronswornActor } from '../actor'
 
-export class LocationData extends foundry.abstract.TypeDataModel<
+export class LocationModel extends foundry.abstract.TypeDataModel<
 	LocationDataSourceData,
 	LocationDataSourceData,
 	IronswornActor<'location'>
@@ -17,7 +17,7 @@ export class LocationData extends foundry.abstract.TypeDataModel<
 		}
 	}
 }
-export interface LocationData extends LocationDataSourceData {}
+export interface LocationModel extends LocationDataSourceData {}
 
 interface LocationDataSourceData {
 	subtype: string
@@ -38,6 +38,6 @@ export interface LocationDataProperties {
 	/**
 	 * @deprecated
 	 */
-	data: LocationData
-	system: LocationData
+	data: LocationModel
+	system: LocationModel
 }

--- a/src/module/actor/subtypes/shared.ts
+++ b/src/module/actor/subtypes/shared.ts
@@ -6,7 +6,7 @@ import { MeterValueField } from '../../fields/MeterValueField'
 import type { DataSchema } from '../../fields/utils'
 import type { IronswornActor } from '../actor'
 
-export class SharedData extends foundry.abstract.TypeDataModel<
+export class SharedModel extends foundry.abstract.TypeDataModel<
 	SharedDataSourceData,
 	SharedDataSourceData,
 	IronswornActor<'shared'>
@@ -21,7 +21,7 @@ export class SharedData extends foundry.abstract.TypeDataModel<
 		}
 	}
 }
-export interface SharedData extends SharedDataSourceData {}
+export interface SharedModel extends SharedDataSourceData {}
 
 interface SharedDataSourceData {
 	biography: string
@@ -41,6 +41,6 @@ export interface SharedDataProperties {
 	/**
 	 * @deprecated
 	 */
-	data: SharedData
-	system: SharedData
+	data: SharedModel
+	system: SharedModel
 }

--- a/src/module/actor/subtypes/site.ts
+++ b/src/module/actor/subtypes/site.ts
@@ -8,7 +8,7 @@ import type { DataSchema } from '../../fields/utils'
 import { OracleTable } from '../../roll-table/oracle-table'
 import type { IronswornActor } from '../actor'
 
-export class SiteData extends foundry.abstract.TypeDataModel<
+export class SiteModel extends foundry.abstract.TypeDataModel<
 	SiteDataSourceData,
 	SiteDataSourceData,
 	IronswornActor<'site'>
@@ -175,7 +175,7 @@ export class SiteData extends foundry.abstract.TypeDataModel<
 	}
 }
 
-export interface SiteData extends SiteDataSourceData {}
+export interface SiteModel extends SiteDataSourceData {}
 
 interface SiteDataSourceData {
 	objective: string
@@ -199,6 +199,6 @@ export interface SiteDataProperties {
 	/**
 	 * @deprecated
 	 */
-	data: SiteData
-	system: SiteData
+	data: SiteModel
+	system: SiteModel
 }

--- a/src/module/actor/subtypes/starship.ts
+++ b/src/module/actor/subtypes/starship.ts
@@ -3,7 +3,7 @@ import { ImpactField } from '../../fields/ImpactField'
 import type { IronswornActor } from '../actor'
 import type { DataSchema } from '../../fields/utils'
 
-export class StarshipData extends foundry.abstract.TypeDataModel<
+export class StarshipModel extends foundry.abstract.TypeDataModel<
 	StarshipDataSourceData,
 	StarshipDataSourceData,
 	IronswornActor<'starship'>
@@ -23,7 +23,7 @@ export class StarshipData extends foundry.abstract.TypeDataModel<
 		}
 	}
 }
-export interface StarshipData extends StarshipDataSourceData {}
+export interface StarshipModel extends StarshipDataSourceData {}
 
 interface StarshipDataSourceData {
 	health: number
@@ -45,6 +45,6 @@ export interface StarshipDataProperties {
 	/**
 	 * @deprecated
 	 */
-	data: StarshipData
-	system: StarshipData
+	data: StarshipModel
+	system: StarshipModel
 }

--- a/src/module/item/config.ts
+++ b/src/module/item/config.ts
@@ -1,12 +1,12 @@
 import type { ConfiguredData } from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes'
 import type { PartialDeep } from 'dataforged'
 import { IronswornItem } from './item'
-import { AssetData } from './subtypes/asset'
-import { BondsetData } from './subtypes/bondset'
-import { DelveDomainData } from './subtypes/delve-domain'
-import { DelveThemeData } from './subtypes/delve-theme'
-import { ProgressData } from './subtypes/progress'
-import { SFMoveData } from './subtypes/sfmove'
+import { AssetModel } from './subtypes/asset'
+import { BondsetModel } from './subtypes/bondset'
+import { DelveDomainModel } from './subtypes/delve-domain'
+import { DelveThemeModel } from './subtypes/delve-theme'
+import { ProgressModel } from './subtypes/progress'
+import { SFMoveModel } from './subtypes/sfmove'
 import type { ChallengeRank } from '../constants'
 import type { AssetDataProperties, AssetDataSource } from './subtypes/asset'
 import type {
@@ -33,12 +33,12 @@ const dataModels: Partial<
 		typeof foundry.abstract.TypeDataModel<any, any>
 	>
 > = {
-	'delve-theme': DelveThemeData,
-	'delve-domain': DelveDomainData,
-	progress: ProgressData,
-	asset: AssetData,
-	sfmove: SFMoveData,
-	bondset: BondsetData
+	'delve-theme': DelveThemeModel,
+	'delve-domain': DelveDomainModel,
+	progress: ProgressModel,
+	asset: AssetModel,
+	sfmove: SFMoveModel,
+	bondset: BondsetModel
 }
 
 type ItemType = ConfiguredData<'Item'>['type']

--- a/src/module/item/subtypes/asset.ts
+++ b/src/module/item/subtypes/asset.ts
@@ -2,7 +2,7 @@ import { MeterField } from '../../fields/MeterField'
 import type { DataSchema } from '../../fields/utils'
 import type { IronswornItem } from '../item'
 
-export class AssetData extends foundry.abstract.TypeDataModel<
+export class AssetModel extends foundry.abstract.TypeDataModel<
 	AssetDataSourceData,
 	AssetDataPropertiesData,
 	IronswornItem<'asset'>
@@ -42,7 +42,7 @@ export class AssetData extends foundry.abstract.TypeDataModel<
 		}
 	}
 }
-export interface AssetData extends AssetDataSourceData {}
+export interface AssetModel extends AssetDataSourceData {}
 
 export interface AssetDataSourceData {
 	category: string
@@ -72,8 +72,8 @@ export interface AssetDataProperties {
 	/**
 	 * @deprecated
 	 */
-	data: AssetData
-	system: AssetData
+	data: AssetModel
+	system: AssetModel
 }
 
 export class AssetConditionMeterField extends MeterField<AssetConditionMeter> {

--- a/src/module/item/subtypes/bondset.ts
+++ b/src/module/item/subtypes/bondset.ts
@@ -3,7 +3,7 @@ import type { DataSchema } from '../../fields/utils'
 import { IronswornPrerollDialog } from '../../rolls'
 import type { IronswornItem } from '../item'
 
-export class BondsetData extends foundry.abstract.TypeDataModel<
+export class BondsetModel extends foundry.abstract.TypeDataModel<
 	BondsetDataSourceData,
 	BondsetDataSourceData,
 	IronswornItem<'bondset'>
@@ -41,7 +41,7 @@ export class BondsetData extends foundry.abstract.TypeDataModel<
 		}
 	}
 }
-export interface BondsetData extends BondsetDataSourceData {}
+export interface BondsetModel extends BondsetDataSourceData {}
 
 export interface Bond {
 	name: string
@@ -58,6 +58,6 @@ export interface BondsetDataSource {
 }
 export interface BondsetDataProperties {
 	type: 'bondset'
-	data: BondsetData
-	system: BondsetData
+	data: BondsetModel
+	system: BondsetModel
 }

--- a/src/module/item/subtypes/delve-domain.ts
+++ b/src/module/item/subtypes/delve-domain.ts
@@ -3,7 +3,7 @@ import type { DataSchema } from '../../fields/utils'
 import type { IronswornItem } from '../item'
 import type { DelveSiteDanger, DelveSiteFeature } from './common'
 
-export class DelveDomainData extends foundry.abstract.TypeDataModel<
+export class DelveDomainModel extends foundry.abstract.TypeDataModel<
 	DelveDomainDataSourceData,
 	DelveDomainDataSourceData,
 	IronswornItem<'delve-domain'>
@@ -47,7 +47,7 @@ export class DelveDomainData extends foundry.abstract.TypeDataModel<
 		}
 	}
 }
-export interface DelveDomainData extends DelveDomainDataPropertiesData {}
+export interface DelveDomainModel extends DelveDomainDataPropertiesData {}
 
 export interface DelveDomainDataSourceData {
 	summary: string
@@ -65,6 +65,6 @@ export interface DelveDomainDataSource {
 }
 export interface DelveDomainDataProperties {
 	type: 'delve-domain'
-	data: DelveDomainData
-	system: DelveDomainData
+	data: DelveDomainModel
+	system: DelveDomainModel
 }

--- a/src/module/item/subtypes/delve-theme.ts
+++ b/src/module/item/subtypes/delve-theme.ts
@@ -3,7 +3,7 @@ import type { DataSchema } from '../../fields/utils'
 import type { IronswornItem } from '../item'
 import type { DelveSiteDanger, DelveSiteFeature } from './common'
 
-export class DelveThemeData extends foundry.abstract.TypeDataModel<
+export class DelveThemeModel extends foundry.abstract.TypeDataModel<
 	DelveThemeDataSourceData,
 	DelveThemeDataSourceData,
 	IronswornItem<'delve-theme'>
@@ -39,15 +39,15 @@ export class DelveThemeData extends foundry.abstract.TypeDataModel<
 			summary: new fields.HTMLField(),
 			description: new fields.HTMLField(),
 			features: new fields.ArrayField(new TableResultField() as any, {
-				initial: DelveThemeData.features as DelveSiteFeature[]
+				initial: DelveThemeModel.features as DelveSiteFeature[]
 			}),
 			dangers: new fields.ArrayField(new TableResultField() as any, {
-				initial: DelveThemeData.dangers as DelveSiteDanger[]
+				initial: DelveThemeModel.dangers as DelveSiteDanger[]
 			})
 		}
 	}
 }
-export interface DelveThemeData extends DelveThemeDataPropertiesData {}
+export interface DelveThemeModel extends DelveThemeDataPropertiesData {}
 
 export interface DelveThemeDataSourceData {
 	summary: string
@@ -66,6 +66,6 @@ export interface DelveThemeDataSource {
 }
 export interface DelveThemeDataProperties {
 	type: 'delve-theme'
-	data: DelveThemeData
-	system: DelveThemeData
+	data: DelveThemeModel
+	system: DelveThemeModel
 }

--- a/src/module/item/subtypes/progress.ts
+++ b/src/module/item/subtypes/progress.ts
@@ -8,7 +8,7 @@ import { IronswornPrerollDialog } from '../../rolls'
 import type { IronswornItem } from '../item'
 import type { ProgressBase } from '../config'
 
-export class ProgressData extends foundry.abstract.TypeDataModel<
+export class ProgressModel extends foundry.abstract.TypeDataModel<
 	ProgressDataSourceData,
 	ProgressDataSourceData,
 	IronswornItem<'progress'>
@@ -25,8 +25,8 @@ export class ProgressData extends foundry.abstract.TypeDataModel<
 	/** The derived progress score, which is an integer from 0 to 10. */
 	get score() {
 		return Math.min(
-			Math.floor(this.current / ProgressData.TICKS_PER_BOX),
-			ProgressData.SCORE_MAX
+			Math.floor(this.current / ProgressModel.TICKS_PER_BOX),
+			ProgressModel.SCORE_MAX
 		)
 	}
 
@@ -42,8 +42,8 @@ export class ProgressData extends foundry.abstract.TypeDataModel<
 		return await this.parent.update({
 			'system.current': clamp(
 				this.current + this.unit * units,
-				ProgressData.TICKS_MIN,
-				ProgressData.TICKS_MAX
+				ProgressModel.TICKS_MIN,
+				ProgressModel.TICKS_MAX
 			)
 		})
 	}
@@ -95,7 +95,7 @@ export class ProgressData extends foundry.abstract.TypeDataModel<
 		}
 	}
 }
-export interface ProgressData extends ProgressDataPropertiesData {}
+export interface ProgressModel extends ProgressDataPropertiesData {}
 
 export interface ProgressDataSourceData extends ProgressBase {
 	subtype: string
@@ -114,6 +114,6 @@ export interface ProgressDataSource {
 }
 export interface ProgressDataProperties {
 	type: 'progress'
-	data: ProgressData
-	system: ProgressData
+	data: ProgressModel
+	system: ProgressModel
 }

--- a/src/module/item/subtypes/sfmove.ts
+++ b/src/module/item/subtypes/sfmove.ts
@@ -13,7 +13,7 @@ import { SourceField } from '../../fields/SourceField'
 import type { DataSchema } from '../../fields/utils'
 import type { IronswornItem } from '../item'
 
-export class SFMoveData extends foundry.abstract.TypeDataModel<
+export class SFMoveModel extends foundry.abstract.TypeDataModel<
 	SFMoveDataSourceData,
 	SFMoveDataSourceData,
 	IronswornItem<'sfmove'>
@@ -132,16 +132,16 @@ export class SFMoveOutcomeField extends foundry.data.fields.SchemaField<
 				Reroll: new fields.SchemaField(
 					{
 						Text: new fields.HTMLField(),
-						Dice: new fields.StringField<ValueOf<typeof SFMoveData.rerollType>>(
-							{
-								choices: SFMoveData.rerollType
-							}
-						)
+						Dice: new fields.StringField<
+							ValueOf<typeof SFMoveModel.rerollType>
+						>({
+							choices: SFMoveModel.rerollType
+						})
 					},
 					{ required: false }
 				) as any,
 				'Count as': new fields.StringField({
-					choices: SFMoveData.outcome as any,
+					choices: SFMoveModel.outcome as any,
 					required: false
 				})
 			},
@@ -160,25 +160,27 @@ export class SFMoveOutcomeMatchableField extends foundry.data.fields
 				Reroll: new fields.SchemaField(
 					{
 						Text: new fields.HTMLField(),
-						Dice: new fields.StringField<ValueOf<typeof SFMoveData.rerollType>>(
-							{
-								choices: SFMoveData.rerollType
-							}
-						)
+						Dice: new fields.StringField<
+							ValueOf<typeof SFMoveModel.rerollType>
+						>({
+							choices: SFMoveModel.rerollType
+						})
 					},
 					{ required: false }
 				) as any,
-				'Count as': new fields.StringField<ValueOf<typeof SFMoveData.outcome>>({
-					choices: SFMoveData.outcome,
-					required: false
-				}) as any,
+				'Count as': new fields.StringField<ValueOf<typeof SFMoveModel.outcome>>(
+					{
+						choices: SFMoveModel.outcome,
+						required: false
+					}
+				) as any,
 				'With a Match': new SFMoveOutcomeField({ required: false }) as any
 			},
 			options
 		)
 	}
 }
-export interface SFMoveData extends SFMoveDataSourceData {}
+export interface SFMoveModel extends SFMoveDataSourceData {}
 
 export interface SFMoveDataSourceData
 	extends Required<
@@ -209,11 +211,11 @@ export class SFMoveTriggerOptionField extends foundry.data.fields
 		const fields = foundry.data.fields
 		super({
 			'Roll type': new fields.StringField<any, any>({
-				choices: SFMoveData.rollType
+				choices: SFMoveModel.rollType
 			}),
 			Text: new fields.HTMLField(),
 			Method: new fields.StringField<any, any>({
-				choices: SFMoveData.rollMethod
+				choices: SFMoveModel.rollMethod
 			}),
 			Using: new fields.ArrayField(new fields.StringField() as any)
 		})
@@ -238,6 +240,6 @@ export interface SFMoveDataSource {
 }
 export interface SFMoveDataProperties {
 	type: 'sfmove'
-	data: SFMoveData
-	system: SFMoveData
+	data: SFMoveModel
+	system: SFMoveModel
 }

--- a/src/module/vue/components/progress/progress-track.vue
+++ b/src/module/vue/components/progress/progress-track.vue
@@ -12,8 +12,8 @@
 		:data-ticks="ticks"
 		:data-score="score"
 		:aria-valuenow="ticks"
-		:aria-valuemin="ProgressData.TICKS_MIN"
-		:aria-valuemax="ProgressData.TICKS_MAX"
+		:aria-valuemin="ProgressModel.TICKS_MIN"
+		:aria-valuemax="ProgressModel.TICKS_MAX"
 		:aria-valuetext="$t('IRONSWORN.PROGRESS.Current', { score, ticks })"
 		:data-tooltip="$t('IRONSWORN.PROGRESS.Current', { score, ticks })">
 		<ProgressTrackBox
@@ -21,7 +21,7 @@
 			:key="`progress-box-${i + 1}`"
 			tabindex="-1"
 			role="presentational"
-			:ticks="boxTicks ?? ProgressData.TICKS_MIN"
+			:ticks="boxTicks ?? ProgressModel.TICKS_MIN"
 			:is-overflow-box="legacyOverflow" />
 	</article>
 </template>
@@ -31,7 +31,7 @@ import { computed } from 'vue'
 import { fill } from 'lodash-es'
 import type { ChallengeRank } from '../../../constants.js'
 import ProgressTrackBox from './progress-track-box.vue'
-import { ProgressData } from '../../../item/subtypes/progress'
+import { ProgressModel } from '../../../item/subtypes/progress'
 
 const props = defineProps<{
 	/**
@@ -51,26 +51,26 @@ const props = defineProps<{
 
 const score = computed(() =>
 	Math.clamped(
-		Math.floor(props.ticks / ProgressData.TICKS_PER_BOX),
-		ProgressData.SCORE_MIN,
-		ProgressData.SCORE_MAX
+		Math.floor(props.ticks / ProgressModel.TICKS_PER_BOX),
+		ProgressModel.SCORE_MIN,
+		ProgressModel.SCORE_MAX
 	)
 )
 
 const visibleTicks = computed(() =>
-	props.ticks > ProgressData.TICKS_MAX
-		? props.ticks % ProgressData.TICKS_MAX
+	props.ticks > ProgressModel.TICKS_MAX
+		? props.ticks % ProgressModel.TICKS_MAX
 		: props.ticks
 )
 
 const boxes = computed(() => {
-	const boxTicks = Array<number>(ProgressData.BOXES)
+	const boxTicks = Array<number>(ProgressModel.BOXES)
 	const filledBoxes = Math.floor(
-		visibleTicks.value / ProgressData.TICKS_PER_BOX
+		visibleTicks.value / ProgressModel.TICKS_PER_BOX
 	)
-	const ticksRemainder = visibleTicks.value % ProgressData.TICKS_PER_BOX
+	const ticksRemainder = visibleTicks.value % ProgressModel.TICKS_PER_BOX
 
-	fill(boxTicks, ProgressData.TICKS_PER_BOX, 0, filledBoxes)
+	fill(boxTicks, ProgressModel.TICKS_PER_BOX, 0, filledBoxes)
 	if (ticksRemainder > 0) {
 		boxTicks[filledBoxes] = ticksRemainder
 	}

--- a/src/module/vue/sf-charactermovesheet.vue
+++ b/src/module/vue/sf-charactermovesheet.vue
@@ -42,7 +42,6 @@
 import SfMovesheetmoves from './components/sf-movesheetmoves.vue'
 import SfMovesheetoracles from './components/sf-movesheetoracles.vue'
 import { computed, provide, ref } from 'vue'
-import type { CharacterData } from '../actor/config'
 import { ActorKey } from './provisions.js'
 import TabSet from './components/tabs/tab-set.vue'
 import TabList from './components/tabs/tab-list.vue'


### PR DESCRIPTION
Just some type data model renames. Rationale: `FooModel` is more informative/specific than `FooData`. `CharacterData` in particular shares a name with a DOM type, which gets annoying for tab completion.

I'll merge this once it passes CI; direct references to the type data models aren't widespread.