### PR TITLE
Replace marked with FVTT-provided showdown

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -41,42 +41,48 @@ module.exports = {
 		'no-undef': 'off',
 
 		// FIXME: part of standard-ts. not an awful idea, but it's not doable via autofix, so it's disabled for now
-		'@typescript-eslint/explicit-function-return-type': 'off',
+		'@typescript-eslint/explicit-function-return-type': 'off'
 
 		// prefer lodash-es to regular lodash, and FVTT-provided utilities to lodash utilities
-		'no-restricted-imports': [
-			'error',
-			{
-				paths: [
+	},
+	overrides: [
+		{
+			files: '*.ts',
+			rules: {
+				// restrict imports that duplicate libraries provided by FVTT at run-time
+				'no-restricted-imports': [
+					'error',
 					{
-						name: 'marked',
-						message: 'Please use CONFIG.IRONSWORN.showdown instead.'
-					},
-					{
-						name: 'lodash',
-						message: 'Please use lodash-es instead.'
-					},
-					{
-						name: 'lodash-es',
-						importNames: ['clamp'],
-						message: 'Please use FVTT Math.clamped instead.'
-					},
-					{
-						name: 'lodash-es',
-						importNames: ['capitalize'],
-						message: 'Please use FVTT String#capitalize instead.'
-					},
-					{
-						name: 'lodash-es',
-						importNames: ['range'],
-						message:
-							'Please use FVTT Array#fromRange instead, where possible. Note that Array#fromRange orders its parameters differently, and its maximum is inclusive rather than exclusive.'
+						paths: [
+							{
+								name: 'marked',
+								message: 'Please use CONFIG.IRONSWORN.showdown instead.'
+							},
+							{
+								name: 'lodash',
+								message: 'Please use lodash-es instead.'
+							},
+							{
+								name: 'lodash-es',
+								importNames: ['clamp'],
+								message: 'Please use FVTT Math.clamped instead.'
+							},
+							{
+								name: 'lodash-es',
+								importNames: ['capitalize'],
+								message: 'Please use FVTT String#capitalize instead.'
+							},
+							{
+								name: 'lodash-es',
+								importNames: ['range'],
+								message:
+									'Please use FVTT Array#fromRange instead, where possible. Note that Array#fromRange orders its parameters differently, and its maximum is inclusive rather than exclusive.'
+							}
+						]
 					}
 				]
 			}
-		]
-	},
-	overrides: [
+		},
 		{
 			files: ['*.ts', '*.js', '*.cjs'],
 			parserOptions: { project: './tsconfig.json' }

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -49,6 +49,10 @@ module.exports = {
 			{
 				paths: [
 					{
+						name: 'marked',
+						message: 'Please use CONFIG.IRONSWORN.showdown instead.'
+					},
+					{
 						name: 'lodash',
 						message: 'Please use lodash-es instead.'
 					},

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,8 @@ export interface IronswornConfig {
 	actorClass: typeof IronswornActor
 	OracleTable: typeof OracleTable
 
+	showdown: showdown.Converter
+
 	applications: {
 		// Dialogs
 		FirstStartDialog: typeof FirstStartDialog
@@ -65,6 +67,11 @@ export interface IronswornConfig {
 export const IRONSWORN: IronswornConfig = {
 	actorClass: IronswornActor,
 	OracleTable,
+
+	// TODO: if we wanted to implement enrichMarkdown as a showdown plugin, we could use our own instance instead.
+	get showdown() {
+		return JournalTextPageSheet._converter
+	},
 
 	applications: {
 		FirstStartDialog,

--- a/src/module/dataforged/rendering.ts
+++ b/src/module/dataforged/rendering.ts
@@ -1,6 +1,5 @@
 import type { IMove } from 'dataforged'
 import { get, set } from 'lodash-es'
-import { marked } from 'marked'
 import { hash } from '.'
 
 const COMPENDIUM_KEY_MAP = {
@@ -49,8 +48,8 @@ export function renderLinksInStr(text: string): string {
 	})
 }
 
-export function renderMarkdown(md: string, markedFn = marked.parse) {
-	return markedFn(renderLinksInStr(md))
+export function renderMarkdown(md: string) {
+	return CONFIG.IRONSWORN.showdown.makeHtml(renderLinksInStr(md))
 }
 
 export function renderLinksInMove(move: IMove) {

--- a/src/module/helpers/handlebars.ts
+++ b/src/module/helpers/handlebars.ts
@@ -1,5 +1,4 @@
 import { range, sum } from 'lodash-es'
-import { marked } from 'marked'
 import {
 	ACTION_DICE_ROLLED,
 	ACTION_DIE_SIDES,
@@ -209,12 +208,8 @@ export class IronswornHandlebarsHelpers {
 	}
 
 	static enrichMarkdown(md?: string) {
-		if (!md) return ''
-		const html = marked.parse(md, {
-			gfm: true,
-			mangle: false,
-			headerIds: false
-		})
+		if (md == null) return ''
+		const html = CONFIG.IRONSWORN.showdown.makeHtml(md)
 		return IronswornHandlebarsHelpers.enrichHtml(html)
 	}
 

--- a/src/module/roll-table/oracle-table.ts
+++ b/src/module/roll-table/oracle-table.ts
@@ -2,7 +2,6 @@ import type { RollTableDataConstructorData } from '@league-of-foundry-developers
 import type { ConfiguredFlags } from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes'
 import type { IOracle, IOracleCategory, IRow } from 'dataforged'
 import { max } from 'lodash-es'
-import { marked } from 'marked'
 import type { IronswornActor } from '../actor/actor'
 import { hashLookup, renderLinksInStr } from '../dataforged'
 import { ISOracleCategories, SFOracleCategories } from '../dataforged/data'
@@ -158,9 +157,8 @@ export class OracleTable extends RollTable {
 	static getConstructorData(
 		oracle: OracleTable.IOracleLeaf
 	): RollTableDataConstructorData {
-		const description = marked.parseInline(
-			renderLinksInStr(oracle.Description ?? ''),
-			{ gfm: true, mangle: false, headerIds: false }
+		const description = CONFIG.IRONSWORN.showdown.makeHtml(
+			renderLinksInStr(oracle.Description ?? '')
 		)
 		const maxRoll = max(oracle.Table.map((x) => x.Ceiling ?? 0)) // oracle.Table && maxBy(oracle.Table, (x) => x.Ceiling)?.Ceiling
 		const data: RollTableDataConstructorData = {

--- a/src/module/vue/vue-plugin.ts
+++ b/src/module/vue/vue-plugin.ts
@@ -1,4 +1,3 @@
-import { marked } from 'marked'
 import type { Plugin } from 'vue'
 import { formatRollPlusStat } from '../rolls/ironsworn-roll-message.js'
 import { $EnrichHtmlKey, $EnrichMarkdownKey } from './provisions'
@@ -30,8 +29,10 @@ export function enrichHtml(text) {
 }
 
 export function enrichMarkdown(md?: string): string {
-	if (!md) return ''
-	const html = marked.parse(md, { mangle: false, gfm: true, headerIds: false })
+	if (md == null) return ''
+
+	const html = CONFIG.IRONSWORN.showdown.makeHtml(md)
+
 	return enrichHtml(html)
 }
 

--- a/src/types/const.ts
+++ b/src/types/const.ts
@@ -1,0 +1,16 @@
+declare module '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/constants.mjs' {
+	/**
+	 * The configured showdown bi-directional HTML <-> Markdown converter options.
+	 * @default ```{
+	 * disableForced4SpacesIndentedSublists: true,
+	 * noHeaderId: true,
+	 * parseImgDimensions: true,
+	 * strikethrough: true,
+	 * tables: true,
+	 * tablesHeaderId: true
+	 * }```
+	 */
+	export const SHOWDOWN_OPTIONS: showdown.ShowdownOptions
+}
+
+export {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
 		"lib": ["es2015", "es2019", "dom"],
 		"types": [
 			"@league-of-foundry-developers/foundry-vtt-types",
-			"vite-plugin-svg-icons/client"
+			"vite-plugin-svg-icons/client",
+			"showdown"
 		],
 		"moduleResolution": "node",
 		"sourceMap": true,


### PR DESCRIPTION
Resolves #764 .

`marked` remains in the JS scripts, which don't happen at run-time anyways.

It provides a modest size decrease (at least compared to the ~5 MB monstrosity that is DF):
### Before
![Screenshot_20230626_184132](https://github.com/ben/foundry-ironsworn/assets/5354757/017d1467-2ecc-4754-9a53-5bffb1a1df5b)
### After
![Screenshot_20230626_190137](https://github.com/ben/foundry-ironsworn/assets/5354757/443b68cf-942e-4cdc-8993-2f5edc4e0633)
