### PR TITLE
Fix truths generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Cursed die support when rolling oracles ([#1026](https://github.com/ben/foundry-ironsworn/pull/1026))
+- Fix an issue with the truths dialog resulting in blank outputs ([#1027](https://github.com/ben/foundry-ironsworn/pull/1027))
 
 ## 1.24.2
 

--- a/src/module/vue/components/truth/custom-truth.vue
+++ b/src/module/vue/components/truth/custom-truth.vue
@@ -5,20 +5,22 @@
 			type="radio"
 			:name="radioGroup"
 			class="nogrow"
-			@change="select" />
+			@change="select"
+		/>
 		<MceEditor
 			ref="editor"
 			v-model="state.html"
 			:style="{ height: state.height, 'min-height': state.height }"
-			@save="emitHtml" />
+			@save="emitHtml"
+		/>
 	</label>
 </template>
 
 <script lang="ts" setup>
-import { reactive, ref } from 'vue'
+import { onBeforeUnmount, reactive, ref } from 'vue'
 import MceEditor from '../mce-editor.vue'
 
-const props = defineProps<{
+defineProps<{
 	radioGroup: string
 }>()
 
@@ -35,11 +37,19 @@ function select() {
 	state.height = '300px'
 }
 
+// Do not emit change events from the editor if we've been unmounted
+let emitChanges = true
+onBeforeUnmount(() => {
+	console.log('onBeforeUnmount')
+	emitChanges = false
+})
+
 const $emit = defineEmits<{
 	change: [string]
 }>()
 function emitHtml() {
-	$emit('change', state.html)
+	console.log({ emitChanges })
+	if (emitChanges) $emit('change', state.html)
 }
 </script>
 

--- a/src/module/vue/components/truth/custom-truth.vue
+++ b/src/module/vue/components/truth/custom-truth.vue
@@ -40,7 +40,6 @@ function select() {
 // Do not emit change events from the editor if we've been unmounted
 let emitChanges = true
 onBeforeUnmount(() => {
-	console.log('onBeforeUnmount')
 	emitChanges = false
 })
 
@@ -48,7 +47,6 @@ const $emit = defineEmits<{
 	change: [string]
 }>()
 function emitHtml() {
-	console.log({ emitChanges })
 	if (emitChanges) $emit('change', state.html)
 }
 </script>

--- a/src/module/vue/components/truth/truth-category.vue
+++ b/src/module/vue/components/truth/truth-category.vue
@@ -44,6 +44,8 @@ const props = defineProps<{
 	je: () => IronswornJournalEntry
 }>()
 
+const model = defineModel()
+
 type NonTruthPage = IronswornJournalPage<Exclude<JournalEntryPageType, 'truth'>>
 
 const truthPages = props.je()?.pageTypes.truth
@@ -57,16 +59,19 @@ const state = reactive<{
 	title?: string
 	text?: string
 	html?: string
+	custom?: boolean
 }>({})
-function valueChange(title: string, text: string) {
+async function valueChange(title: string, text: string) {
 	state.title = title
 	state.text = text
 	state.html = undefined
+	model.value = await selectedValue()
 }
-function customValueChange(html: string) {
+async function customValueChange(html: string) {
 	state.title = undefined
 	state.text = undefined
 	state.html = html
+	model.value = await selectedValue()
 }
 
 async function selectedValue() {

--- a/src/module/vue/components/truth/truth-category.vue
+++ b/src/module/vue/components/truth/truth-category.vue
@@ -77,17 +77,21 @@ async function customValueChange(html: string) {
 async function selectedValue() {
 	let html = state.html
 	if (!html) {
-		html = `
-      ${await enrichMarkdown(`**${state.title}**`)}
-      ${await enrichMarkdown(state.text)}
-    `
+		if (state.title) {
+			html = `
+				${await enrichMarkdown(`**${state.title}**`)}
+				${await enrichMarkdown(state.text)}
+			`
+		} else {
+			html = await enrichMarkdown(state.text)
+		}
 	}
 	html += nonTruthPages?.map((x) => x.text.content).join('\n\n')
 
 	return {
 		title: props.je()?.name,
 		html: html.trim(),
-		valid: !!(state.title || state.html)
+		valid: true
 	}
 }
 

--- a/src/module/vue/components/truth/truth-selectable.vue
+++ b/src/module/vue/components/truth/truth-selectable.vue
@@ -104,6 +104,8 @@ async function selectAndRandomize() {
 		)
 		suboptions.value[selectedIndex]?.click()
 	}
+
+	emitValue()
 }
 
 defineExpose({ selectAndRandomize })

--- a/src/module/vue/components/truth/truth-selectable.vue
+++ b/src/module/vue/components/truth/truth-selectable.vue
@@ -73,7 +73,13 @@ const $emit = defineEmits<{
 	change: [string, string] // title, text
 }>()
 function emitValue() {
-	let text = `${pageSystem.Description} ${suboption ?? ''}\n\n_${
+	// Some pages (i.e. Classic) don't have a title
+	let title = props.page.name ?? ''
+	if (title?.startsWith('truth.option')) {
+		title = ''
+	}
+
+	let text = `${pageSystem.Description} ${suboption.value ?? ''}\n\n_${
 		pageSystem.Quest
 	}_`
 
@@ -83,7 +89,7 @@ function emitValue() {
 			template.Description.replace(/{{table>.*?}}/, `> ${suboption.value}`) +
 			`\n\n_${pageSystem.Quest}_`
 	}
-	$emit('change', props.page.name ?? '???', text.trim())
+	$emit('change', title, text.trim())
 }
 
 const suboptions = ref<HTMLElement[]>([])

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -33,6 +33,7 @@
 				ref="categoryComponents"
 				:key="(truth.je()._id as string)"
 				:je="truth.je"
+				v-model="categoryModels[truth.ds._id]"
 			/>
 		</section>
 	</div>
@@ -57,6 +58,11 @@ const props = defineProps<{
 }>()
 
 const categoryComponents = ref<(typeof TruthCategory)[]>([])
+const categoryModels = ref<
+	Record<string, { title?: string; html?: string; valid: boolean }>
+>(
+	Object.fromEntries(props.data.truths.map((x) => [x.ds._id, { valid: false }]))
+)
 
 function scrollToCategory(i: number) {
 	categoryComponents.value[i]?.scrollIntoView()
@@ -65,19 +71,17 @@ function scrollToCategory(i: number) {
 const $localEmitter = inject($LocalEmitterKey)
 async function saveTruths() {
 	// Fetch values from the category components
-	const allValues = await Promise.all(
-		categoryComponents.value.map((x) => x.selectedValue())
-	)
-	const values = allValues.filter((x) => x.valid)
+	const contentSections: string[] = []
+	for (const t of props.data.truths) {
+		const model = categoryModels.value[t.ds._id]
+		if (model.valid)
+			contentSections.push(
+				`<h2>${model.title}</h2>
+				${model.html}`
+			)
+	}
 
-	const content = values
-		.map(
-			({ title, html }) => `
-        <h2>${title}</h2>
-        ${html}
-      `
-		)
-		.join('\n\n')
+	const content = contentSections.join('\n\n')
 
 	const title = game.i18n.localize('IRONSWORN.JOURNALENTRYPAGES.TypeTruth')
 	const journal = await IronswornJournalEntry.create({

--- a/src/module/vue/sf-truths.vue
+++ b/src/module/vue/sf-truths.vue
@@ -33,7 +33,7 @@
 				ref="categoryComponents"
 				:key="(truth.je()._id as string)"
 				:je="truth.je"
-				v-model="categoryModels[truth.ds._id]"
+				v-model="categoryModels[truth.je()._id]"
 			/>
 		</section>
 	</div>
@@ -61,7 +61,9 @@ const categoryComponents = ref<(typeof TruthCategory)[]>([])
 const categoryModels = ref<
 	Record<string, { title?: string; html?: string; valid: boolean }>
 >(
-	Object.fromEntries(props.data.truths.map((x) => [x.ds._id, { valid: false }]))
+	Object.fromEntries(
+		props.data.truths.map((x) => [x.je()._id, { valid: false }])
+	)
 )
 
 function scrollToCategory(i: number) {
@@ -73,7 +75,7 @@ async function saveTruths() {
 	// Fetch values from the category components
 	const contentSections: string[] = []
 	for (const t of props.data.truths) {
-		const model = categoryModels.value[t.ds._id]
+		const model = categoryModels.value[t.je()._id]
 		if (model.valid)
 			contentSections.push(
 				`<h2>${model.title}</h2>


### PR DESCRIPTION
Bug reported [in Discord](https://discord.com/channels/437120373436186625/867434336201605160/1280984434430181489), turns out there was more than one issue here.

- [x] Prevent editors from emitting after unmount as though they had been chosen (this race was causing the blank outputs)
- [x] Fix the section titles of Ironsworn truths
- [x] Fix an `[object object]` turd in the output
- [x] Make sure randomize-all and randomize-section work properly
- [x] Update CHANGELOG.md
