### PR TITLE
Truths warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Fix a UI warning when randomizing Starforged truths ([#915]https://github.com/ben/foundry-ironsworn/pull/915)
+
 ## 1.22.8
 
 - Fix a bug where the _Repair_ move was having its table removed ([#910](https://github.com/ben/foundry-ironsworn/pull/910))

--- a/src/module/plugin/custom-icons.ts
+++ b/src/module/plugin/custom-icons.ts
@@ -2,7 +2,7 @@ import { readdirSync } from 'fs'
 import path from 'path'
 
 import type { LegacySyncFunction as SassSyncFunction } from 'sass'
-import Sass from 'sass'
+import * as Sass from 'sass'
 import { assertString } from './sass-assert'
 import { map2SassMap } from './sass-convert'
 

--- a/src/module/plugin/sass-assert.ts
+++ b/src/module/plugin/sass-assert.ts
@@ -1,6 +1,6 @@
 import type { InterpolationMode } from 'chroma-js'
 import type chroma from 'chroma-js'
-import Sass from 'sass'
+import * as Sass from 'sass'
 
 // Hack because the sass types package appears to be incorrect.
 export type SassLegacyValue<T extends Sass.LegacyValue> = T & {

--- a/src/module/plugin/sass-chroma-js.ts
+++ b/src/module/plugin/sass-chroma-js.ts
@@ -4,7 +4,7 @@ import Chroma from 'chroma-js'
 import { last, maxBy, minBy } from 'lodash-es'
 
 import type { LegacySyncFunction as SassSyncFunction } from 'sass'
-import Sass from 'sass'
+import * as Sass from 'sass'
 import type { SassLegacyValue } from './sass-assert'
 import {
 	assertColor,

--- a/src/module/plugin/sass-convert.ts
+++ b/src/module/plugin/sass-convert.ts
@@ -1,5 +1,5 @@
 import Chroma from 'chroma-js'
-import Sass from 'sass'
+import * as Sass from 'sass'
 
 /**
  * Converts a {@link Sass.types.List} to a standard {@link Array}.

--- a/src/module/vue/components/truth/truth-selectable.vue
+++ b/src/module/vue/components/truth/truth-selectable.vue
@@ -5,7 +5,8 @@
 			type="radio"
 			class="nogrow"
 			:name="radioGroup"
-			@change="emitValue" />
+			@change="emitValue"
+		/>
 		<div class="flexcol">
 			<p>
 				<strong>{{ page.name }}</strong>
@@ -17,13 +18,15 @@
 				<label
 					v-for="(entry, i) in page.subtable.results"
 					:key="`subtableRow${i}`"
-					class="flexrow nogrow">
+					class="flexrow nogrow"
+				>
 					<input
 						ref="suboptions"
 						type="radio"
 						class="nogrow"
 						:name="pageSystem.dfid"
-						@change="subtableSelect(entry)" />
+						@change="subtableSelect(entry)"
+					/>
 					<p v-html="entry.text" />
 				</label>
 

--- a/src/module/vue/components/truth/truth-selectable.vue
+++ b/src/module/vue/components/truth/truth-selectable.vue
@@ -77,7 +77,7 @@ const suboptions = ref<HTMLElement[]>([])
 async function selectAndRandomize() {
 	topRadio.value?.click()
 
-	if (props.page.subtable) {
+	if ((props.page.subtable?.length ?? 0) > 0) {
 		const { roll } = await props.page.subtable.draw()
 
 		if (!roll || !roll.total) return

--- a/src/module/vue/components/truth/truth-selectable.vue
+++ b/src/module/vue/components/truth/truth-selectable.vue
@@ -80,7 +80,10 @@ const suboptions = ref<HTMLElement[]>([])
 async function selectAndRandomize() {
 	topRadio.value?.click()
 
-	if ((props.page.subtable?.length ?? 0) > 0) {
+	if (
+		props.page.subtable &&
+		((props.page.subtable?.results as any)?.length ?? 0) > 0
+	) {
 		const { roll } = await props.page.subtable.draw()
 
 		if (!roll || !roll.total) return


### PR DESCRIPTION
Mainly fixing a "there are no available results which can be drawn from this table" when randomizing DF-style truths, but I found a couple niggles along the way.

- [x] Fix the warning
- [x] Fix a Sass import warning
- [x] Allow my editor to run `prettier` on a file
- [x] Update CHANGELOG.md
