### PR TITLE
Oceanic theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Update the SF "sector" dialog to include SI region terms, and make it available via scene-nav right-click ([#996](https://github.com/ben/foundry-ironsworn/pull/996))
+- Add the beginnings of an "Oceanic" color theme ([#997](https://github.com/ben/foundry-ironsworn/pull/997))
 
 ## 1.23.2
 

--- a/src/module/features/ironcolor.ts
+++ b/src/module/features/ironcolor.ts
@@ -4,6 +4,7 @@ import '../../styles/styles.less'
 import '../../styles/_irontheme.scss'
 import '../../styles/_ironcolor/zinc.scss'
 import '../../styles/_ironcolor/phosphor.scss'
+import '../../styles/_ironcolor/oceanic.scss'
 
 export const PREFIX = 'ironcolor__'
 const tinyMceCssPath =

--- a/src/module/helpers/settings.ts
+++ b/src/module/helpers/settings.ts
@@ -30,7 +30,7 @@ declare global {
 				| 'sheet'
 
 			'foundry-ironsworn.theme': keyof typeof IronTheme.THEMES
-			'foundry-ironsworn.color-scheme': 'zinc' | 'phosphor'
+			'foundry-ironsworn.color-scheme': 'zinc' | 'phosphor' | 'oceanic'
 			'foundry-ironsworn.progress-mark-animation': boolean
 
 			'foundry-ironsworn.log-changes': boolean
@@ -137,7 +137,8 @@ export class IronswornSettings {
 			type: String,
 			choices: {
 				zinc: 'IRONSWORN.Settings.ColorScheme.Zinc',
-				phosphor: 'IRONSWORN.Settings.ColorScheme.Phosphor'
+				phosphor: 'IRONSWORN.Settings.ColorScheme.Phosphor',
+				oceanic: 'IRONSWORN.Settings.ColorScheme.Oceanic'
 			},
 			default: 'zinc',
 			onChange: IronColor.updateColorScheme

--- a/src/styles/_ironcolor/oceanic.scss
+++ b/src/styles/_ironcolor/oceanic.scss
@@ -10,8 +10,8 @@
 		// FIXME: migrate to OKLCH once this issue is resolved and VSC provides color previews: https://github.com/microsoft/vscode-css-languageservice/issues/305
 		$fg-color: hsl(0deg, 0%, 0%),
 		$bg-color: hsl(0deg, 0%, 100%),
-		$warm-color: hsl(41deg 77% 57%),
-		$cool-color: hsl(194, 25%, 50%),
+		$warm-color: hsl(41deg, 100%, 60%),
+		$cool-color: hsl(41deg, 100%, 20%),
 		$prefix: 'ironsworn-color'
 	);
 

--- a/src/styles/_ironcolor/oceanic.scss
+++ b/src/styles/_ironcolor/oceanic.scss
@@ -1,5 +1,5 @@
 /* stylelint-disable order/order */
-// Dark theme for Starforged, with aggressive restyling of FVTT's stock UX elements.
+// Oceanic theme for Starforged, with minimal restyling of FVTT's stock UI.
 
 // @use 'sass:meta';
 @use 'mixin:color.scss';
@@ -8,8 +8,8 @@
 .ironcolor__oceanic {
 	@include color.palettize(
 		// FIXME: migrate to OKLCH once this issue is resolved and VSC provides color previews: https://github.com/microsoft/vscode-css-languageservice/issues/305
-		$fg-color: hsl(0deg, 0%, 0%),
-		$bg-color: hsl(0deg, 0%, 100%),
+		$fg-color: hsl(245, 65%, 10%),
+		$bg-color: hsl(40, 100%, 95%),
 		$warm-color: hsl(41deg, 100%, 60%),
 		$cool-color: hsl(41deg, 100%, 20%),
 		$prefix: 'ironsworn-color'

--- a/src/styles/_ironcolor/oceanic.scss
+++ b/src/styles/_ironcolor/oceanic.scss
@@ -1,0 +1,32 @@
+/* stylelint-disable order/order */
+// Dark theme for Starforged, with aggressive restyling of FVTT's stock UX elements.
+
+// @use 'sass:meta';
+@use 'mixin:color.scss';
+// @use 'mixin:fvtt.scss';
+
+.ironcolor__oceanic {
+	@include color.palettize(
+		// FIXME: migrate to OKLCH once this issue is resolved and VSC provides color previews: https://github.com/microsoft/vscode-css-languageservice/issues/305
+		$fg-color: hsl(0deg, 0%, 0%),
+		$bg-color: hsl(0deg, 0%, 100%),
+		$warm-color: hsl(41deg 77% 57%),
+		$cool-color: hsl(194, 25%, 50%),
+		$prefix: 'ironsworn-color'
+	);
+
+	@include color.lightTheme('ironsworn-color');
+	@include color.sharpBorder('ironsworn-color');
+	@include color.interactiveInvert(
+		'ironsworn-color-clickable-block',
+		'ironsworn-color'
+	);
+
+	--ironsworn-color-text-stroke: transparent;
+
+	// CLICKABLE TEXT: HOVER FILTER EFFECT
+	--ironsworn-filter-highlight: drop-shadow(
+		0 0 3px var(--ironsworn-color-cool)
+	);
+	--ironsworn-box-shadow-highlight: 0 0 3px var(--ironsworn-color-cool);
+}

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -300,7 +300,8 @@
 				"Name": "Appearance: Color scheme",
 				"Hint": "Each user can set their own color scheme.",
 				"Zinc": "Zinc",
-				"Phosphor": "Phosphor"
+				"Phosphor": "Phosphor",
+				"Oceanic": "Oceanic"
 			},
 			"Tools": {
 				"Name": "Character Tools",


### PR DESCRIPTION
This adds an "Oceanic" color scheme to the list of options. Currently it's just the Zinc theme with brass-esque highlight colors, but perhaps it can be more later on.

- [x] Add the theme to the list
- [x] Zinc with brass highlights
- [x] Update CHANGELOG.md
