### PR TITLE
Call a hook when oracle trees are ready for customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Next Release
 
-- Make player condition meters and momentum available as bar displays on actor tokens
-  - Under the hood: all meter fields are now objects with `max` and `value` properties, rather than a single number value
-- Under the hood: Migrate all actor and item subclasses to DataModel API. This brings several benefits such as stricter run-time validation which improve the reliability of the data used in `foundry-ironsworn`, and near-instant data migrations. It also makes it _much_ easier to implement data migrations for new features in the future.
+- Add a hook that fires when custom oracle registration is ready ([#864](https://github.com/ben/foundry-ironsworn/pull/864))
 - Organize compendium packs into folders
 - Improve appearance of v11 compendium sidebar and popouts with the "Phosphor" theme
-- Under the hood: refactor all `RollTable`s and oracle rolls to use a single standardized pipeline (with `foundry-ironsworn`-style table roll messages) by default; certain kinds of results will fall back to FVTT-style messages instead.
 - Include most of Starforged's oracle icons in the `foundry-ironsworn/assets` directory -- use them as symbolic tokens, map pins, etc
+- Make player condition meters and momentum available as bar displays on actor tokens
+- Under the hood changes:
+  - All meter fields are now objects with `max` and `value` properties, rather than a single number value
+  - Migrate all actor and item subclasses to DataModel API. This brings several benefits such as stricter run-time validation which improve the reliability of the data used in `foundry-ironsworn`, and near-instant data migrations. It also makes it _much_ easier to implement data migrations for new features in the future.
+  - Refactor all `RollTable`s and oracle rolls to use a single standardized pipeline (with `foundry-ironsworn`-style table roll messages) by default; certain kinds of results will fall back to FVTT-style messages instead.
 
 ## 1.21.7
 

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -230,6 +230,7 @@ export async function registerDefaultOracleTrees() {
 	registerOracleTreeInternal('starforged', starforgedOracles)
 
 	defaultTreesInitialized = true
+	Hooks.call('ironswornOracleTreesReady')
 }
 
 // Available in browser


### PR DESCRIPTION
The `ready` hook fires too early for customization efforts to work. This adds a new hook that fires when the default trees are registered, and new registration can take place.

- [x] Add the hook
- [x] Update the [wiki](https://github.com/ben/foundry-ironsworn/wiki/Extensibility#using-registration)
- [x] Update CHANGELOG.md
