### PR TITLE
Cursed Oracles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Cursed die support when rolling oracles ([#1026](https://github.com/ben/foundry-ironsworn/pull/1026))
+
 ## 1.24.2
 
 - Some moves had been imported wrongly, and weren't rollable as they should be, e.g. _Endure Stress_ ([#1025](https://github.com/ben/foundry-ironsworn/pull/1025))

--- a/json-packs/sundered-isles-oracles/Armada_d59bdfa011d439d6.json
+++ b/json-packs/sundered-isles-oracles/Armada_d59bdfa011d439d6.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship/mission",
-      "dsid": "oracle_rollable:sundered_isles/ship/mission/armada"
+      "dsid": "oracle_rollable:sundered_isles/ship/mission/armada",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/mission_cursed"
     }
   },
   "name": "Armada",

--- a/json-packs/sundered-isles-oracles/Cargo_6eb8856a76563a7d.json
+++ b/json-packs/sundered-isles-oracles/Cargo_6eb8856a76563a7d.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship",
-      "dsid": "oracle_rollable:sundered_isles/ship/cargo"
+      "dsid": "oracle_rollable:sundered_isles/ship/cargo",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/cargo_cursed"
     }
   },
   "name": "Cargo",

--- a/json-packs/sundered-isles-oracles/Cave_Threshold_7a23a144553d4617.json
+++ b/json-packs/sundered-isles-oracles/Cave_Threshold_7a23a144553d4617.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/cave",
-      "dsid": "oracle_rollable:sundered_isles/cave/threshold"
+      "dsid": "oracle_rollable:sundered_isles/cave/threshold",
+      "cursed_variant": "oracle_rollable:sundered_isles/cave/threshold_cursed"
     }
   },
   "name": "Cave Threshold",

--- a/json-packs/sundered-isles-oracles/Character_Details_c9d0b645648be892.json
+++ b/json-packs/sundered-isles-oracles/Character_Details_c9d0b645648be892.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/character",
-      "dsid": "oracle_rollable:sundered_isles/character/details"
+      "dsid": "oracle_rollable:sundered_isles/character/details",
+      "cursed_variant": "oracle_rollable:sundered_isles/character/details_cursed"
     }
   },
   "name": "Character Details",

--- a/json-packs/sundered-isles-oracles/Character_First_Look_fde52f9b5a457652.json
+++ b/json-packs/sundered-isles-oracles/Character_First_Look_fde52f9b5a457652.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/character",
-      "dsid": "oracle_rollable:sundered_isles/character/first_look"
+      "dsid": "oracle_rollable:sundered_isles/character/first_look",
+      "cursed_variant": "oracle_rollable:sundered_isles/character/first_look_cursed"
     }
   },
   "name": "Character First Look",

--- a/json-packs/sundered-isles-oracles/Character_Goals_2ea72e7250432b2a.json
+++ b/json-packs/sundered-isles-oracles/Character_Goals_2ea72e7250432b2a.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/character",
-      "dsid": "oracle_rollable:sundered_isles/character/goals"
+      "dsid": "oracle_rollable:sundered_isles/character/goals",
+      "cursed_variant": "oracle_rollable:sundered_isles/character/goals_cursed"
     }
   },
   "name": "Character Goals",

--- a/json-packs/sundered-isles-oracles/Colossal_8946ef8c68d12dc7.json
+++ b/json-packs/sundered-isles-oracles/Colossal_8946ef8c68d12dc7.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship/mission",
-      "dsid": "oracle_rollable:sundered_isles/ship/mission/colossal"
+      "dsid": "oracle_rollable:sundered_isles/ship/mission/colossal",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/mission_cursed"
     }
   },
   "name": "Colossal",

--- a/json-packs/sundered-isles-oracles/Crew_Characteristics_e78670e6281b8935.json
+++ b/json-packs/sundered-isles-oracles/Crew_Characteristics_e78670e6281b8935.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/getting_underway/take_command",
-      "dsid": "oracle_rollable:sundered_isles/getting_underway/take_command/crew"
+      "dsid": "oracle_rollable:sundered_isles/getting_underway/take_command/crew",
+      "cursed_variant": "oracle_rollable:sundered_isles/getting_underway/take_command/crew_cursed"
     }
   },
   "name": "Crew Characteristics",

--- a/json-packs/sundered-isles-oracles/Cursed_Ship_Details_438d363a310ffd3b.json
+++ b/json-packs/sundered-isles-oracles/Cursed_Ship_Details_438d363a310ffd3b.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship",
-      "dsid": "oracle_rollable:sundered_isles/ship/details_cursed"
+      "dsid": "oracle_rollable:sundered_isles/ship/details_cursed",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/details_cursed"
     }
   },
   "name": "Cursed Ship Details",

--- a/json-packs/sundered-isles-oracles/Fleet_588e48df37a0399f.json
+++ b/json-packs/sundered-isles-oracles/Fleet_588e48df37a0399f.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship/mission",
-      "dsid": "oracle_rollable:sundered_isles/ship/mission/fleet"
+      "dsid": "oracle_rollable:sundered_isles/ship/mission/fleet",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/mission_cursed"
     }
   },
   "name": "Fleet",

--- a/json-packs/sundered-isles-oracles/Flotilla_414bdf7fac5a29a7.json
+++ b/json-packs/sundered-isles-oracles/Flotilla_414bdf7fac5a29a7.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship/mission",
-      "dsid": "oracle_rollable:sundered_isles/ship/mission/flotilla"
+      "dsid": "oracle_rollable:sundered_isles/ship/mission/flotilla",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/mission_cursed"
     }
   },
   "name": "Flotilla",

--- a/json-packs/sundered-isles-oracles/Foul_Weather_cec9db2f0aaf8cfe.json
+++ b/json-packs/sundered-isles-oracles/Foul_Weather_cec9db2f0aaf8cfe.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/weather",
-      "dsid": "oracle_rollable:sundered_isles/weather/foul"
+      "dsid": "oracle_rollable:sundered_isles/weather/foul",
+      "cursed_variant": "oracle_rollable:sundered_isles/weather/cursed"
     }
   },
   "name": "Foul Weather",

--- a/json-packs/sundered-isles-oracles/Highlands_22bfe152e86e3b7c.json
+++ b/json-packs/sundered-isles-oracles/Highlands_22bfe152e86e3b7c.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/overland/region_landmarks",
-      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/highlands"
+      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/highlands",
+      "cursed_variant": "oracle_rollable:sundered_isles/overland/region_landmarks/cursed"
     }
   },
   "name": "Highlands",

--- a/json-packs/sundered-isles-oracles/Inland_94bc6ec7323d8745.json
+++ b/json-packs/sundered-isles-oracles/Inland_94bc6ec7323d8745.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/settlement/focus",
-      "dsid": "oracle_rollable:sundered_isles/settlement/focus/inland"
+      "dsid": "oracle_rollable:sundered_isles/settlement/focus/inland",
+      "cursed_variant": "oracle_rollable:sundered_isles/settlement/focus_cursed"
     }
   },
   "name": "Inland",

--- a/json-packs/sundered-isles-oracles/Inland_Cave_Features_34d1e8677416fda0.json
+++ b/json-packs/sundered-isles-oracles/Inland_Cave_Features_34d1e8677416fda0.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/cave/inland_cave",
-      "dsid": "oracle_rollable:sundered_isles/cave/inland_cave/feature"
+      "dsid": "oracle_rollable:sundered_isles/cave/inland_cave/feature",
+      "cursed_variant": "oracle_rollable:sundered_isles/cave/inland_cave/feature_cursed"
     }
   },
   "name": "Inland Cave Features",

--- a/json-packs/sundered-isles-oracles/Island_Name_19123b0d765f94c3.json
+++ b/json-packs/sundered-isles-oracles/Island_Name_19123b0d765f94c3.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/island",
-      "dsid": "oracle_rollable:sundered_isles/island/name"
+      "dsid": "oracle_rollable:sundered_isles/island/name",
+      "cursed_variant": "oracle_rollable:sundered_isles/island/name_cursed"
     }
   },
   "name": "Island Name",

--- a/json-packs/sundered-isles-oracles/Jungle_cc4be741ca30b038.json
+++ b/json-packs/sundered-isles-oracles/Jungle_cc4be741ca30b038.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/overland/region_landmarks",
-      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/jungle"
+      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/jungle",
+      "cursed_variant": "oracle_rollable:sundered_isles/overland/region_landmarks/cursed"
     }
   },
   "name": "Jungle",

--- a/json-packs/sundered-isles-oracles/Large_5025c54e1158894d.json
+++ b/json-packs/sundered-isles-oracles/Large_5025c54e1158894d.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship/mission",
-      "dsid": "oracle_rollable:sundered_isles/ship/mission/large"
+      "dsid": "oracle_rollable:sundered_isles/ship/mission/large",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/mission_cursed"
     }
   },
   "name": "Large",

--- a/json-packs/sundered-isles-oracles/Lava_Field_214cc3a5e0062ec3.json
+++ b/json-packs/sundered-isles-oracles/Lava_Field_214cc3a5e0062ec3.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/overland/region_landmarks",
-      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/lava_field"
+      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/lava_field",
+      "cursed_variant": "oracle_rollable:sundered_isles/overland/region_landmarks/cursed"
     }
   },
   "name": "Lava Field",

--- a/json-packs/sundered-isles-oracles/Location_Details_fcfcb0bceae33bfe.json
+++ b/json-packs/sundered-isles-oracles/Location_Details_fcfcb0bceae33bfe.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/getting_underway/chart_your_course",
-      "dsid": "oracle_rollable:sundered_isles/getting_underway/chart_your_course/details"
+      "dsid": "oracle_rollable:sundered_isles/getting_underway/chart_your_course/details",
+      "cursed_variant": "oracle_rollable:sundered_isles/getting_underway/chart_your_course/details_cursed"
     }
   },
   "name": "Location Details",

--- a/json-packs/sundered-isles-oracles/Lurking_Threat_00b6028d93a842be.json
+++ b/json-packs/sundered-isles-oracles/Lurking_Threat_00b6028d93a842be.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/cave",
-      "dsid": "oracle_rollable:sundered_isles/cave/lurking_threat"
+      "dsid": "oracle_rollable:sundered_isles/cave/lurking_threat",
+      "cursed_variant": "oracle_rollable:sundered_isles/cave/lurking_threat_cursed"
     }
   },
   "name": "Lurking Threat",

--- a/json-packs/sundered-isles-oracles/Marsh_5e3a3041a8ae82c0.json
+++ b/json-packs/sundered-isles-oracles/Marsh_5e3a3041a8ae82c0.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/overland/region_landmarks",
-      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/marsh"
+      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/marsh",
+      "cursed_variant": "oracle_rollable:sundered_isles/overland/region_landmarks/cursed"
     }
   },
   "name": "Marsh",

--- a/json-packs/sundered-isles-oracles/Medium_d3016c0852310962.json
+++ b/json-packs/sundered-isles-oracles/Medium_d3016c0852310962.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship/mission",
-      "dsid": "oracle_rollable:sundered_isles/ship/mission/medium"
+      "dsid": "oracle_rollable:sundered_isles/ship/mission/medium",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/mission_cursed"
     }
   },
   "name": "Medium",

--- a/json-packs/sundered-isles-oracles/Moniker_21e30acb34a7591c.json
+++ b/json-packs/sundered-isles-oracles/Moniker_21e30acb34a7591c.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/character/name",
-      "dsid": "oracle_rollable:sundered_isles/character/name/moniker"
+      "dsid": "oracle_rollable:sundered_isles/character/name/moniker",
+      "cursed_variant": "oracle_rollable:sundered_isles/character/name/moniker_cursed/category"
     }
   },
   "name": "Moniker",

--- a/json-packs/sundered-isles-oracles/Offshore_Observations_014a1448e279b9bd.json
+++ b/json-packs/sundered-isles-oracles/Offshore_Observations_014a1448e279b9bd.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/island",
-      "dsid": "oracle_rollable:sundered_isles/island/offshore_observations"
+      "dsid": "oracle_rollable:sundered_isles/island/offshore_observations",
+      "cursed_variant": "oracle_rollable:sundered_isles/island/offshore_observations_cursed"
     }
   },
   "name": "Offshore Observations",

--- a/json-packs/sundered-isles-oracles/Overland_Details_1ee2d9f3f3344aa4.json
+++ b/json-packs/sundered-isles-oracles/Overland_Details_1ee2d9f3f3344aa4.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/overland",
-      "dsid": "oracle_rollable:sundered_isles/overland/details"
+      "dsid": "oracle_rollable:sundered_isles/overland/details",
+      "cursed_variant": "oracle_rollable:sundered_isles/overland/details_cursed"
     }
   },
   "name": "Overland Details",

--- a/json-packs/sundered-isles-oracles/River_e59342f67b015a1f.json
+++ b/json-packs/sundered-isles-oracles/River_e59342f67b015a1f.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/overland/region_landmarks",
-      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/river"
+      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/river",
+      "cursed_variant": "oracle_rollable:sundered_isles/overland/region_landmarks/cursed"
     }
   },
   "name": "River",

--- a/json-packs/sundered-isles-oracles/Ruin_Cipher_4d6d3716cc598d8f.json
+++ b/json-packs/sundered-isles-oracles/Ruin_Cipher_4d6d3716cc598d8f.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ruin",
-      "dsid": "oracle_rollable:sundered_isles/ruin/cipher"
+      "dsid": "oracle_rollable:sundered_isles/ruin/cipher",
+      "cursed_variant": "oracle_rollable:sundered_isles/ruin/cipher_cursed"
     }
   },
   "name": "Ruin Cipher",

--- a/json-packs/sundered-isles-oracles/Ruin_Features_be7364705b8fd7db.json
+++ b/json-packs/sundered-isles-oracles/Ruin_Features_be7364705b8fd7db.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ruin",
-      "dsid": "oracle_rollable:sundered_isles/ruin/feature"
+      "dsid": "oracle_rollable:sundered_isles/ruin/feature",
+      "cursed_variant": "oracle_rollable:sundered_isles/ruin/feature_cursed"
     }
   },
   "name": "Ruin Features",

--- a/json-packs/sundered-isles-oracles/Ruin_First_Look_5d105379b22e0dd0.json
+++ b/json-packs/sundered-isles-oracles/Ruin_First_Look_5d105379b22e0dd0.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ruin",
-      "dsid": "oracle_rollable:sundered_isles/ruin/first_look"
+      "dsid": "oracle_rollable:sundered_isles/ruin/first_look",
+      "cursed_variant": "oracle_rollable:sundered_isles/ruin/first_look_cursed"
     }
   },
   "name": "Ruin First Look",

--- a/json-packs/sundered-isles-oracles/Ruin_Mystery_3e07af2891acbea8.json
+++ b/json-packs/sundered-isles-oracles/Ruin_Mystery_3e07af2891acbea8.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ruin",
-      "dsid": "oracle_rollable:sundered_isles/ruin/mystery"
+      "dsid": "oracle_rollable:sundered_isles/ruin/mystery",
+      "cursed_variant": "oracle_rollable:sundered_isles/ruin/mystery_cursed"
     }
   },
   "name": "Ruin Mystery",

--- a/json-packs/sundered-isles-oracles/Scrub_4ed7371f0a5b972a.json
+++ b/json-packs/sundered-isles-oracles/Scrub_4ed7371f0a5b972a.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/overland/region_landmarks",
-      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/scrub"
+      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/scrub",
+      "cursed_variant": "oracle_rollable:sundered_isles/overland/region_landmarks/cursed"
     }
   },
   "name": "Scrub",

--- a/json-packs/sundered-isles-oracles/Sea_Cave_Features_082fdf434af8131f.json
+++ b/json-packs/sundered-isles-oracles/Sea_Cave_Features_082fdf434af8131f.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/cave/sea",
-      "dsid": "oracle_rollable:sundered_isles/cave/sea/feature"
+      "dsid": "oracle_rollable:sundered_isles/cave/sea/feature",
+      "cursed_variant": "oracle_rollable:sundered_isles/cave/sea/feature_cursed"
     }
   },
   "name": "Sea Cave Features",

--- a/json-packs/sundered-isles-oracles/Seafaring_Details_70db4601738cf167.json
+++ b/json-packs/sundered-isles-oracles/Seafaring_Details_70db4601738cf167.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/seafaring",
-      "dsid": "oracle_rollable:sundered_isles/seafaring/details"
+      "dsid": "oracle_rollable:sundered_isles/seafaring/details",
+      "cursed_variant": "oracle_rollable:sundered_isles/seafaring/details_cursed"
     }
   },
   "name": "Seafaring Details",

--- a/json-packs/sundered-isles-oracles/Settlement_Details_b6ab07c01ac3e5d2.json
+++ b/json-packs/sundered-isles-oracles/Settlement_Details_b6ab07c01ac3e5d2.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/settlement",
-      "dsid": "oracle_rollable:sundered_isles/settlement/details"
+      "dsid": "oracle_rollable:sundered_isles/settlement/details",
+      "cursed_variant": "oracle_rollable:sundered_isles/settlement/details_cursed"
     }
   },
   "name": "Settlement Details",

--- a/json-packs/sundered-isles-oracles/Settlement_First_Look_199267df3d4bcfd8.json
+++ b/json-packs/sundered-isles-oracles/Settlement_First_Look_199267df3d4bcfd8.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/settlement",
-      "dsid": "oracle_rollable:sundered_isles/settlement/first_look"
+      "dsid": "oracle_rollable:sundered_isles/settlement/first_look",
+      "cursed_variant": "oracle_rollable:sundered_isles/settlement/first_look_cursed"
     }
   },
   "name": "Settlement First Look",

--- a/json-packs/sundered-isles-oracles/Settlement_Name_9efc54c6814c333e.json
+++ b/json-packs/sundered-isles-oracles/Settlement_Name_9efc54c6814c333e.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/settlement",
-      "dsid": "oracle_rollable:sundered_isles/settlement/name"
+      "dsid": "oracle_rollable:sundered_isles/settlement/name",
+      "cursed_variant": "oracle_rollable:sundered_isles/settlement/name_cursed"
     }
   },
   "name": "Settlement Name",

--- a/json-packs/sundered-isles-oracles/Ship_Details_af4ff510c746793e.json
+++ b/json-packs/sundered-isles-oracles/Ship_Details_af4ff510c746793e.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship",
-      "dsid": "oracle_rollable:sundered_isles/ship/details"
+      "dsid": "oracle_rollable:sundered_isles/ship/details",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/details_cursed"
     }
   },
   "name": "Ship Details",

--- a/json-packs/sundered-isles-oracles/Ship_First_Look_88c70187266d3b02.json
+++ b/json-packs/sundered-isles-oracles/Ship_First_Look_88c70187266d3b02.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship",
-      "dsid": "oracle_rollable:sundered_isles/ship/first_look"
+      "dsid": "oracle_rollable:sundered_isles/ship/first_look",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/first_look_cursed"
     }
   },
   "name": "Ship First Look",

--- a/json-packs/sundered-isles-oracles/Ship_History_97cb6c2795650ab6.json
+++ b/json-packs/sundered-isles-oracles/Ship_History_97cb6c2795650ab6.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/getting_underway/take_command",
-      "dsid": "oracle_rollable:sundered_isles/getting_underway/take_command/ship_history"
+      "dsid": "oracle_rollable:sundered_isles/getting_underway/take_command/ship_history",
+      "cursed_variant": "oracle_rollable:sundered_isles/getting_underway/take_command/ship_history_cursed"
     }
   },
   "name": "Ship History",

--- a/json-packs/sundered-isles-oracles/Ship_Name_bd9e5c9663902508.json
+++ b/json-packs/sundered-isles-oracles/Ship_Name_bd9e5c9663902508.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship",
-      "dsid": "oracle_rollable:sundered_isles/ship/name"
+      "dsid": "oracle_rollable:sundered_isles/ship/name",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/name_cursed"
     }
   },
   "name": "Ship Name",

--- a/json-packs/sundered-isles-oracles/Ship_Symbol_712208723134cf7e.json
+++ b/json-packs/sundered-isles-oracles/Ship_Symbol_712208723134cf7e.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship",
-      "dsid": "oracle_rollable:sundered_isles/ship/symbol"
+      "dsid": "oracle_rollable:sundered_isles/ship/symbol",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/symbol_cursed"
     }
   },
   "name": "Ship Symbol",

--- a/json-packs/sundered-isles-oracles/Shipwreck_Details_6853b581a85a73bb.json
+++ b/json-packs/sundered-isles-oracles/Shipwreck_Details_6853b581a85a73bb.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/shipwreck",
-      "dsid": "oracle_rollable:sundered_isles/shipwreck/details"
+      "dsid": "oracle_rollable:sundered_isles/shipwreck/details",
+      "cursed_variant": "oracle_rollable:sundered_isles/shipwreck/details_cursed"
     }
   },
   "name": "Shipwreck Details",

--- a/json-packs/sundered-isles-oracles/Shipwreck_First_Look_7a7b8d82302bcd36.json
+++ b/json-packs/sundered-isles-oracles/Shipwreck_First_Look_7a7b8d82302bcd36.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/shipwreck",
-      "dsid": "oracle_rollable:sundered_isles/shipwreck/first_look"
+      "dsid": "oracle_rollable:sundered_isles/shipwreck/first_look",
+      "cursed_variant": "oracle_rollable:sundered_isles/shipwreck/first_look_cursed"
     }
   },
   "name": "Shipwreck First Look",

--- a/json-packs/sundered-isles-oracles/Shore_4add7b7073d92003.json
+++ b/json-packs/sundered-isles-oracles/Shore_4add7b7073d92003.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/settlement/focus",
-      "dsid": "oracle_rollable:sundered_isles/settlement/focus/shore"
+      "dsid": "oracle_rollable:sundered_isles/settlement/focus/shore",
+      "cursed_variant": "oracle_rollable:sundered_isles/settlement/focus_cursed"
     }
   },
   "name": "Shore",

--- a/json-packs/sundered-isles-oracles/Shore_747f18d37af50737.json
+++ b/json-packs/sundered-isles-oracles/Shore_747f18d37af50737.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/overland/region_landmarks",
-      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/shore"
+      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/shore",
+      "cursed_variant": "oracle_rollable:sundered_isles/overland/region_landmarks/cursed"
     }
   },
   "name": "Shore",

--- a/json-packs/sundered-isles-oracles/Small_bd0c16d5f3b391cc.json
+++ b/json-packs/sundered-isles-oracles/Small_bd0c16d5f3b391cc.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/ship/mission",
-      "dsid": "oracle_rollable:sundered_isles/ship/mission/small"
+      "dsid": "oracle_rollable:sundered_isles/ship/mission/small",
+      "cursed_variant": "oracle_rollable:sundered_isles/ship/mission_cursed"
     }
   },
   "name": "Small",

--- a/json-packs/sundered-isles-oracles/Swamp_1e3463e94c54d419.json
+++ b/json-packs/sundered-isles-oracles/Swamp_1e3463e94c54d419.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/overland/region_landmarks",
-      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/swamp"
+      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/swamp",
+      "cursed_variant": "oracle_rollable:sundered_isles/overland/region_landmarks/cursed"
     }
   },
   "name": "Swamp",

--- a/json-packs/sundered-isles-oracles/Tokens_0aa8af4001afac1f.json
+++ b/json-packs/sundered-isles-oracles/Tokens_0aa8af4001afac1f.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/treasure",
-      "dsid": "oracle_rollable:sundered_isles/treasure/tokens"
+      "dsid": "oracle_rollable:sundered_isles/treasure/tokens",
+      "cursed_variant": "oracle_rollable:sundered_isles/treasure/tokens_cursed"
     }
   },
   "name": "Tokens",

--- a/json-packs/sundered-isles-oracles/Treasure_Aspects_b39568c61afa93c8.json
+++ b/json-packs/sundered-isles-oracles/Treasure_Aspects_b39568c61afa93c8.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/treasure",
-      "dsid": "oracle_rollable:sundered_isles/treasure/aspects"
+      "dsid": "oracle_rollable:sundered_isles/treasure/aspects",
+      "cursed_variant": "oracle_rollable:sundered_isles/treasure/aspects_cursed"
     }
   },
   "name": "Treasure Aspects",

--- a/json-packs/sundered-isles-oracles/Treasure_Location_ded7a7ea1270f5a2.json
+++ b/json-packs/sundered-isles-oracles/Treasure_Location_ded7a7ea1270f5a2.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/treasure",
-      "dsid": "oracle_rollable:sundered_isles/treasure/location"
+      "dsid": "oracle_rollable:sundered_isles/treasure/location",
+      "cursed_variant": "oracle_rollable:sundered_isles/treasure/location_cursed"
     }
   },
   "name": "Treasure Location",

--- a/json-packs/sundered-isles-oracles/Wastes_6aef040657e5a9ec.json
+++ b/json-packs/sundered-isles-oracles/Wastes_6aef040657e5a9ec.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/overland/region_landmarks",
-      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/wastes"
+      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/wastes",
+      "cursed_variant": "oracle_rollable:sundered_isles/overland/region_landmarks/cursed"
     }
   },
   "name": "Wastes",

--- a/json-packs/sundered-isles-oracles/Waterside_aa174ccdac648c03.json
+++ b/json-packs/sundered-isles-oracles/Waterside_aa174ccdac648c03.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/settlement/focus",
-      "dsid": "oracle_rollable:sundered_isles/settlement/focus/waterside"
+      "dsid": "oracle_rollable:sundered_isles/settlement/focus/waterside",
+      "cursed_variant": "oracle_rollable:sundered_isles/settlement/focus_cursed"
     }
   },
   "name": "Waterside",

--- a/json-packs/sundered-isles-oracles/Woodland_51df8b454d349a65.json
+++ b/json-packs/sundered-isles-oracles/Woodland_51df8b454d349a65.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/overland/region_landmarks",
-      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/woodland"
+      "dsid": "oracle_rollable:sundered_isles/overland/region_landmarks/woodland",
+      "cursed_variant": "oracle_rollable:sundered_isles/overland/region_landmarks/cursed"
     }
   },
   "name": "Woodland",

--- a/json-packs/sundered-isles-oracles/Your_Backstory_88d2400f463b9c29.json
+++ b/json-packs/sundered-isles-oracles/Your_Backstory_88d2400f463b9c29.json
@@ -3,7 +3,8 @@
   "flags": {
     "foundry-ironsworn": {
       "category": "oracle_collection:sundered_isles/getting_underway/create_your_character",
-      "dsid": "oracle_rollable:sundered_isles/getting_underway/create_your_character/your_backstory"
+      "dsid": "oracle_rollable:sundered_isles/getting_underway/create_your_character/your_backstory",
+      "cursed_variant": "oracle_rollable:sundered_isles/getting_underway/create_your_character/your_backstory_cursed"
     }
   },
   "name": "Your Backstory",

--- a/src/module/applications/firstStartDialog.ts
+++ b/src/module/applications/firstStartDialog.ts
@@ -31,8 +31,8 @@ export class FirstStartDialog extends FormApplication<FormApplicationOptions> {
 
 		// Auto-check required rulesets
 		html.find('input.ruleset').on('change', (ev) => {
-			console.log(ev)
-			if (ev.target.checked) {
+			const input = ev.target as HTMLInputElement
+			if (input.checked) {
 				// Clicked on, make sure all required checks are checked as well
 				html
 					.find(`input.ruleset[value="${ev.target.dataset.requires}"]`)
@@ -40,7 +40,7 @@ export class FirstStartDialog extends FormApplication<FormApplicationOptions> {
 			} else {
 				// Clicked off, make sure all dependents are unchecked
 				html
-					.find(`input.ruleset[data-requires="${ev.target.value}"]`)
+					.find(`input.ruleset[data-requires="${input.value}"]`)
 					.prop('checked', false)
 			}
 		})

--- a/src/module/datasworn2/import/index.ts
+++ b/src/module/datasworn2/import/index.ts
@@ -388,7 +388,8 @@ const processOracle = async (
 			'foundry-ironsworn': {
 				dfid: DataswornToLegacyIds[oracle._id],
 				category: legacyFolderId,
-				dsid: oracle._id
+				dsid: oracle._id,
+				cursed_variant: oracle.tags?.sundered_isles?.cursed_by
 			}
 		},
 		name: oracle.name,

--- a/src/module/features/dice/cursed-die.ts
+++ b/src/module/features/dice/cursed-die.ts
@@ -17,18 +17,8 @@ export class DieCursed extends Die {
 	/* -------------------------------------------- */
 
 	/** @override */
-	getResultLabel(result) {
-		return {
-			'1': '&nbsp;',
-			'2': '&nbsp;',
-			'3': '&nbsp;',
-			'4': '&nbsp;',
-			'5': '&nbsp;',
-			'6': '&nbsp;',
-			'7': '&nbsp;',
-			'8': '&nbsp;',
-			'9': '&nbsp;',
-			'10': '💀'
-		}[result.result]
+	getResultLabel({ result }) {
+		if (result === 10) return '💀'
+		return '&nbsp;'
 	}
 }

--- a/src/module/features/dice/index.ts
+++ b/src/module/features/dice/index.ts
@@ -11,16 +11,16 @@ Hooks.once('diceSoNiceReady', (dice3d) => {
 			system: 'ironsworn',
 			type: 'ds',
 			labels: [
-				'systems/foundry-ironsworn/assets/dice/dcursed-cursed.webp',
-				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp',
-				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp',
-				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp',
-				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp',
-				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp',
-				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp',
-				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp',
-				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp',
-				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp'
+				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp', // 1
+				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp', // 2
+				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp', // 3
+				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp', // 4
+				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp', // 5
+				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp', // 6
+				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp', // 7
+				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp', // 8
+				'systems/foundry-ironsworn/assets/dice/dcursed-blank.webp', // 9
+				'systems/foundry-ironsworn/assets/dice/dcursed-cursed.webp' // 10
 			]
 		},
 		'd10'

--- a/src/module/features/dice/index.ts
+++ b/src/module/features/dice/index.ts
@@ -55,3 +55,14 @@ export function cinderAndWraithifyRoll(roll: Roll) {
 		edge: wraithColor
 	}
 }
+
+export function cursifyRoll(roll: Roll) {
+	const die = roll.dice[0]
+	const cursedColor = '#228822'
+	;(die.options as any).appearance = {
+		labelColor: (game.dice3d as any).exports?.Utils?.contrastOf(cursedColor),
+		background: cursedColor,
+		outline: cursedColor,
+		edge: cursedColor
+	}
+}

--- a/src/module/roll-table/oracle-table.ts
+++ b/src/module/roll-table/oracle-table.ts
@@ -379,6 +379,7 @@ export class OracleTable extends RollTable {
 		// defer render to chat so we can manually set the chat message id
 		const { results, roll } = await oracleTable.draw({ displayChat: false })
 		const { cursedResults, cursedDie } = await oracleTable.cursedResults(roll)
+		console.log(cursedResults)
 
 		const templateData = await oracleTable._prepareTemplateData(
 			results,
@@ -424,11 +425,11 @@ export class OracleTable extends RollTable {
 		if (cursedDie.total !== 1) return { cursedDie }
 
 		// Draw from the cursed table
-		const { results: cursedResults } = await cursedTable.draw({
-			roll: originalRoll,
-			displayChat: false
-		})
-		return { cursedResults, cursedDie }
+		const cursedResult = cursedTable.results.find(
+			(x) =>
+				originalRoll.total >= x.range[0] && originalRoll.total <= x.range[1]
+		)
+		return { cursedResults: [cursedResult], cursedDie }
 	}
 }
 

--- a/src/module/roll-table/oracle-table.ts
+++ b/src/module/roll-table/oracle-table.ts
@@ -419,9 +419,9 @@ export class OracleTable extends RollTable {
 		if (!cursedTable) return {}
 
 		// Roll the cursed die
-		const cursedDie = await new Roll('1d10').roll()
+		const cursedDie = await new Roll('1ds').roll()
 		cursifyRoll(cursedDie)
-		if (cursedDie.total !== 10) return { cursedDie }
+		if (cursedDie.total !== 1) return { cursedDie }
 
 		// Draw from the cursed table
 		const { results: cursedResults } = await cursedTable.draw({

--- a/src/module/roll-table/oracle-table.ts
+++ b/src/module/roll-table/oracle-table.ts
@@ -1,6 +1,6 @@
 import type { RollTableDataConstructorData } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs/rollTableData'
 import type { ConfiguredFlags } from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes'
-import { max } from 'lodash-es'
+import { compact, max } from 'lodash-es'
 import type { IronswornActor } from '../actor/actor'
 import { getPackAndIndexForCompendiumKey, IdParser } from '../datasworn2'
 import {
@@ -8,6 +8,7 @@ import {
 	getCustomizedOracleTrees,
 	IOracleTreeNode
 } from '../features/customoracles'
+import { cursifyRoll } from '../features/dice'
 import { DataswornRulesetKey } from '../helpers/settings'
 import { hashLookup } from '../helpers/util'
 import { DFIOracle, DFIRow } from '../item/types'
@@ -185,64 +186,18 @@ export class OracleTable extends RollTable {
 	}
 
 	/**
-	 * Initialize one or more instances of OracleTable from a Dataforged {@link IOracle} node.
-	 * @param options Default constructor options for the tables.
-	 * @param context Default constructor context for the tables
-	 */
-	static async fromDataforged(
-		tableData: OracleTable.IOracleLeaf,
-		options?: Partial<RollTableDataConstructorData>,
-		context?: DocumentModificationContext
-	): Promise<OracleTable | undefined>
-	static async fromDataforged(
-		tableData: OracleTable.IOracleLeaf[],
-		options?: Partial<RollTableDataConstructorData>,
-		context?: DocumentModificationContext
-	): Promise<OracleTable[]>
-	static async fromDataforged(
-		tableData: OracleTable.IOracleLeaf | OracleTable.IOracleLeaf[],
-		options: Partial<RollTableDataConstructorData> = {},
-		context: DocumentModificationContext = {}
-	): Promise<OracleTable | OracleTable[] | undefined> {
-		const clonedOptions = deepClone(options)
-
-		if (!Array.isArray(tableData)) {
-			logger.info(`Building ${tableData.$id}`)
-			return await OracleTable.create(
-				foundry.utils.mergeObject(
-					clonedOptions,
-					OracleTable.getConstructorData(tableData),
-					{
-						overwrite: false,
-						inplace: false
-					}
-				) as RollTableDataConstructorData,
-				context
-			)
-		}
-		logger.info(`Building ${tableData.map((item) => item.$id).join(', ')}`)
-		return await OracleTable.createDocuments(
-			tableData.map(
-				(table) =>
-					foundry.utils.mergeObject(
-						deepClone(clonedOptions),
-						OracleTable.getConstructorData(table),
-						{
-							overwrite: false,
-							inplace: false
-						}
-					) as RollTableDataConstructorData
-			),
-			context
-		)
-	}
-
-	/**
 	 * Prepares handlebars template data for an oracle roll message.
 	 * @remarks This is provided as its own method so that it can be reused to 'fake' rerolls in OracleTable#reroll
 	 */
-	async _prepareTemplateData(results: OracleTableResult[], roll: null | Roll) {
+	async _prepareTemplateData(
+		results: OracleTableResult[],
+		cursedResults: OracleTableResult[] | undefined,
+		cursedDie: Roll | undefined,
+		roll: null | Roll
+	) {
 		const result = results[0]
+		const cursedResult = cursedResults?.[0]
+
 		return {
 			// NB: with these options, this is async in v10
 			// eslint-disable-next-line @typescript-eslint/await-thenable
@@ -256,7 +211,15 @@ export class OracleTable extends RollTable {
 				icon: result.icon,
 				displayRows: result.displayRows.map((row) => row?.toObject())
 			}),
+			cursedResult:
+				cursedResult &&
+				foundry.utils.mergeObject(cursedResult.toObject(false), {
+					text: cursedResult.getChatText(),
+					icon: cursedResult.icon,
+					displayRows: cursedResult.displayRows.map((row) => row?.toObject())
+				}),
 			roll: roll?.toJSON(),
+			cursedDie: cursedDie?.toJSON?.(),
 			table: this,
 			subtitle:
 				this.getFlag('foundry-ironsworn', 'subtitle') ??
@@ -322,6 +285,9 @@ export class OracleTable extends RollTable {
 			}
 		}
 
+		const { cursedResults, cursedDie } =
+			(roll && (await this.cursedResults(roll))) ?? {}
+
 		// Construct chat data
 		messageData = foundry.utils.mergeObject(
 			{
@@ -332,7 +298,7 @@ export class OracleTable extends RollTable {
 						? CONST.CHAT_MESSAGE_TYPES.ROLL
 						: CONST.CHAT_MESSAGE_TYPES.OTHER,
 				roll,
-				rolls: [roll],
+				rolls: compact([roll, cursedDie]),
 				sound: roll != null ? CONFIG.sounds.dice : null,
 				flags
 			},
@@ -341,7 +307,12 @@ export class OracleTable extends RollTable {
 
 		// console.log('messageData', messageData)
 
-		const templateData = await this._prepareTemplateData(results, roll)
+		const templateData = await this._prepareTemplateData(
+			results,
+			cursedResults,
+			cursedDie,
+			roll
+		)
 
 		// Render the chat card which combines the dice roll with the drawn results
 		messageData.content = await renderTemplate(
@@ -407,8 +378,14 @@ export class OracleTable extends RollTable {
 
 		// defer render to chat so we can manually set the chat message id
 		const { results, roll } = await oracleTable.draw({ displayChat: false })
+		const { cursedResults, cursedDie } = await oracleTable.cursedResults(roll)
 
-		const templateData = await oracleTable._prepareTemplateData(results, roll)
+		const templateData = await oracleTable._prepareTemplateData(
+			results,
+			cursedResults,
+			cursedDie,
+			roll
+		)
 
 		const flags = foundry.utils.mergeObject(msg.toObject().flags, {
 			'foundry-ironsworn': {
@@ -417,13 +394,41 @@ export class OracleTable extends RollTable {
 		}) as ConfiguredFlags<'ChatMessage'>
 
 		// trigger sound + 3d dice manually because updating the message won't
-		if (game.dice3d != null) void game.dice3d.showForRoll(roll, game.user, true)
-		else void AudioHelper.play({ src: CONFIG.sounds.dice })
+		if (game.dice3d != null) {
+			void game.dice3d.showForRoll(roll, game.user)
+			if (cursedDie) void game.dice3d.showForRoll(cursedDie, game.user)
+		} else void AudioHelper.play({ src: CONFIG.sounds.dice })
 
 		return await msg.update({
 			content: await renderTemplate(OracleTable.resultTemplate, templateData),
 			flags
 		})
+	}
+
+	async cursedResults(originalRoll: Roll): Promise<{
+		cursedResults?: OracleTableResult[]
+		cursedDie?: Roll
+	}> {
+		const cursedAlternateDsId = this.getFlag(
+			'foundry-ironsworn',
+			'cursed_variant'
+		)
+		if (!cursedAlternateDsId) return {}
+
+		const cursedTable = await OracleTable.getByDsId(cursedAlternateDsId)
+		if (!cursedTable) return {}
+
+		// Roll the cursed die
+		const cursedDie = await new Roll('1d10').roll()
+		cursifyRoll(cursedDie)
+		if (cursedDie.total !== 10) return { cursedDie }
+
+		// Draw from the cursed table
+		const { results: cursedResults } = await cursedTable.draw({
+			roll: originalRoll,
+			displayChat: false
+		})
+		return { cursedResults, cursedDie }
 	}
 }
 

--- a/src/styles/chat-message.less
+++ b/src/styles/chat-message.less
@@ -97,6 +97,11 @@
 		border: none;
 
 		.oracle-table.oracle-table-partial {
+			&.cursed {
+				background-color: var(--ironsworn-color-fg);
+				color: var(--ironsworn-color-bg);
+			}
+
 			transition: none;
 			margin: var(--ironsworn-spacer-xs) 0;
 			// tint to make this an easier read when the message uses e.g. FVTT's default background texture

--- a/system/lang/en.json
+++ b/system/lang/en.json
@@ -67,6 +67,7 @@
 		"Stat": "Stat",
 		"Stats": "Stats",
 		"OracleTable": {
+			"CursedResult": "Cursed Result:",
 			"ColumnLabel": {
 				"Roll": "Roll",
 				"RollRange": "Roll range",

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -14,6 +14,7 @@
     {{#each result.displayRows}}
       {{#if this}}
       <tr class="oracle-result-row" {{#if (eq @index 1)}}aria-selected="true"{{/if}}>
+
         <td class="oracle-table-column-roll-range">
           <span class="oracle-row-content">
           {{#if (eq this.range.[0] this.range.[1])}}{{this.range.[0]}}{{else}}{{this.range.[0]}}–{{this.range.[1]}}{{/if}}
@@ -28,8 +29,11 @@
             <i class="icon fas fa-copy" role="presentational"></i>
           </button>
         </td>
-        <td class="oracle-table-column-result-text">{{{this.text}}}
+
+        <td class="oracle-table-column-result-text">
+          {{{this.text}}}
         </td>
+
         <td class="oracle-table-column-roll-result" >
           {{#if (eq @index 1)}}
           <span class="oracle-row-content">
@@ -46,9 +50,61 @@
           </button>
           {{/if}}
         </td>
+
       </tr>
       {{/if}}
     {{/each}}
     </tbody>
   </table>
+
+  {{#if cursedDie}}
+  <h3 class="flexrow nogrow">
+    <span>Cursed die:</span>
+    <i class="icon isicon-d10-tilt nogrow" role="presentational"></i>
+    &nbsp;
+    <span class="nogrow" style="text-wrap: nowrap;">{{{ cursedDie.total }}}</span>
+  </h3>
+  {{/if}}
+
+  {{#if cursedResult}}
+  <table class="oracle-table oracle-table-partial cursed">
+    <tbody>
+    {{#each cursedResult.displayRows}}
+      {{#if this}}
+      <tr class="oracle-result-row" {{#if (eq @index 1)}}aria-selected="true"{{/if}}>
+
+        <td class="oracle-table-column-roll-range">
+          <span class="oracle-row-content">
+          {{#if (eq this.range.[0] this.range.[1])}}{{this.range.[0]}}{{else}}{{this.range.[0]}}–{{this.range.[1]}}{{/if}}
+          </span>
+          <button
+            type="button"
+            class="oracle-result-control copy-result clickable text"
+            data-result="{{this.text}}"
+            data-tooltip="{{localize 'IRONSWORN.CopyTextToClipboard'}}"
+            data-tooltip-direction="LEFT"
+          >
+            <i class="icon fas fa-copy" role="presentational"></i>
+          </button>
+        </td>
+
+        <td class="oracle-table-column-result-text">
+          {{{this.text}}}
+        </td>
+
+        <td class="oracle-table-column-roll-result" >
+          {{#if (eq @index 1)}}
+          <span class="oracle-row-content">
+            <i class="icon isicon-d10-tilt" role="presentational"></i>
+            <span>{{{ @root.roll.total }}}</span>
+          </span>
+          {{/if}}
+        </td>
+
+      </tr>
+      {{/if}}
+    {{/each}}
+    </tbody>
+  </table>
+  {{/if}}
 </article>

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -60,7 +60,7 @@
   {{#if cursedResult}}
   <h3 class="nogrow">
     <i class="fa fa-skull"></i>
-    Cursed result:
+    {{localize 'IRONSWORN.OracleTable.CursedResult'}}
   </h3>
   <table class="oracle-table oracle-table-partial cursed">
     <tbody>

--- a/system/templates/rolls/oracle-roll-message.hbs
+++ b/system/templates/rolls/oracle-roll-message.hbs
@@ -57,16 +57,11 @@
     </tbody>
   </table>
 
-  {{#if cursedDie}}
-  <h3 class="flexrow nogrow">
-    <span>Cursed die:</span>
-    <i class="icon isicon-d10-tilt nogrow" role="presentational"></i>
-    &nbsp;
-    <span class="nogrow" style="text-wrap: nowrap;">{{{ cursedDie.total }}}</span>
-  </h3>
-  {{/if}}
-
   {{#if cursedResult}}
+  <h3 class="nogrow">
+    <i class="fa fa-skull"></i>
+    Cursed result:
+  </h3>
   <table class="oracle-table oracle-table-partial cursed">
     <tbody>
     {{#each cursedResult.displayRows}}


### PR DESCRIPTION
Sundered Isles has the concept of a cursed die, and alternate tables to roll on. This adds automation for doing that.

- [x] Add a flag to tables with cursed alternates
- [x] If the flag is present when an oracle is rolled
  - [x] Roll a cursed die alongside the d100 for results
  - [x] If the cursed die comes up ☠️, display the matching results from the cursed alternate table as well
- [x] Make it pretty(ish)
- [x] I18n
- [x] Update CHANGELOG.md

![CleanShot 2024-09-05 at 13 56 39](https://github.com/user-attachments/assets/59e2d60e-56ae-4943-97eb-c49f8158065a)

