### PR TITLE
restructure move row components to circumvent vue complaint

### DIFF
--- a/src/module/vue/components/buttons/btn-rollmove.vue
+++ b/src/module/vue/components/buttons/btn-rollmove.vue
@@ -9,7 +9,7 @@
 		aria-haspopup="dialog"
 		icon="ironsworn:d10-tilt"
 		v-bind="($props, $attrs)"
-		@click="rollMove">
+		@click="clickFn($actor, move)">
 		<template v-for="(_, slot) of $slots" #[slot]="scope">
 			<slot :name="slot" v-bind="scope" />
 		</template>
@@ -18,34 +18,27 @@
 
 <script setup lang="ts">
 import { inject } from 'vue'
+import { IronswornActor } from '../../../actor/actor'
 import type { Move } from '../../../features/custommoves.js'
 import { IronswornPrerollDialog } from '../../../rolls'
 import { $ActorKey } from '../../provisions'
 import IronBtn from './iron-btn.vue'
 
 interface Props extends Omit<PropsOf<typeof IronBtn>, 'tooltip'> {
-	move?: Move
-	overrideClick?: boolean
-
-	// Hack: if we declare `click` in the emits, there's no $attrs['onClick']
-	// This allows us to check for presence and still use $emit('click')
-	// https://github.com/vuejs/core/issues/4736#issuecomment-934156497
-	onClick?: Function
+	move: Move
+	clickFn?: (actor: IronswornActor | undefined, move: Move) => void
 }
+const $actor = inject($ActorKey, undefined)
 
-const props = defineProps<Props>()
-
-const $actor = inject($ActorKey)
-const $emit = defineEmits(['click'])
-
-async function rollMove() {
-	if (props.overrideClick && props.onClick) return $emit('click')
-	if (!props.move) throw new Error('No move?')
-	if (props.move.dataforgedMove)
-		return IronswornPrerollDialog.showForOfficialMove(
-			props.move?.dataforgedMove.$id,
-			{ actor: $actor }
-		)
-	IronswornPrerollDialog.showForMove(props.move.moveItem(), { actor: $actor })
-}
+const props = withDefaults(defineProps<Props>(), {
+	clickFn: async (actor: IronswornActor | undefined, move: Move) => {
+		if (!move) throw new Error('No move?')
+		if (move.dataforgedMove)
+			return IronswornPrerollDialog.showForOfficialMove(
+				move?.dataforgedMove.$id,
+				{ actor }
+			)
+		IronswornPrerollDialog.showForMove(move.moveItem(), { actor })
+	}
+})
 </script>

--- a/src/module/vue/components/sf-moverow.vue
+++ b/src/module/vue/components/sf-moverow.vue
@@ -22,19 +22,31 @@
 				class="nogrow"
 				data-tooltip-direction="UP"
 				data-tourid="move-buttons">
-				<BtnRollmove
-					:disabled="!canRoll"
-					:move="move"
-					:class="$style.btn"
-					:override-click="onRollClick !== undefined"
-					@click="$emit('rollClick')" />
-				<BtnOracle
-					:node="data.oracles[0] ?? {}"
-					:disabled="preventOracle"
-					:class="$style.btn"
-					:override-click="onOracleClick !== undefined"
-					@click="$emit('oracleClick')" />
-				<BtnSendmovetochat :move="move" :class="$style.btn" />
+				<slot name="controls">
+					<slot
+						name="btn-roll-move"
+						v-bind="{ disabled: !canRoll, move, class: $style.btn }">
+						<BtnRollmove
+							:disabled="!canRoll"
+							:move="move"
+							:class="$style.btn" />
+					</slot>
+					<slot
+						name="btn-oracle"
+						v-bind="{
+							node: data.oracles[0] ?? {},
+							disabled: preventOracle,
+							class: $style.btn
+						}">
+						<BtnOracle
+							:node="data.oracles[0] ?? {}"
+							:disabled="preventOracle"
+							:class="$style.btn" />
+					</slot>
+					<slot name="btn-chat" v-bind="{ move, class: $style.btn }">
+						<BtnSendmovetochat :move="move" :class="$style.btn" />
+					</slot>
+				</slot>
 			</section>
 		</template>
 		<template #default>
@@ -79,13 +91,6 @@ const props = withDefaults(
 		headingLevel?: number
 		toggleSectionClass?: any
 		toggleButtonClass?: any
-		oracleDisabled?: true | false | null
-
-		// Hack: if we declare `click` in the emits, there's no $attrs['onClick']
-		// This allows us to check for presence and still use $emit('click')
-		// https://github.com/vuejs/core/issues/4736#issuecomment-934156497
-		onRollClick?: Function
-		onOracleClick?: Function
 		/**
 		 * Props to be passed to the Collapsible component.
 		 */
@@ -123,21 +128,10 @@ const data = reactive({
 
 const $collapsible = ref<typeof Collapsible>()
 
-type CollapsibleEmits = (typeof Collapsible)['$emit']
-
-interface MoveRowEmits extends CollapsibleEmits {
-	rollClick(): void
-	oracleClick(): void
-}
-
-const $emit = defineEmits<MoveRowEmits>()
-
 const canRoll = computed(() => {
-	if (props.onRollClick) return true
 	return moveHasRollableOptions($item.value)
 })
 const preventOracle = computed(() => {
-	if (props.oracleDisabled !== null) return props.oracleDisabled
 	return data.oracles.length !== 1
 })
 

--- a/src/module/vue/components/site/site-moves.vue
+++ b/src/module/vue/components/site/site-moves.vue
@@ -22,9 +22,14 @@
 			<SfMoverow
 				v-if="moves.revealADanger"
 				:move="moves.revealADanger"
-				class="nogrow"
-				:oracle-disabled="!hasThemeAndDomain"
-				@oracleClick="revealADanger" />
+				class="nogrow">
+				<template #btn-oracle="{ disabled, ...props }">
+					<BtnOracle
+						v-bind="props"
+						:disabled="disabled || !hasThemeAndDomain"
+						@click="revealADanger" />
+				</template>
+			</SfMoverow>
 		</li>
 		<li class="list-block-item" :class="$style.listItem">
 			<SfMoverow
@@ -36,8 +41,11 @@
 			<SfMoverow
 				v-if="moves.locateObjective"
 				:move="moves.locateObjective"
-				class="nogrow"
-				@rollClick="locateObjective" />
+				class="nogrow">
+				<template #btn-roll-move="{ disabled, ...props }">
+					<BtnRollmove v-bind="props" :clickFn="locateObjective" />
+				</template>
+			</SfMoverow>
 		</li>
 		<li class="list-block-item" :class="$style.listItem">
 			<SfMoverow
@@ -62,6 +70,8 @@ import type { Move } from '../../../features/custommoves'
 import { createIronswornMoveTree } from '../../../features/custommoves'
 import { IronswornPrerollDialog } from '../../../rolls'
 import { $ActorKey, ActorKey } from '../../provisions'
+import BtnOracle from '../buttons/btn-oracle.vue'
+import BtnRollmove from '../buttons/btn-rollmove.vue'
 
 import SfMoverow from '../sf-moverow.vue'
 
@@ -114,15 +124,11 @@ async function locateObjective() {
 	if (!$site) return
 	const progress = Math.floor($site.system.current / 4)
 
-	IronswornPrerollDialog.showForOfficialMove(
-		'Ironsworn/Moves/Delve/Locate_Your_Objective',
-		{
-			actor: $site,
-			progress: {
-				source: $site.name ?? '',
-				value: progress
-			}
-		}
+	IronswornPrerollDialog.showForProgress(
+		$site.name ?? '',
+		progress,
+		$site,
+		'Ironsworn/Moves/Delve/Locate_Your_Objective'
 	)
 }
 </script>


### PR DESCRIPTION
So far as I can tell this is what's causing dependabot's vue-tsc 1.8+ to fail our CI. In hindsight, using slots is probably better than props in this context anyways (main reason I didn't when I wrote the component is I didn't understand slot bindings at the time).

Fairly simple change, I'll merge this shortly.