### PR TITLE
Fix colorization of dice with dsn 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- Fix Cinder and Wraith dice with dice-so-nice 5 ([#1009](https://github.com/ben/foundry-ironsworn/pull/1009))
 - Allow edge/heart/etc. attributes to range from -5 to +10 ([#1007](https://github.com/ben/foundry-ironsworn/pull/1007))
 - Behind the scenes
   - Build compendiums from source, which makes management of this data a lot easier ([#1006](https://github.com/ben/foundry-ironsworn/pull/1006))

--- a/src/module/features/dice/index.ts
+++ b/src/module/features/dice/index.ts
@@ -42,7 +42,6 @@ export function cinderAndWraithifyRoll(roll: Roll) {
 
 	const cd0options = challengeDice[0].options as any
 	cd0options.appearance = {
-		colorset: 'custom',
 		labelColor: (game.dice3d as any).exports?.Utils?.contrastOf(cinderColor),
 		background: cinderColor,
 		outline: cinderColor,
@@ -51,7 +50,6 @@ export function cinderAndWraithifyRoll(roll: Roll) {
 	const cd1options = challengeDice[1].options as any
 	cd1options.appearance = {
 		labelColor: (game.dice3d as any).exports?.Utils?.contrastOf(wraithColor),
-		colorset: 'custom',
 		background: wraithColor,
 		outline: wraithColor,
 		edge: wraithColor


### PR DESCRIPTION
Looks like we overspecified a bit. This fixes Cinder and Wraith dice with DSN 5.0.

Before:
![CleanShot 2024-08-12 at 07 20 04](https://github.com/user-attachments/assets/4a81aab3-a605-4c62-8fbc-697aa35bc580)

After:
![CleanShot 2024-08-12 at 07 20 19](https://github.com/user-attachments/assets/85bba41c-a2c0-4bf3-a1af-585c64b61a3d)

- [x] Fix the dice
- [x] Update CHANGELOG.md
