### PR TITLE
Foundry v13 Support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -85,5 +85,8 @@ export const IRONSWORN: IronswornConfig = {
 	registerOracleTree,
 	getOracleTree,
 
-	parseUuid: typeof parseUuid === 'function' ? parseUuid : _parseUuid
+	parseUuid:
+		foundry.utils?.parseUuid ?? typeof parseUuid === 'function'
+			? parseUuid
+			: _parseUuid
 }

--- a/src/module/features/customassets.ts
+++ b/src/module/features/customassets.ts
@@ -104,10 +104,10 @@ async function customAssetFolderContents(): Promise<
 	DisplayAssetCategory | undefined
 > {
 	const name = game.i18n.localize('IRONSWORN.Asset Categories.Custom')
-	const folder = (game.items?.directory as any)?.folders.find(
-		(x) => x.name === name
-	) as Folder | undefined
-	if (folder == null || folder.contents.length == 0) return
+	const folder = (game.items as any)?.folders.find((x) => x.name === name) as
+		| Folder
+		| undefined
+	if (folder == null || folder.contents.length === 0) return
 
 	const customAssets = [] as DisplayAsset[]
 	for (const item of folder.contents) {

--- a/src/module/features/custommoves.ts
+++ b/src/module/features/custommoves.ts
@@ -77,7 +77,7 @@ export async function createMoveTreeForRuleset(
 
 function customFolderMoveCategory(): DisplayMoveRuleset | undefined {
 	const name = game.i18n.localize('IRONSWORN.MOVES.Custom Moves')
-	const rootFolder = game.items?.directory?.folders.find((x) => x.name === name)
+	const rootFolder = game.items?.folders.find((x) => x.name === name)
 	if (!rootFolder) return undefined
 
 	const category: DisplayMoveCategory = {

--- a/src/module/features/customoracles.ts
+++ b/src/module/features/customoracles.ts
@@ -33,9 +33,7 @@ function customFolderOracleCategory(): [IOracleTreeNode, number] {
 	const ret = { ...emptyNode(), displayName: name }
 	let count = 0
 
-	const rootFolder = game.tables?.directory?.folders.find(
-		(x) => x.name === name
-	)
+	const rootFolder = game.tables?.folders?.find((x) => x.name === name)
 	if (rootFolder == null) return [ret, count]
 
 	function walkFolder(parent: IOracleTreeNode, folder: Folder) {

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -158,17 +158,22 @@ export function activateSceneButtonListeners() {
 
 	Hooks.on('getSceneControlButtons', (controls) => {
 		const oracleButton: SceneControlTool = {
-			name: 'Oracles',
+			name: 'oracles',
 			title: game.i18n.localize('IRONSWORN.ROLLTABLES.TypeOracle'),
 			icon: 'isicon-oracle',
 			visible: true,
 			button: true,
 			onClick: async () => await theOracleWindow().render(true, { focus: true })
 		}
-		controls[0].tools.push(oracleButton)
+
+		if (controls.tokens) {
+			controls.tokens.tools.oracles = oracleButton
+		} else {
+			controls[0].tools.push(oracleButton)
+		}
 
 		const control: SceneControl = {
-			name: game.i18n.localize('IRONSWORN.Ironsworn'),
+			name: 'ironsworn',
 			title: game.i18n.localize('IRONSWORN.StarforgedTools'),
 			icon: 'isicon-logo-starforged-dk',
 			layer: 'ironsworn',
@@ -186,7 +191,11 @@ export function activateSceneButtonListeners() {
 		else if (IronswornSettings.enabledRulesets.includes('starforged'))
 			starforgifyControl(control)
 
-		controls.push(control)
+		if (controls[0]) {
+			controls.push(control)
+		} else {
+			controls.ironsworn = control
+		}
 		return controls
 	})
 }

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -21,6 +21,14 @@
 		width: auto;
 		line-height: var(--ironsworn-line-height);
 	}
+
+	:where(.window-content) {
+		.flexcol,
+		.flexrow {
+			display: flex;
+			align-items: initial;
+		}
+	}
 }
 
 @import 'transitions.less';

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -28,6 +28,10 @@
 			display: flex;
 			align-items: initial;
 		}
+
+		h5 {
+			font-size: revert;
+		}
 	}
 }
 

--- a/system/system.json
+++ b/system/system.json
@@ -9,7 +9,7 @@
   "download": "https://github.com/ben/foundry-ironsworn/releases/download/1.24.10/ironsworn.zip",
   "compatibility": {
     "minimum": 11,
-    "verified": 12
+    "verified": 13
   },
   "authors": [
     {


### PR DESCRIPTION
Adds support for Foundry v13 (using build 336 "testing 1")

- [ ] Fix sheet layout issues with `flexrow` and `flexcol` changing
- [ ] Fix custom asset/move/oracle loading
- [ ] Fix layout in first-start dialog
- [ ] Mark the system as compatible with v13
- [ ] Update CHANGELOG.md
