### PR TITLE
Use the compendium name for moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Fix a bug where changing the name of a move in the compendium doesn't change it in the move sheet ([#1036](https://github.com/ben/foundry-ironsworn/pull/1036))
+
 ## 1.24.5
 
 - Fix a bug where cinder/wraith and cursed-die rolls wouldn't work unless Dice So Nice was enabled ([#1035](https://github.com/ben/foundry-ironsworn/pull/1035))

--- a/src/module/features/custommoves.ts
+++ b/src/module/features/custommoves.ts
@@ -63,7 +63,7 @@ export async function createMoveTreeForRuleset(
 				)
 				return {
 					color: move.color ?? null,
-					displayName: move.name,
+					displayName: indexEntry.name,
 					uuid: indexEntry.uuid, // TODO: move.uuid
 					triggerText: indexEntry.system?.Trigger?.Text,
 					isRollable: moveTriggerIsRollable(indexEntry?.system?.Trigger),

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -28,39 +28,6 @@ const emptyNode: () => IOracleTreeNode = () => ({
 	children: []
 })
 
-async function augmentWithFolderContents(node: IOracleTreeNode) {
-	const name = game.i18n.localize('IRONSWORN.OracleCategories.Custom')
-	const rootFolder = game.tables?.directory?.folders.find(
-		(x) => x.name === name
-	)
-	if (rootFolder == null) return
-
-	function walkFolder(parent: IOracleTreeNode, folder: Folder) {
-		// Add this folder
-		const newNode: IOracleTreeNode = {
-			...emptyNode(),
-			displayName: folder.name ?? '(folder)'
-		}
-		parent.children.push(newNode)
-
-		// Add its folder children
-		for (const sub of folder.getSubfolders()) {
-			walkFolder(newNode, sub)
-		}
-
-		// Add its table children
-		for (const table of folder.contents) {
-			newNode.children.push({
-				...emptyNode(),
-				tables: [table.uuid],
-				displayName: table.name ?? '(table)'
-			})
-		}
-	}
-
-	walkFolder(node, rootFolder)
-}
-
 function customFolderOracleCategory(): [IOracleTreeNode, number] {
 	const name = game.i18n.localize('IRONSWORN.OracleCategories.Custom')
 	const ret = { ...emptyNode(), displayName: name }


### PR DESCRIPTION
Fixing a bug found on [Discord](https://discord.com/channels/437120373436186625/867434336201605160/1303071238696079453).

- [x] Move sidebar uses names of compendium items, not from Datasworn
- [x] Update CHANGELOG.md
