### PR TITLE
add trackable attribute config

### DIFF
--- a/src/module/actor/config.ts
+++ b/src/module/actor/config.ts
@@ -44,6 +44,7 @@ export interface ActorConfig extends _actorConfig {
 	dataModels: Record<ActorType, typeof foundry.abstract.TypeDataModel<any, any>>
 	typeLabels: Record<ActorType, string>
 	typeIcons: Record<ActorType, string>
+	trackableAttributes: Record<ActorType, { bar: string[]; value: string[] }>
 }
 
 const config: Partial<ActorConfig> = {
@@ -64,8 +65,19 @@ const config: Partial<ActorConfig> = {
 		shared: 'fa-solid fa-people-group',
 		site: 'fa-solid fa-dungeon',
 		starship: 'fa-solid fa-starship-freighter'
+	},
+	trackableAttributes: {
+		character: {
+			bar: ['momentum', 'health', 'spirit', 'supply'],
+			value: ['edge', 'heart', 'iron', 'shadow', 'wits']
+		},
+		foe: { bar: [], value: [] },
+		location: { bar: [], value: [] },
+		shared: { bar: ['supply'], value: [] },
+		site: { bar: [], value: [] },
+		starship: { bar: [], value: [] }
 	}
-} as const
+}
 
 export default config
 


### PR DESCRIPTION
Configures trackable attributes by token actor subtype. I'd like to expand this later by making it possible to show progress on a token, but this should cut out some of the noise for now.

documentation: https://foundryvtt.com/article/system-data-models/

Not a big change so I'll merge this immediately.