### PR TITLE
Regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Update the SF "sector" dialog to include SI region terms, and make it available via scene-nav right-click ([#996](https://github.com/ben/foundry-ironsworn/pull/996))
+
 ## 1.23.2
 
 - v12: new PCs' tokens are now linked to their actor when created

--- a/src/module/applications/sf/editSectorApp.ts
+++ b/src/module/applications/sf/editSectorApp.ts
@@ -1,3 +1,4 @@
+import { IronswornSettings } from '../../helpers/settings'
 import editSectorVue from '../../vue/edit-sector.vue'
 import { VueAppMixin } from '../../vue/vueapp.js'
 
@@ -7,8 +8,13 @@ export class EditSectorDialog extends VueAppMixin(Application) {
 	}
 
 	static get defaultOptions() {
+		const defaultToolbox = IronswornSettings.defaultToolbox
+		const titleKey =
+			defaultToolbox === 'starforged'
+				? 'IRONSWORN.SCENE.TypeSector'
+				: 'IRONSWORN.SCENE.TypeChart'
 		return foundry.utils.mergeObject(super.defaultOptions, {
-			title: game.i18n.localize('IRONSWORN.SCENE.TypeSector'),
+			title: game.i18n.localize(titleKey),
 			id: 'edit-sector-dialog',
 			resizable: true,
 			left: 115,

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -252,7 +252,7 @@ function sunderedIslesControl(
 	if (game.user?.isGM) {
 		control.tools.push({
 			name: 'edit',
-			icon: 'isicon-region-sf', // TODO: sundered isles
+			icon: 'isicon-region-sf', // TODO: sundered isles icon
 			title: game.i18n.format('DOCUMENT.Update', {
 				type: game.i18n.localize('IRONSWORN.SCENE.TypeChart')
 			}),
@@ -290,3 +290,14 @@ class IronswornCanvasLayer extends InteractionLayer {
 		return []
 	}
 }
+
+Hooks.on('getSceneNavigationContext', (_html, contextOptions) => {
+	contextOptions.push({
+		name: game.i18n.format('DOCUMENT.Update', {
+			type: game.i18n.localize('IRONSWORN.SCENE.TypeChart')
+		}),
+		icon: '<i class="fa isicon-region-sf" style="display: inline-block;"></i>', // TODO: sundered isles icon
+		condition: game.user?.isGM,
+		callback: editSector
+	})
+})

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -37,10 +37,10 @@ async function ensureFolder(...path: string[]): Promise<Folder | undefined> {
 	return parentFolder
 }
 
-function editSector() {
+async function editSector() {
 	const sceneId = game.user?.viewedScene
 	if (sceneId) {
-		void new EditSectorDialog(sceneId).render(true)
+		await new EditSectorDialog(sceneId).render(true, { focus: true })
 	}
 }
 
@@ -148,94 +148,133 @@ export function activateSceneButtonListeners() {
 		}
 		controls[0].tools.push(oracleButton)
 
-		// TODO: sundered isles
-		if (IronswornSettings.defaultToolbox === 'starforged') {
-			const sfControl: SceneControl = {
-				name: 'Starforged',
-				title: game.i18n.localize('IRONSWORN.StarforgedTools'),
-				icon: 'isicon-logo-starforged-dk',
-				layer: 'ironsworn',
-				visible: true,
-				activeTool: 'select',
-				tools: [oracleButton]
-			}
+		const control =
+			IronswornSettings.defaultToolbox === 'starforged'
+				? starforgedControl(oracleButton)
+				: IronswornSettings.defaultToolbox === 'sunderedisles'
+				? sunderedIslesControl(oracleButton)
+				: ironswornControl(oracleButton)
 
-			if (game.user?.isGM) {
-				sfControl.tools.push(
-					{
-						name: 'edit',
-						icon: 'isicon-region-sf',
-						title: game.i18n.format('DOCUMENT.Update', {
-							type: game.i18n.localize('IRONSWORN.SCENE.TypeSector')
-						}),
-						onClick: editSector
-					},
-					// { // TODO: maybe reenable this when we have a good way of doing it
-					//   name: 'sector',
-					//   icon: 'isicon-sector',
-					//   title: game.i18n.format('DOCUMENT.Create',{type: ('IRONSWORN.SCENE.TypeSector')}),
-					//   onClick: warn,
-					// },
-					{
-						name: 'star',
-						icon: 'isicon-stellar-object',
-						title: game.i18n.format('DOCUMENT.Create', {
-							type: game.i18n.localize('IRONSWORN.ACTOR.SubtypeStar')
-						}),
-						onClick: newStar
-					},
-					{
-						name: 'planet',
-						icon: 'isicon-world',
-						title: game.i18n.format('DOCUMENT.Create', {
-							type: game.i18n.localize('IRONSWORN.ACTOR.SubtypePlanet')
-						}),
-						onClick: newPlanet
-					},
-					{
-						name: 'settlement',
-						icon: 'isicon-settlement-sf',
-						title: game.i18n.format('DOCUMENT.Create', {
-							type: game.i18n.localize('IRONSWORN.ACTOR.SubtypeSettlement')
-						}),
-						onClick: newSettlement
-					},
-					{
-						name: 'derelict',
-						icon: 'isicon-derelict',
-						title: game.i18n.format('DOCUMENT.Create', {
-							type: game.i18n.localize('IRONSWORN.ACTOR.SubtypeDerelict')
-						}),
-						onClick: newDerelict
-					},
-					{
-						name: 'vault',
-						icon: 'isicon-precursor-vault',
-						title: game.i18n.format('DOCUMENT.Create', {
-							type: game.i18n.localize('IRONSWORN.ACTOR.SubtypeVault')
-						}),
-						onClick: newVault
-					}
-				)
-			}
-
-			controls.push(sfControl)
-		} else {
-			const isControl: SceneControl = {
-				name: 'Ironsworn',
-				title: game.i18n.localize('IRONSWORN.IronswornTools'),
-				icon: 'isicon-logo-ironsworn-dk',
-				layer: 'ironsworn',
-				visible: true,
-				activeTool: 'select',
-				tools: [oracleButton]
-			}
-
-			controls.push(isControl)
-		}
+		if (control) controls.push(control)
 
 		return controls
 	})
+}
+
+function starforgedControl(
+	oracleButton: SceneControlToolNoToggle
+): SceneControl {
+	const sfControl: SceneControl = {
+		name: 'Starforged',
+		title: game.i18n.localize('IRONSWORN.StarforgedTools'),
+		icon: 'isicon-logo-starforged-dk',
+		layer: 'ironsworn',
+		visible: true,
+		activeTool: 'select',
+		tools: [oracleButton]
+	}
+
+	if (game.user?.isGM) {
+		sfControl.tools.push(
+			{
+				name: 'edit',
+				icon: 'isicon-region-sf',
+				title: game.i18n.format('DOCUMENT.Update', {
+					type: game.i18n.localize('IRONSWORN.SCENE.TypeSector')
+				}),
+				onClick: editSector
+			},
+			// { // TODO: maybe reenable this when we have a good way of doing it
+			//   name: 'sector',
+			//   icon: 'isicon-sector',
+			//   title: game.i18n.format('DOCUMENT.Create',{type: ('IRONSWORN.SCENE.TypeSector')}),
+			//   onClick: warn,
+			// },
+			{
+				name: 'star',
+				icon: 'isicon-stellar-object',
+				title: game.i18n.format('DOCUMENT.Create', {
+					type: game.i18n.localize('IRONSWORN.ACTOR.SubtypeStar')
+				}),
+				onClick: newStar
+			},
+			{
+				name: 'planet',
+				icon: 'isicon-world',
+				title: game.i18n.format('DOCUMENT.Create', {
+					type: game.i18n.localize('IRONSWORN.ACTOR.SubtypePlanet')
+				}),
+				onClick: newPlanet
+			},
+			{
+				name: 'settlement',
+				icon: 'isicon-settlement-sf',
+				title: game.i18n.format('DOCUMENT.Create', {
+					type: game.i18n.localize('IRONSWORN.ACTOR.SubtypeSettlement')
+				}),
+				onClick: newSettlement
+			},
+			{
+				name: 'derelict',
+				icon: 'isicon-derelict',
+				title: game.i18n.format('DOCUMENT.Create', {
+					type: game.i18n.localize('IRONSWORN.ACTOR.SubtypeDerelict')
+				}),
+				onClick: newDerelict
+			},
+			{
+				name: 'vault',
+				icon: 'isicon-precursor-vault',
+				title: game.i18n.format('DOCUMENT.Create', {
+					type: game.i18n.localize('IRONSWORN.ACTOR.SubtypeVault')
+				}),
+				onClick: newVault
+			}
+		)
+	}
+
+	return sfControl
+}
+
+function sunderedIslesControl(
+	oracleButton: SceneControlToolNoToggle
+): SceneControl {
+	const control: SceneControl = {
+		name: 'Starforged',
+		title: game.i18n.localize('IRONSWORN.SunderedIslesTools'),
+		icon: 'isicon-logo-starforged-dk',
+		layer: 'ironsworn',
+		visible: true,
+		activeTool: 'select',
+		tools: [oracleButton]
+	}
+
+	if (game.user?.isGM) {
+		control.tools.push({
+			name: 'edit',
+			icon: 'isicon-region-sf', // TODO: sundered isles
+			title: game.i18n.format('DOCUMENT.Update', {
+				type: game.i18n.localize('IRONSWORN.SCENE.TypeChart')
+			}),
+			onClick: editSector
+		})
+	}
+
+	return control
+}
+
+function ironswornControl(
+	oracleButton: SceneControlToolNoToggle
+): SceneControl {
+	return {
+		name: 'Ironsworn',
+		title: game.i18n.localize('IRONSWORN.IronswornTools'),
+		icon: 'isicon-logo-ironsworn-dk',
+		layer: 'ironsworn',
+		visible: true,
+		activeTool: 'select',
+		tools: [oracleButton]
+	}
 }
 
 // @ts-expect-error

--- a/src/module/vue/edit-sector.vue
+++ b/src/module/vue/edit-sector.vue
@@ -4,25 +4,26 @@
 			{{ $t('IRONSWORN.Region') }}
 			<i class="fa fa-circle-question" data-tooltip="IRONSWORN.RegionTip"></i>
 		</h4>
-		<label class="nogrow">
-			<input v-model="region" type="radio" value="terminus" />
-			{{ $t('IRONSWORN.REGION.Terminus') }}
-		</label>
-		<label class="nogrow">
-			<input v-model="region" type="radio" value="outlands" />
-			{{ $t('IRONSWORN.REGION.Outlands') }}
-		</label>
-		<label class="nogrow">
-			<input v-model="region" type="radio" value="expanse" />
-			{{ $t('IRONSWORN.REGION.Expanse') }}
+		<label class="nogrow" v-for="option in options">
+			<input v-model="region" type="radio" :value="option.toLowerCase()" />
+			{{ $t(`IRONSWORN.REGION.${option}`) }}
 		</label>
 	</div>
 </template>
 
 <script setup lang="ts">
 import { watch, ref } from 'vue'
+import { IronswornSettings } from '../helpers/settings'
 
 const props = defineProps<{ data: { sceneId: string } }>()
+
+const defaultToolbox = IronswornSettings.defaultToolbox
+const options: string[] =
+	defaultToolbox === 'starforged'
+		? ['Terminus', 'Outlands', 'Expanse']
+		: defaultToolbox === 'sunderedisles'
+		? ['Myriads', 'Margins', 'Reaches']
+		: []
 
 const scene = game.scenes?.get(props.data.sceneId)
 const region = ref<string>(scene?.flags['foundry-ironsworn']?.['region'])

--- a/src/module/vue/edit-sector.vue
+++ b/src/module/vue/edit-sector.vue
@@ -5,36 +5,30 @@
 			<i class="fa fa-circle-question" data-tooltip="IRONSWORN.RegionTip"></i>
 		</h4>
 		<label class="nogrow">
-			<input v-model="data.region" type="radio" value="terminus" />
+			<input v-model="region" type="radio" value="terminus" />
 			{{ $t('IRONSWORN.REGION.Terminus') }}
 		</label>
 		<label class="nogrow">
-			<input v-model="data.region" type="radio" value="outlands" />
+			<input v-model="region" type="radio" value="outlands" />
 			{{ $t('IRONSWORN.REGION.Outlands') }}
 		</label>
 		<label class="nogrow">
-			<input v-model="data.region" type="radio" value="expanse" />
+			<input v-model="region" type="radio" value="expanse" />
 			{{ $t('IRONSWORN.REGION.Expanse') }}
 		</label>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, watch } from 'vue'
+import { watch, ref } from 'vue'
 
 const props = defineProps<{ data: { sceneId: string } }>()
 
-function foundryScene() {
-	const scene = game.scenes?.get(props.data.sceneId)
-	console.log(scene)
-	return scene
-}
-const scene = computed(() => foundryScene()?.toObject() as any)
+const scene = game.scenes?.get(props.data.sceneId)
+const region = ref<string>(scene?.flags['foundry-ironsworn']?.['region'])
 
-const data = reactive({
-	region: scene.value?.flags['foundry-ironsworn']?.['region']
-})
-watch(data, ({ region }) => {
-	foundryScene()?.setFlag('foundry-ironsworn', 'region', region)
+// Send updates to Foundry
+watch(region, (newValue) => {
+	scene?.setFlag('foundry-ironsworn', 'region', newValue)
 })
 </script>

--- a/src/module/vue/edit-sector.vue
+++ b/src/module/vue/edit-sector.vue
@@ -26,6 +26,7 @@ const options: string[] =
 		: []
 
 const scene = game.scenes?.get(props.data.sceneId)
+// @ts-expect-error scene.flags isn't in the types
 const region = ref<string>(scene?.flags['foundry-ironsworn']?.['region'])
 
 // Send updates to Foundry

--- a/src/styles/icons.less
+++ b/src/styles/icons.less
@@ -241,6 +241,7 @@ i {
 	npc: 'https://game-icons.net/1x1/lorc/drama-masks.html';
 	precursor-vault: 'https://game-icons.net/1x1/lorc/moebius-triangle.html';
 	region-sf: 'https://game-icons.net/1x1/delapouite/galaxy.html';
+	// TODO: sundered isles region-si: 'https://game-icons.net/1x1/delapouite/galaxy.html';
 	sector: 'https://game-icons.net/1x1/skoll/hexes.html';
 	settlement-is: 'https://game-icons.net/1x1/delapouite/huts-village.html';
 	settlement-sf: 'https://game-icons.net/1x1/delapouite/modern-city.html';

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -229,6 +229,7 @@
 		"Fifth": "fifth",
 		"StarforgedTools": "Starforged Tools",
 		"IronswornTools": "Ironsworn Tools",
+		"SunderedIslesTools": "Sundered Isles Tools",
 		"Region": "Region",
 		"RegionTip": "This sets the default region for locations in this scene. It affects the outcomes of some location oracles.",
 		"REGION": {

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -234,7 +234,10 @@
 		"REGION": {
 			"Terminus": "Terminus",
 			"Outlands": "Outlands",
-			"Expanse": "Expanse"
+			"Expanse": "Expanse",
+			"Myriads": "Myriads",
+			"Margins": "Margins",
+			"Reaches": "Reaches"
 		},
 		"RotateCCW": "Rotate counter-clockwise",
 		"RotateCW": "Rotate clockwise",
@@ -674,7 +677,8 @@
 			"TypeOracle": "Oracles"
 		},
 		"SCENE": {
-			"TypeSector": "Sector"
+			"TypeSector": "Sector",
+			"TypeChart": "Chart"
 		},
 		"SCENES": {
 			"TypeSector": "Sectors"


### PR DESCRIPTION
This updates the scene-oriented "sector" dialog to also work for Sundered Isles regions.

- [x] Update the dialog to use SI terms when SI is the default toolbox
- [x] Add an SI category to the sidebar, with the oracle and region buttons
- [x] Add an update-sector menu item to the context menu of nav-bar scenes
- [x] Update CHANGELOG.md
