### PR TITLE
Multiple tables display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Display all oracle tables in the preview area ([#894](https://github.com/ben/foundry-ironsworn/pull/894))
+
 ## 1.22.5
 
 - Add compendium folders for oracles, moves, and assets

--- a/src/module/vue/components/rules-text/rules-text-oracle.vue
+++ b/src/module/vue/components/rules-text/rules-text-oracle.vue
@@ -1,9 +1,11 @@
 <template>
 	<RulesText class="rules-text-oracle" :source="source" type="slot">
 		<template #default>
+			<h4 v-if="props.title">{{ props.title }}</h4>
 			<OracleTable
 				:table-description="tableDescription"
-				:table-rows="tableRows" />
+				:table-rows="tableRows"
+			/>
 		</template>
 		<template #before-main>
 			<slot name="before-main"></slot>
@@ -17,6 +19,14 @@
 	</RulesText>
 </template>
 
+<style lang="less" scoped>
+h4 {
+	text-transform: uppercase;
+	margin-top: 0.5rem;
+	font-weight: bold;
+}
+</style>
+
 <script setup lang="ts">
 import RulesText from './rules-text.vue'
 import OracleTable from './oracle-table.vue'
@@ -24,6 +34,7 @@ import type { ISource } from 'dataforged'
 import type { LegacyTableRow } from '../../../roll-table/roll-table-types'
 
 const props = defineProps<{
+	title?: string
 	tableRows: LegacyTableRow[]
 	tableDescription: string
 	source?: ISource

--- a/src/module/vue/components/rules-text/rules-text-oracle.vue
+++ b/src/module/vue/components/rules-text/rules-text-oracle.vue
@@ -1,7 +1,7 @@
 <template>
 	<RulesText class="rules-text-oracle" :source="source" type="slot">
 		<template #default>
-			<h4 v-if="props.title">{{ props.title }}</h4>
+			<h4>{{ props.title }}</h4>
 			<OracleTable
 				:table-description="tableDescription"
 				:table-rows="tableRows"


### PR DESCRIPTION
Previously, even if multiple tables were configured for a single oracle tree node, we would only display the first one. This expands that to show all of them.

- [x] Show all the tables
- [x] Collapse descriptions into one place if they all match
- [x] Update CHANGELOG.md
