### PR TITLE
Add the starship's notes field to the data model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Fix a bug with saving the notes tab on the starship sheet ([#932](https://github.com/ben/foundry-ironsworn/pull/932))
+
 ## 1.22.10
 
 - Fix: the site's "reveal a danger" oracle roll wasn't using values from the theme and domain ([#927](https://github.com/ben/foundry-ironsworn/pull/927))

--- a/src/module/actor/subtypes/starship.ts
+++ b/src/module/actor/subtypes/starship.ts
@@ -9,8 +9,9 @@ export class StarshipModel extends foundry.abstract.TypeDataModel<
 > {
 	static _enableV10Validation = true
 
-	static override defineSchema(): DataSchema<StarshipDataSourceData> {
+	static override defineSchema (): DataSchema<StarshipDataSourceData> {
 		return {
+			notes: new foundry.data.fields.HTMLField(),
 			debility: new foundry.data.fields.SchemaField<
 				StarshipDataSourceData['debility']
 			>({
@@ -23,6 +24,7 @@ export class StarshipModel extends foundry.abstract.TypeDataModel<
 export interface StarshipModel extends StarshipDataSourceData {}
 
 interface StarshipDataSourceData {
+	notes: string
 	debility: {
 		battered: boolean
 		cursed: boolean


### PR DESCRIPTION
Ship sheet notes weren't getting saved. This fixes it so that Foundry recognizes that field as a persistable thing.

- [x] Fix the bug
- [x] Update CHANGELOG.md
