### PR TITLE
Cinder and Wraith on all rolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Optionally colorize challenge dice as Cinder and Wraith ([#1002](https://github.com/ben/foundry-ironsworn/pull/1002))
+
 ## 1.23.4
 
 - Don't let the beta setting break the world

--- a/src/module/features/dice/index.ts
+++ b/src/module/features/dice/index.ts
@@ -26,3 +26,34 @@ Hooks.once('diceSoNiceReady', (dice3d) => {
 		'd10'
 	)
 })
+
+export function cinderAndWraithifyRoll(roll: Roll) {
+	if (!game.settings.get('foundry-ironsworn', 'dsn-cinder-wraith')) {
+		return
+	}
+
+	const challengeDice = roll.dice.filter((x) => x.faces === 10) ?? []
+	if (challengeDice.length !== 2) {
+		return
+	}
+
+	const cinderColor = '#e0887f'
+	const wraithColor = '#6bafd7'
+
+	const cd0options = challengeDice[0].options as any
+	cd0options.appearance = {
+		colorset: 'custom',
+		labelColor: game.dice3d.exports.Utils.contrastOf(cinderColor),
+		background: cinderColor,
+		outline: cinderColor,
+		edge: cinderColor
+	}
+	const cd1options = challengeDice[1].options as any
+	cd1options.appearance = {
+		labelColor: game.dice3d.exports.Utils.contrastOf(wraithColor),
+		colorset: 'custom',
+		background: wraithColor,
+		outline: wraithColor,
+		edge: wraithColor
+	}
+}

--- a/src/module/features/dice/index.ts
+++ b/src/module/features/dice/index.ts
@@ -43,14 +43,14 @@ export function cinderAndWraithifyRoll(roll: Roll) {
 	const cd0options = challengeDice[0].options as any
 	cd0options.appearance = {
 		colorset: 'custom',
-		labelColor: game.dice3d.exports.Utils.contrastOf(cinderColor),
+		labelColor: (game.dice3d as any).exports?.Utils?.contrastOf(cinderColor),
 		background: cinderColor,
 		outline: cinderColor,
 		edge: cinderColor
 	}
 	const cd1options = challengeDice[1].options as any
 	cd1options.appearance = {
-		labelColor: game.dice3d.exports.Utils.contrastOf(wraithColor),
+		labelColor: (game.dice3d as any).exports?.Utils?.contrastOf(wraithColor),
 		colorset: 'custom',
 		background: wraithColor,
 		outline: wraithColor,

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -3,6 +3,7 @@ import { OracleWindow } from '../applications/oracle-window'
 import { EditSectorDialog } from '../applications/sf/editSectorApp'
 import { createSiMoonsChatMessage } from '../chat/si-moons-chat-message'
 import { IronswornSettings } from '../helpers/settings'
+import { cinderAndWraithifyRoll } from './dice'
 
 function warn() {
 	ui.notifications?.warn('Soon™')
@@ -48,6 +49,7 @@ async function editSector() {
 async function rollMoons() {
 	// Roll the dice
 	const r = new Roll('{d10[Cinder],d10[Wraith]}')
+	cinderAndWraithifyRoll(r)
 	await r.roll()
 	const [cinder, wraith] = (r.terms[0] as PoolTerm).rolls
 	await createSiMoonsChatMessage(cinder, wraith)

--- a/src/module/helpers/settings.ts
+++ b/src/module/helpers/settings.ts
@@ -38,6 +38,7 @@ declare global {
 
 			'foundry-ironsworn.sundered-isles-beta': boolean
 			'foundry-ironsworn.character-hold': boolean
+			'foundry-ironsworn.dsn-cinder-wraith': boolean
 
 			// Internal only
 			'foundry-ironsworn.first-run-tips-shown': boolean
@@ -207,6 +208,15 @@ export class IronswornSettings {
 		game.settings.register('foundry-ironsworn', 'character-hold', {
 			name: 'IRONSWORN.Settings.CharacterHold.Name',
 			hint: 'IRONSWORN.Settings.CharacterHold.Hint',
+			scope: 'world',
+			config: true,
+			type: Boolean,
+			default: false
+		})
+
+		game.settings.register('foundry-ironsworn', 'dsn-cinder-wraith', {
+			name: 'IRONSWORN.Settings.RollCinderAndWraith.Name',
+			hint: 'IRONSWORN.Settings.RollCinderAndWraith.Hint',
 			scope: 'world',
 			config: true,
 			type: Boolean,

--- a/src/module/rolls/ironsworn-roll.ts
+++ b/src/module/rolls/ironsworn-roll.ts
@@ -7,6 +7,7 @@
 
 import { cloneDeep, compact, pick, range, sum } from 'lodash-es'
 import { getFoundryMoveByDfId } from '../dataforged'
+import { cinderAndWraithifyRoll } from '../features/dice'
 import type { IronswornItem } from '../item/item'
 import { computeRollOutcome } from './ironsworn-roll-message'
 
@@ -222,7 +223,7 @@ export class IronswornRoll {
 
 		// Roll 'em
 		this.roll = new Roll(`{${diceTerms.join(', ')}}`)
-		this.cinderAndWraithifyRoll()
+		cinderAndWraithifyRoll(this.roll)
 		await this.roll.roll({ async: true })
 
 		// Pull out raw results
@@ -451,31 +452,5 @@ export class IronswornRoll {
 	clone(): IronswornRoll {
 		const json = this.serialize()
 		return IronswornRoll.fromJson(cloneDeep(json))
-	}
-
-	private cinderAndWraithifyRoll() {
-		if (!game.settings.get('foundry-ironsworn', 'dsn-cinder-wraith')) {
-			return
-		}
-
-		const challengeDice = this.roll?.dice.filter((x) => x.faces === 10) ?? []
-		if (challengeDice.length !== 2) {
-			return
-		}
-
-		const cd0options = challengeDice[0].options as any
-		cd0options.appearance = {
-			colorset: 'custom',
-			background: 'red',
-			outline: 'red',
-			edge: 'red'
-		}
-		const cd1options = challengeDice[1].options as any
-		cd1options.appearance = {
-			colorset: 'custom',
-			background: 'blue',
-			outline: 'blue',
-			edge: 'blue'
-		}
 	}
 }

--- a/src/module/rolls/ironsworn-roll.ts
+++ b/src/module/rolls/ironsworn-roll.ts
@@ -222,6 +222,7 @@ export class IronswornRoll {
 
 		// Roll 'em
 		this.roll = new Roll(`{${diceTerms.join(', ')}}`)
+		this.cinderAndWraithifyRoll()
 		await this.roll.roll({ async: true })
 
 		// Pull out raw results
@@ -450,5 +451,31 @@ export class IronswornRoll {
 	clone(): IronswornRoll {
 		const json = this.serialize()
 		return IronswornRoll.fromJson(cloneDeep(json))
+	}
+
+	private cinderAndWraithifyRoll() {
+		if (!game.settings.get('foundry-ironsworn', 'dsn-cinder-wraith')) {
+			return
+		}
+
+		const challengeDice = this.roll?.dice.filter((x) => x.faces === 10) ?? []
+		if (challengeDice.length !== 2) {
+			return
+		}
+
+		const cd0options = challengeDice[0].options as any
+		cd0options.appearance = {
+			colorset: 'custom',
+			background: 'red',
+			outline: 'red',
+			edge: 'red'
+		}
+		const cd1options = challengeDice[1].options as any
+		cd1options.appearance = {
+			colorset: 'custom',
+			background: 'blue',
+			outline: 'blue',
+			edge: 'blue'
+		}
 	}
 }

--- a/src/module/rolls/ironsworn-roll.ts
+++ b/src/module/rolls/ironsworn-roll.ts
@@ -8,6 +8,7 @@
 import { cloneDeep, compact, pick, range, sum } from 'lodash-es'
 import { getFoundryMoveByDfId } from '../dataforged'
 import { cinderAndWraithifyRoll } from '../features/dice'
+import { IronswornSettings } from '../helpers/settings'
 import type { IronswornItem } from '../item/item'
 import { computeRollOutcome } from './ironsworn-roll-message'
 
@@ -342,8 +343,8 @@ export class IronswornRoll {
 	get challengeDice(): Array<SourcedValue<number | undefined>> {
 		if (this.rawChallengeDiceValues !== undefined) {
 			// challenge dice have been rolled, report them
-			return this.rawChallengeDiceValues.map((x) => ({
-				source: 'd10',
+			return this.rawChallengeDiceValues.map((x, i) => ({
+				source: maybeCinderAndWraithSource(i + 1, 'd10'),
 				value: x
 			}))
 		}
@@ -398,8 +399,9 @@ export class IronswornRoll {
 					| SourcedValue
 					| undefined
 				const die = this.rawChallengeDiceValues![i]
+				const source = maybeCinderAndWraithSource(i + 1, 'd10')
 				return {
-					source: preset?.source ?? 'd10',
+					source: preset?.source ?? source,
 					value: preset?.value ?? die
 				}
 			}) as [SourcedValue, SourcedValue]
@@ -453,4 +455,20 @@ export class IronswornRoll {
 		const json = this.serialize()
 		return IronswornRoll.fromJson(cloneDeep(json))
 	}
+}
+
+function maybeCinderAndWraithSource(
+	challengeDieNumber: number,
+	originalSource: string
+): string {
+	if (!IronswornSettings.get('dsn-cinder-wraith')) {
+		return originalSource
+	}
+
+	if (challengeDieNumber === 1) {
+		return game.i18n.localize('IRONSWORN.Cinder')
+	} else if (challengeDieNumber === 2) {
+		return game.i18n.localize('IRONSWORN.Wraith')
+	}
+	return originalSource
 }

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -350,6 +350,10 @@
 				"Name": "'Hold' Stat",
 				"Hint": "Show the 'Hold' tracker for Starforged characters and shared sheets."
 			},
+			"RollCinderAndWraith": {
+				"Name": "Cinder and Wraith",
+				"Hint": "Roll challenge dice as Cinder and Wraith. This will override your Dice-So-Nice color theme for challenge-die rolls, and include which die represents which moon in the tooltips."
+			},
 			"ProgressMarkAnimation": {
 				"Name": "Enable progress mark animation",
 				"Hint": "Toggle the progress mark animation. Note that the animation doesn't lock the mark button, so this change is purely cosmetic."


### PR DESCRIPTION
This adds an option to always roll challenge dice as Cinder and Wraith. It includes colorized challenge dice (overriding your Dice So Nice color setting) and tooltips in the chat message.

![CleanShot 2024-06-22 at 09 24 51](https://github.com/ben/foundry-ironsworn/assets/39902/5c3baf78-0e26-4141-b601-1f1cfcc06f61)
![CleanShot 2024-06-22 at 09 25 03](https://github.com/ben/foundry-ironsworn/assets/39902/da801f4f-e55c-4da8-a8d7-dd7bac7e23b4)


- [x] Register the setting and i18n strings
- [x] Apply per-die colors with DSN when option is enabled
- [x] Replace tooltips for challenge dice when option is enabled
- [x] Update CHANGELOG.md
