### PR TITLE
Fix reveal-a-danger oracle rolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Fix: the site's "reveal a danger" oracle roll wasn't using values from the theme and domain ([#927](https://github.com/ben/foundry-ironsworn/pull/927))
+
 ## 1.22.9
 
 - Fix a UI warning when randomizing Starforged truths ([#915]https://github.com/ben/foundry-ironsworn/pull/915)

--- a/src/module/vue/components/site/site-moves.vue
+++ b/src/module/vue/components/site/site-moves.vue
@@ -27,6 +27,7 @@
 					<BtnOracle
 						v-bind="props"
 						:disabled="disabled || !hasThemeAndDomain"
+						:override-click="true"
 						@click="revealADanger" />
 				</template>
 			</SfMoverow>


### PR DESCRIPTION
As reported in [Discord](https://discord.com/channels/437120373436186625/867434336201605160/1180352305317564478), this wasn't pulling in the values from the theme/domain. Whoopsy.

- [x] Fix the bug
- [x] Update CHANGELOG.md
