### PR TITLE
"Manual rolling mode"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Extend the new setting into a "manual rolling mode" ([#961](https://github.com/ben/foundry-ironsworn/pull/961))
+
 ## 1.22.12
 
 - Add a setting to default the "advanced" rolling options to expanded ([#960](https://github.com/ben/foundry-ironsworn/pull/960))

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -306,8 +306,8 @@
 				"Hint": "If on, changing any character/shared supply tracker changes all other actors' supply trackers as well."
 			},
 			"AdvancedRollingOpen": {
-				"Name": "Advanced Rolling Options Default",
-				"Hint": "If on, the \"advanced\" section of the roll dialog will default to open."
+				"Name": "Manual Rolling Mode",
+				"Hint": "If on, the \"advanced\" section of the roll dialog will default to open, and focus will be set to the first die-roll entry box."
 			},
 			"LogChanges": {
 				"Name": "Log Character Updates",

--- a/system/templates/rolls/preroll-dialog.hbs
+++ b/system/templates/rolls/preroll-dialog.hbs
@@ -57,14 +57,14 @@
     {{#if action}}
     <fieldset class='form-group'>
       <label>{{localize 'IRONSWORN.RollDialog.PresetActionDie'}}</label>
-      <input type='number' step='1' name='presetActionDieValue' />
+      <input type='number' step='1' name='presetActionDieValue' {{#if advancedOptionsOpen}}autofocus{{/if}} />
     </fieldset>
     {{/if}}
 
     <fieldset class='form-group'>
       <label>{{localize 'IRONSWORN.RollDialog.PresetChallengeDice'}}</label>
       <div class="flexrow" style="gap: var(--ironsworn-spacer-md)">
-        <input type='number' step='1' name='presetChallengeDie1Value' />
+        <input type='number' step='1' name='presetChallengeDie1Value' {{#if advancedOptionsOpen}}autofocus{{/if}} />
         <input type='number' step='1' name='presetChallengeDie2Value' />
       </div>
     </fieldset>


### PR DESCRIPTION
This extends the "Advanced Rolling Options Default" to be a "Manual rolling mode", which also sets an autofocus on the first manual-entry die-roll box in the pre-roll dialog.

- [x] Update the markup
- [x] Update the strings
- [x] Update CHANGELOG.md
