### PR TITLE
translate +{stat} at end of trigger on move roll popup and stat tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Fix an i18n issue with the translation of stats in the pre-roll dialog ([#1039](https://github.com/ben/foundry-ironsworn/pull/1039/files)) - thanks [@sharak](https://github.com/sharak)!
+
 ## 1.24.9
 
 - Set a default icon for stellar objects, at least when changing their subtype

--- a/src/module/rolls/ironsworn-roll-message.ts
+++ b/src/module/rolls/ironsworn-roll-message.ts
@@ -40,14 +40,16 @@ export function formatRollPlusStat(stat: string, initialCaps = false) {
  * // returns "roll highest of spirit, heart, wits" for en.json
  */
 export function formatRollMethod(rollMethod: DFRollMethod, stats: string[]) {
-	// skip if there's no choice to be made
-	if (stats.length === 1) {
-		return formatRollPlusStat(stats[0])
-	}
-	// canonical triggers have 2 stats; there's a good chance a nice string already exists, so we check for that first.
 	const localizedStats = stats.map((stat) =>
 		game.i18n.localize('IRONSWORN.' + stat.capitalize())
 	)
+
+	// skip if there's no choice to be made
+	if (localizedStats.length === 1) {
+		return formatRollPlusStat(localizedStats[0])
+	}
+
+	// canonical triggers have 2 stats; there's a good chance a nice string already exists, so we check for that first.
 	const methodKeyRoot = `IRONSWORN.roll method.${rollMethod}`
 	const possibleNiceKey = `${methodKeyRoot}.${stats.length}`
 	if (game.i18n.has(possibleNiceKey)) {

--- a/src/module/vue/components/attr-box.vue
+++ b/src/module/vue/components/attr-box.vue
@@ -2,7 +2,7 @@
 	<div
 		class="block"
 		:class="{ [$style.box]: true, ...classes }"
-		:data-tooltip="formatRollPlusStat(attr, true)"
+		:data-tooltip="formatRollPlusStat(i18nKey, true)"
 		@click="click">
 		<label :class="$style.label">{{ $t(i18nKey) }}</label>
 		<div class="flexrow">


### PR DESCRIPTION
This fixes issue #1038.

In languages other than English, the stat is not translated correctly.

- [x] Update CHANGELOG.md
