### PR TITLE
Hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- Add a "hold" resource to PC and shared sheets ([#998](https://github.com/ben/foundry-ironsworn/pull/998))
 - Update the SF "sector" dialog to include SI region terms, and make it available via scene-nav right-click ([#996](https://github.com/ben/foundry-ironsworn/pull/996))
 - Add the beginnings of an "Oceanic" color theme ([#997](https://github.com/ben/foundry-ironsworn/pull/997))
 

--- a/src/module/actor/sheets/sharedsheet-v2.ts
+++ b/src/module/actor/sheets/sharedsheet-v2.ts
@@ -4,7 +4,7 @@ import { VueActorSheet } from '../../vue/vueactorsheet'
 export class IronswornSharedSheetV2 extends VueActorSheet {
 	static get defaultOptions() {
 		return foundry.utils.mergeObject(super.defaultOptions, {
-			width: 350,
+			width: 425,
 			height: 700,
 			rootComponent: sharedSheetVue
 		}) as any

--- a/src/module/actor/subtypes/character.ts
+++ b/src/module/actor/subtypes/character.ts
@@ -78,6 +78,7 @@ export class CharacterModel extends foundry.abstract.TypeDataModel<
 			health: new ConditionMeterField({ label: 'IRONSWORN.Health' }),
 			spirit: new ConditionMeterField({ label: 'IRONSWORN.Spirit' }),
 			supply: new ConditionMeterField({ label: 'IRONSWORN.Supply' }),
+			hold: new ConditionMeterField({ label: 'IRONSWORN.Hold' }),
 
 			momentum: new MomentumField(),
 
@@ -148,6 +149,7 @@ export interface CharacterDataSourceData {
 	health: ConditionMeterSource
 	spirit: ConditionMeterSource
 	supply: ConditionMeterSource
+	hold: ConditionMeterSource
 	momentum: MomentumSource
 
 	xp: number

--- a/src/module/actor/subtypes/shared.ts
+++ b/src/module/actor/subtypes/shared.ts
@@ -13,7 +13,8 @@ export class SharedModel extends foundry.abstract.TypeDataModel<
 	static override defineSchema(): DataSchema<SharedDataSourceData> {
 		return {
 			biography: new foundry.data.fields.HTMLField(),
-			supply: new ConditionMeterField({ label: 'IRONSWORN.Supply' })
+			supply: new ConditionMeterField({ label: 'IRONSWORN.Supply' }),
+			hold: new ConditionMeterField({ label: 'IRONSWORN.Hold' })
 		}
 	}
 }
@@ -22,6 +23,7 @@ export interface SharedModel extends SharedDataSourceData {}
 interface SharedDataSourceData {
 	biography: string
 	supply: ConditionMeterSource
+	hold: ConditionMeterSource
 }
 
 export interface SharedDataSource {

--- a/src/module/features/chat-alert.ts
+++ b/src/module/features/chat-alert.ts
@@ -152,7 +152,8 @@ const ACTOR_TYPE_HANDLERS: ActorTypeHandlers = {
 			'momentum',
 			'health',
 			'spirit',
-			'supply'
+			'supply',
+			'hold'
 		] as const) {
 			const newValue = get(data.system, resource)?.value
 			if (newValue !== undefined) {

--- a/src/module/helpers/settings.ts
+++ b/src/module/helpers/settings.ts
@@ -203,8 +203,20 @@ export class IronswornSettings {
 			scope: 'world',
 			config: true,
 			type: Boolean,
-			default: false
+			default: false,
+			onChange: reload
 		})
+
+		if (this.get('sundered-isles-beta')) {
+			game.settings.register('foundry-ironsworn', 'character-hold', {
+				name: 'IRONSWORN.Settings.CharacterHold.Name',
+				hint: 'IRONSWORN.Settings.CharacterHold.Hint',
+				scope: 'world',
+				config: true,
+				type: Boolean,
+				default: false
+			})
+		}
 
 		game.settings.register('foundry-ironsworn', 'data-version', {
 			scope: 'world',

--- a/src/module/vue/components/resource-meter/pc-condition-meters.vue
+++ b/src/module/vue/components/resource-meter/pc-condition-meters.vue
@@ -1,15 +1,16 @@
 <template>
 	<div class="condition-meters flexcol">
 		<ConditionMeterSlider
-			v-for="resource in ['Health', 'Spirit', 'Supply']"
+			v-for="resource in resources"
 			:key="resource.toLowerCase()"
 			slider-style="vertical"
 			class="nogrow"
 			document-type="Actor"
-			:global="resource === 'Supply' && IronswornSettings.get('shared-supply')"
+			:global="resourceIsShared(resource)"
 			:attr="resource.toLowerCase()"
 			:stat-label="$t(`IRONSWORN.${resource}`)"
-			:label-position="props.labelPosition" />
+			:label-position="props.labelPosition"
+		/>
 	</div>
 </template>
 
@@ -20,7 +21,18 @@ import { IronswornSettings } from '../../../helpers/settings.js'
 const props = defineProps<{
 	labelPosition: 'left' | 'right'
 }>()
+
+const resources = ['Health', 'Spirit', 'Supply']
+if (IronswornSettings.get('character-hold')) {
+	resources.push('Hold')
+}
+
+const supplyIsShared = IronswornSettings.get('shared-supply')
+function resourceIsShared(rsrc: string): boolean {
+	return supplyIsShared && ['Supply', 'Hold'].includes(rsrc)
+}
 </script>
+
 <style lang="scss">
 .condition-meters {
 	--ironsworn-meter-spacing: 6px;

--- a/src/module/vue/shared-sheet.vue
+++ b/src/module/vue/shared-sheet.vue
@@ -1,25 +1,38 @@
 <template>
-	<SheetBasic :document="data.actor" class="shared-sheet" body-class="flexcol">
-		<section class="sheet-area nogrow">
+	<SheetBasic :document="data.actor" class="shared-sheet" body-class="flexrow">
+		<section class="flexcol">
+			<section v-if="hasBonds" class="sheet-area nogrow">
+				<bonds :compact-progress="true" />
+			</section>
+
+			<active-completed-progresses />
+
+			<section class="sheet-area flexcol">
+				<h4 class="nogrow">{{ $t('Notes') }}</h4>
+				<mce-editor v-model="data.actor.system.biography" @save="saveNotes" />
+			</section>
+		</section>
+		<section class="condition-meters nogrow flexcol">
 			<ConditionMeter
-				slider-style="horizontal"
+				slider-style="vertical"
+				class="nogrow"
 				attr="supply"
 				:stat-label="$t('IRONSWORN.Supply')"
 				:max="data.actor.system.supply.max"
 				:min="data.actor.system.supply.min"
 				document-type="Actor"
-				:global="IronswornSettings.get('shared-supply')" />
-		</section>
-
-		<section v-if="hasBonds" class="sheet-area nogrow">
-			<bonds :compact-progress="true" />
-		</section>
-
-		<active-completed-progresses />
-
-		<section class="sheet-area flexcol">
-			<h4 class="nogrow">{{ $t('Notes') }}</h4>
-			<mce-editor v-model="data.actor.system.biography" @save="saveNotes" />
+				:global="IronswornSettings.get('shared-supply')"
+			/>
+			<ConditionMeter
+				v-if="IronswornSettings.get('character-hold')"
+				slider-style="vertical"
+				attr="hold"
+				:stat-label="$t('IRONSWORN.Hold')"
+				:max="data.actor.system.hold.max"
+				:min="data.actor.system.hold.min"
+				document-type="Actor"
+				:global="IronswornSettings.get('shared-supply')"
+			/>
 		</section>
 	</SheetBasic>
 </template>
@@ -70,5 +83,21 @@ textarea.notes {
 	min-height: 150px;
 	resize: none;
 	font-family: var(--font-primary);
+}
+
+.condition-meters {
+	--ironsworn-meter-spacing: 6px;
+
+	gap: var(--ironsworn-meter-spacing);
+
+	.condition-meter {
+		&:not(:first-child) {
+			padding-top: var(--ironsworn-meter-spacing);
+		}
+	}
+
+	button {
+		height: max-content;
+	}
 }
 </style>

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -344,6 +344,10 @@
 				"Name": "(Beta) Sundered Isles",
 				"Hint": "Enables in-progress Sundered Isles features."
 			},
+			"CharacterHold": {
+				"Name": "'Hold' Stat",
+				"Hint": "Show the 'Hold' tracker for characters and shared sheets."
+			},
 			"ProgressMarkAnimation": {
 				"Name": "Enable progress mark animation",
 				"Hint": "Toggle the progress mark animation. Note that the animation doesn't lock the mark button, so this change is purely cosmetic."

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -90,6 +90,7 @@
 		"Health": "health",
 		"Spirit": "spirit",
 		"Supply": "supply",
+		"Hold": "hold",
 		"Edge": "edge",
 		"Heart": "heart",
 		"Iron": "iron",


### PR DESCRIPTION
This adds a "Hold" resource tracker to the SF PC and Shared sheets, which behaves like a second Supply track.

- [x] Add value to models
- [x] Register setting to show the tracks
- [x] Add tracks to sheets
  - [x] Only show if setting is on
- [x] Update shared-resource code
- [x] Update chat-alert code
- [x] Update CHANGELOG.md
