### PR TITLE
Cinder and wraith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update the SF "sector" dialog to include SI region terms, and make it available via scene-nav right-click ([#996](https://github.com/ben/foundry-ironsworn/pull/996))
 - Add the beginnings of an "Oceanic" color theme ([#997](https://github.com/ben/foundry-ironsworn/pull/997))
 - Add a new `ds` dice term for the cursed die ([#1000](https://github.com/ben/foundry-ironsworn/pull/1000))
+- Add a scene button to roll Cinder and Wraith ([#1001](https://github.com/ben/foundry-ironsworn/pull/1001))
 
 ## 1.23.2
 

--- a/src/module/chat/si-moons-chat-message.ts
+++ b/src/module/chat/si-moons-chat-message.ts
@@ -1,6 +1,25 @@
+const MOON_EMOJI = [
+	'',
+	'🌑',
+	'🌒',
+	'🌒',
+	'🌒',
+	'🌓',
+	'🌓',
+	'🌔',
+	'🌔',
+	'🌔',
+	'🌕'
+]
+
 export async function createSiMoonsChatMessage(cinder: Roll, wraith: Roll) {
 	// TODO: resolve which one is higher, matches, etc.
-	const params = { cinder, wraith }
+	const params = {
+		cinder,
+		cinderEmoji: MOON_EMOJI[cinder.total ?? 1],
+		wraith,
+		wraithEmoji: MOON_EMOJI[wraith.total ?? 1]
+	}
 	const content = await renderTemplate(
 		'systems/foundry-ironsworn/templates/rolls/si-moons-roll-message.hbs',
 		params

--- a/src/module/chat/si-moons-chat-message.ts
+++ b/src/module/chat/si-moons-chat-message.ts
@@ -1,0 +1,13 @@
+export async function createSiMoonsChatMessage(cinder: Roll, wraith: Roll) {
+	// TODO: resolve which one is higher, matches, etc.
+	const params = { cinder, wraith }
+	const content = await renderTemplate(
+		'systems/foundry-ironsworn/templates/rolls/si-moons-roll-message.hbs',
+		params
+	)
+	await ChatMessage.create({
+		speaker: ChatMessage.getSpeaker(),
+		content,
+		rolls: [cinder, wraith]
+	})
+}

--- a/src/module/chat/si-moons-chat-message.ts
+++ b/src/module/chat/si-moons-chat-message.ts
@@ -1,15 +1,15 @@
 const MOON_EMOJI = [
-	'',
-	'🌑',
-	'🌒',
-	'🌒',
-	'🌒',
-	'🌓',
-	'🌓',
-	'🌔',
-	'🌔',
-	'🌔',
-	'🌕'
+	'', // 0, not used for die results
+	'🌑', // 1 new
+	'🌒', // 2
+	'🌒', // 3
+	'🌒', // 4
+	'🌓', // 5
+	'🌓', // 6
+	'🌔', // 7
+	'🌔', // 8
+	'🌔', // 9
+	'🌕' // 10 full
 ]
 
 export async function createSiMoonsChatMessage(cinder: Roll, wraith: Roll) {

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -1,6 +1,7 @@
 import { IronswornActor } from '../actor/actor'
 import { OracleWindow } from '../applications/oracle-window'
 import { EditSectorDialog } from '../applications/sf/editSectorApp'
+import { createSiMoonsChatMessage } from '../chat/si-moons-chat-message'
 import { IronswornSettings } from '../helpers/settings'
 
 function warn() {
@@ -42,6 +43,14 @@ async function editSector() {
 	if (sceneId) {
 		await new EditSectorDialog(sceneId).render(true, { focus: true })
 	}
+}
+
+async function rollMoons() {
+	// Roll the dice
+	const r = new Roll('{d10[Cinder],d10[Wraith]}')
+	await r.roll({ async: true })
+	const [cinder, wraith] = (r.terms[0] as PoolTerm).rolls
+	await createSiMoonsChatMessage(cinder, wraith)
 }
 
 async function dropToken(location: IronswornActor) {
@@ -246,7 +255,15 @@ function sunderedIslesControl(
 		layer: 'ironsworn',
 		visible: true,
 		activeTool: 'select',
-		tools: [oracleButton]
+		tools: [
+			oracleButton,
+			{
+				name: 'moons',
+				icon: 'fas fa-moon',
+				title: 'Roll the Moons',
+				onClick: rollMoons
+			}
+		]
 	}
 
 	if (game.user?.isGM) {

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -48,7 +48,7 @@ async function editSector() {
 async function rollMoons() {
 	// Roll the dice
 	const r = new Roll('{d10[Cinder],d10[Wraith]}')
-	await r.roll({ async: true })
+	await r.roll()
 	const [cinder, wraith] = (r.terms[0] as PoolTerm).rolls
 	await createSiMoonsChatMessage(cinder, wraith)
 }

--- a/src/styles/dice.less
+++ b/src/styles/dice.less
@@ -154,4 +154,11 @@
 		text-decoration: line-through;
 		.diceGlowMixin(var(--ironsworn-color-warning));
 	}
+
+	.cinder {
+		.diceGlowMixin(var(--ironsworn-color-danger));
+	}
+	.wraith {
+		.diceGlowMixin(var(--ironsworn-color-success));
+	}
 }

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -27,6 +27,8 @@
 		"On_a_miss": "On a miss",
 		"MarkProgress": "Mark Progress",
 		"ProgressMove": "Progress Move",
+		"Cinder": "Cinder",
+		"Wraith": "Wraith",
 		"PROGRESS": {
 			"Current": "{score} progress ({ticks} ticks)",
 			"Ticks": "{ticks} ticks",

--- a/system/templates/rolls/si-moons-roll-message.hbs
+++ b/system/templates/rolls/si-moons-roll-message.hbs
@@ -1,0 +1,4 @@
+<article class='ironsworn ironsworn-roll flexcol'>
+	<h4>Cinder: {{cinder.total}}</h4>
+	<h4>Wraith: {{wraith.total}}</h4>
+</article>

--- a/system/templates/rolls/si-moons-roll-message.hbs
+++ b/system/templates/rolls/si-moons-roll-message.hbs
@@ -3,11 +3,8 @@
 
 		<div class='flexrow'>
 			<article class='roll-graphic dice-formula action-roll-formula'>
-				<strong>Cinder:</strong>
-				<span
-					class='roll die isiconbg-d10-blank d10 cinder'
-					data-tooltip='Cinder'
-				>
+				<strong>{{localize 'IRONSWORN.Cinder'}}:</strong>
+				<span class='roll die isiconbg-d10-blank d10 cinder'>
 					{{cinder.total}}
 				</span>
 				<span class='moon-emoji cinder'>{{cinderEmoji}}</span>
@@ -16,11 +13,8 @@
 
 		<div class='flexrow'>
 			<article class='roll-graphic dice-formula action-roll-formula'>
-				<strong>Wraith:</strong>
-				<span
-					class='roll die isiconbg-d10-blank d10 wraith'
-					data-tooltip='Wraith'
-				>
+				<strong>{{localize 'IRONSWORN.Wraith'}}:</strong>
+				<span class='roll die isiconbg-d10-blank d10 wraith'>
 					{{wraith.total}}
 				</span>
 				<span class='moon-emoji wraith'>{{wraithEmoji}}</span>

--- a/system/templates/rolls/si-moons-roll-message.hbs
+++ b/system/templates/rolls/si-moons-roll-message.hbs
@@ -1,4 +1,31 @@
-<article class='ironsworn ironsworn-roll flexcol'>
-	<h4>Cinder: {{cinder.total}}</h4>
-	<h4>Wraith: {{wraith.total}}</h4>
+<article class='ironsworn ironsworn-roll'>
+	<section class='dice-result dice-tooltip dice-roll ironsworn-roll flexcol'>
+
+		<div class='flexrow'>
+			<article class='roll-graphic dice-formula action-roll-formula'>
+				<strong>Cinder:</strong>
+				<span
+					class='roll die isiconbg-d10-blank d10 cinder'
+					data-tooltip='Cinder'
+				>
+					{{cinder.total}}
+				</span>
+				<span class='moon-emoji cinder'>{{cinderEmoji}}</span>
+			</article>
+		</div>
+
+		<div class='flexrow'>
+			<article class='roll-graphic dice-formula action-roll-formula'>
+				<strong>Wraith:</strong>
+				<span
+					class='roll die isiconbg-d10-blank d10 wraith'
+					data-tooltip='Wraith'
+				>
+					{{wraith.total}}
+				</span>
+				<span class='moon-emoji wraith'>{{wraithEmoji}}</span>
+			</article>
+		</div>
+
+	</section>
 </article>


### PR DESCRIPTION
This adds a "roll the moons" button to the Sundered Isles scene buttons. It rolls two d10s, and interprets them as Cinder and Wraith in the chat.

- [x] Add the button
- [x] Roll the dice
- [x] Proper chat-message output
- [x] Update CHANGELOG.md
