### PR TITLE
Avoid stripping tables for moves with no oracles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Fix a bug where the _Repair_ move was having its table removed ([#910](https://github.com/ben/foundry-ironsworn/pull/910))
+
 ## 1.22.7
 
 - Fix PopOut! module windows missing custom icons ([#670]https://github.com/ben/foundry-ironsworn/issues/670)

--- a/src/module/rolls/ironsworn-roll-message.ts
+++ b/src/module/rolls/ironsworn-roll-message.ts
@@ -261,13 +261,17 @@ export class IronswornRollMessage {
 		if (this.roll.isMatch && moveOutcome?.['With a Match']?.Text)
 			moveOutcome = moveOutcome['With a Match']
 		if (moveOutcome) {
-			// Render the markdown here so we can strip the tables.
-			// We include oracle buttons in the chat message, no need to
-			// also spam the table contents.
-			ret.moveOutcome = enrichMarkdown(moveOutcome.Text).replace(
-				/<table>[\s\S]*<\/table>/gm,
-				''
-			)
+			// Get the rendered markdown here. If there are oracles, we strip
+			// out the tables, because there will be a button in the chat message.
+			// If no oracles, that table is probably important to the move
+			// (i.e. SF's "Repair" move), so we leave it in.
+			ret.moveOutcome = enrichMarkdown(moveOutcome.Text)
+			if (moveSystem.Oracles?.length > 0) {
+				ret.moveOutcome = ret.moveOutcome.replace(
+					/<table>[\s\S]*<\/table>/gm,
+					''
+				)
+			}
 		}
 		return ret
 	}

--- a/system/templates/chat/sf-move.hbs
+++ b/system/templates/chat/sf-move.hbs
@@ -13,7 +13,11 @@
 		data-move='{{move.Name}}'
 	>
 		<div class='move-outcome'>
-			{{{stripTables (enrichMarkdown move.data.data.Text)}}}
+			{{#if move.system.Oracles?.length}}
+				{{{stripTables (enrichMarkdown move.system.Text)}}}
+			{{else}}
+				{{{enrichMarkdown move.system.Text}}}
+			{{/if}}
 		</div>
 	</div>
 


### PR DESCRIPTION
This fixes a bug with the SF **Repair** move, where there's an important table in the move text, but it was being stripped on the way to the chat message. Now we're mirroring the logic in [`RulesTextMove`](https://github.com/ben/foundry-ironsworn/blob/77d7098efa7cce70283737ad7b4b258393b68ef3/src/module/vue/components/rules-text/rules-text-move.vue), which only strips the tables if there is an oracle (which is probably shown inline, but we hide because there are better ways to get to it).

- [x] Fix the bug
- [x] Update CHANGELOG.md
