### PR TITLE
Indexed moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Brought back support for the "Custom Moves" folder ([#1023](https://github.com/ben/foundry-ironsworn/pull/1023))
+
 ## 1.24.0
 
 This is a major update that includes Sundered Isles content, but also brings along a host of changes:

--- a/src/module/datasworn2/finding.ts
+++ b/src/module/datasworn2/finding.ts
@@ -62,10 +62,13 @@ interface PackAndIndex {
 
 export async function getPackAndIndexForCompendiumKey(
 	ruleset: DataswornRulesetKey,
-	type: keyof typeof COMPENDIUM_KEY_MAP
+	type: keyof typeof COMPENDIUM_KEY_MAP,
+	additionalFields?: string[]
 ): Promise<PackAndIndex> {
 	const pack = game.packs.get(COMPENDIUM_KEY_MAP[type][ruleset])
-	const index = await pack?.getIndex({ fields: ['flags'] })
+	const index = await pack?.getIndex({
+		fields: ['flags', ...((additionalFields ?? []) as any[])]
+	})
 	return { pack, index }
 }
 

--- a/src/module/features/custommoves.ts
+++ b/src/module/features/custommoves.ts
@@ -101,7 +101,7 @@ function customFolderMoveCategory(): DisplayMoveRuleset | undefined {
 		})
 	}
 	if (category.moves.length === 0) return undefined
-	console.log(category)
+
 	return {
 		displayName: name,
 		categories: [category]

--- a/src/module/rolls/preroll-dialog.ts
+++ b/src/module/rolls/preroll-dialog.ts
@@ -58,10 +58,8 @@ function rollableOptions(trigger: SFMoveTrigger) {
 	)
 }
 
-export function moveHasRollableOptions(move: IronswornItem<'sfmove'>) {
-	if (!move.assert('sfmove')) return false
-	const options = rollableOptions(move.system.Trigger)
-	return options.length > 0
+export function moveTriggerIsRollable(trigger?: SFMoveTrigger) : boolean {
+	return !!trigger && rollableOptions(trigger).length > 0
 }
 
 export function getStatData(

--- a/src/module/vue/components/buttons/btn-sendmovetochat.vue
+++ b/src/module/vue/components/buttons/btn-sendmovetochat.vue
@@ -13,22 +13,22 @@
 </template>
 
 <script setup lang="ts">
-import { inject } from 'vue'
 import { createSfMoveChatMessage } from '../../../chat/sf-move-chat-message'
 import type { DisplayMove } from '../../../features/custommoves'
-import { $ItemKey } from '../../provisions.js'
 import IronBtn from './iron-btn.vue'
+import { IronswornItem } from '../../../item/item'
 
 interface Props
 	extends /* @vue-ignore */ Omit<PropsOf<typeof IronBtn>, 'tooltip'> {
 	move: DisplayMove
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
 
-const $item = inject($ItemKey)
-
-function sendToChat(e) {
-	if ($item) createSfMoveChatMessage($item)
+async function sendToChat(e) {
+	const foundryMove = (await fromUuid(
+		props.move.uuid
+	)) as IronswornItem<'sfmove'>
+	if (foundryMove) createSfMoveChatMessage(foundryMove)
 }
 </script>

--- a/src/module/vue/components/move/move-content.vue
+++ b/src/module/vue/components/move/move-content.vue
@@ -1,0 +1,71 @@
+<template>
+	<RulesTextMove
+		:data="moveObj"
+		:is-progress-move="foundryMove.system.isProgressMove"
+		:class="$style.summary"
+	>
+		<template #after-footer>
+			<OracleTreeNode
+				v-for="node of oracleNodes"
+				:key="node.displayName"
+				:class="$style.oracle"
+				:node="node"
+			/>
+		</template>
+	</RulesTextMove>
+</template>
+
+<script setup lang="ts">
+import { ref, provide } from 'vue'
+import { uniq, compact } from 'lodash-es'
+import { IronswornItem } from '../../../item/item'
+import { OracleTable } from '../../../roll-table/oracle-table'
+import { ItemKey, $ItemKey } from '../../provisions.js'
+import type { DisplayMove } from '../../../features/custommoves'
+import type { IOracleTreeNode } from '../../../features/customoracles'
+
+import RulesTextMove from '../rules-text/rules-text-move.vue'
+import OracleTreeNode from '../oracle-tree-node.vue'
+
+const props = defineProps<{
+	move: DisplayMove
+}>()
+
+const foundryMove = (await fromUuid(props.move.uuid)) as IronswornItem<'sfmove'>
+const moveObj = ref(foundryMove.toObject())
+provide(ItemKey, moveObj as any)
+provide($ItemKey, foundryMove)
+
+const oracleDsIds = uniq([
+	...(foundryMove?.system?.dsOracleIds ?? []),
+	...Object.values(props.move.ds?.oracles ?? {}).map((x) => x._id)
+])
+const oracleNodes: IOracleTreeNode[] = await Promise.all(
+	oracleDsIds.map(async (oid) => {
+		const t = await OracleTable.getByDsId(oid)
+		return {
+			displayName: t?.name ?? '(missing)',
+			tables: compact([t?.uuid]),
+			children: []
+		}
+	})
+)
+</script>
+
+<style lang="scss" module>
+.oracle {
+	border-width: var(--ironsworn-border-width-md);
+	border-style: solid;
+	border-radius: var(--ironsworn-border-radius-sm);
+	border-color: var(--ironsworn-color-border);
+	padding: 0;
+
+	h4 {
+		font-size: var(--font-size-16);
+
+		button.icon-button {
+			height: inherit;
+		}
+	}
+}
+</style>

--- a/src/module/vue/components/move/sf-moverow.vue
+++ b/src/module/vue/components/move/sf-moverow.vue
@@ -77,20 +77,21 @@
 
 <script setup lang="ts">
 import { computed, onMounted, provide, ref, watch } from 'vue'
-import type { DisplayMove } from '../../features/custommoves'
-import type { IOracleTreeNode } from '../../features/customoracles'
-import type { IronswornItem } from '../../item/item'
-import { moveHasRollableOptions } from '../../rolls/preroll-dialog'
-import BtnRollmove from './buttons/btn-rollmove.vue'
-import BtnSendmovetochat from './buttons/btn-sendmovetochat.vue'
-import OracleTreeNode from './oracle-tree-node.vue'
-import RulesTextMove from './rules-text/rules-text-move.vue'
-import Collapsible from './collapsible/collapsible.vue'
-import BtnOracle from './buttons/btn-oracle.vue'
-import { ItemKey, $ItemKey } from '../provisions.js'
-import { enrichMarkdown } from '../vue-plugin.js'
+import type { DisplayMove } from '../../../features/custommoves'
+import type { IOracleTreeNode } from '../../../features/customoracles'
+import type { IronswornItem } from '../../../item/item'
+import { moveHasRollableOptions } from '../../../rolls/preroll-dialog'
+import { ItemKey, $ItemKey } from '../../provisions.js'
+import { enrichMarkdown } from '../../vue-plugin.js'
 import { compact, uniq } from 'lodash-es'
-import { OracleTable } from '../../roll-table/oracle-table'
+import { OracleTable } from '../../../roll-table/oracle-table'
+
+import BtnRollmove from '../buttons/btn-rollmove.vue'
+import BtnSendmovetochat from '../buttons/btn-sendmovetochat.vue'
+import OracleTreeNode from '../oracle-tree-node.vue'
+import RulesTextMove from '../rules-text/rules-text-move.vue'
+import Collapsible from '../collapsible/collapsible.vue'
+import BtnOracle from '../buttons/btn-oracle.vue'
 
 const props = withDefaults(
 	defineProps<{

--- a/src/module/vue/components/sf-move-category-rows.vue
+++ b/src/module/vue/components/sf-move-category-rows.vue
@@ -39,7 +39,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { DisplayMoveCategory } from '../../features/custommoves.js'
-import SfMoverow from './sf-moverow.vue'
+import SfMoverow from './move/sf-moverow.vue'
 import Collapsible from './collapsible/collapsible.vue'
 import { snakeCase } from 'lodash-es'
 import { enrichMarkdown } from '../vue-plugin'

--- a/src/module/vue/components/sf-movesheetmoves.vue
+++ b/src/module/vue/components/sf-movesheetmoves.vue
@@ -60,7 +60,7 @@ import { computed, nextTick, provide, reactive, ref } from 'vue'
 import type { DisplayMoveCategory } from '../../features/custommoves'
 import { createMergedMoveTree } from '../../features/custommoves'
 import SfMoveCategoryRows from './sf-move-category-rows.vue'
-import SfMoverow from './sf-moverow.vue'
+import SfMoverow from './move/sf-moverow.vue'
 import IronBtn from './buttons/iron-btn.vue'
 
 const state = reactive({

--- a/src/module/vue/components/site/site-moves.vue
+++ b/src/module/vue/components/site/site-moves.vue
@@ -83,7 +83,7 @@ import { $ActorKey, ActorKey } from '../../provisions'
 import BtnOracle from '../buttons/btn-oracle.vue'
 import BtnRollmove from '../buttons/btn-rollmove.vue'
 
-import SfMoverow from '../sf-moverow.vue'
+import SfMoverow from '../move/sf-moverow.vue'
 
 const site = inject(ActorKey) as Ref<ActorSource<'site'>>
 const $site = inject($ActorKey) as IronswornActor<'site'>


### PR DESCRIPTION
Moving away from loading all documents and having to keep them fresh. This restructures the way we display moves, so that we can only load an index for the compendiums being displayed, and load full moves only when they are expanded.

- [x] Refactor full display into an async component
- [x] Index-load only for bare move sheet
- [x] Reinstate support for the custom-moves folder
- [x] Update CHANGELOG.md
