### PR TITLE
Allow more scene buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Fix scene sidebar buttons in v13 ([#1048](https://github.com/ben/foundry-ironsworn/pull/1048))
+- Enable all ruleset buttons in the sidebar ([#1053](https://github.com/ben/foundry-ironsworn/pull/1053))
 
 ## 1.25.0
 

--- a/src/module/features/sceneButtons.ts
+++ b/src/module/features/sceneButtons.ts
@@ -190,14 +190,16 @@ export function activateSceneButtonListeners() {
 		}
 		addTool(control, oracleButton)
 
-		// Apply updates in order. If you've got IS and SI both enabled, too bad, you're in the isles
-		if (IronswornSettings.enabledRulesets.includes('classic'))
+		// Apply updates in order for all enabled rulesets
+		if (IronswornSettings.enabledRulesets.includes('classic')) {
 			ironswornifyControl(control)
-		// HOWEVER, if you've got both SF and SI enabled, you're only in the isles
-		if (IronswornSettings.enabledRulesets.includes('sundered_isles'))
-			sunderedIslifyControl(control)
-		else if (IronswornSettings.enabledRulesets.includes('starforged'))
+		}
+		if (IronswornSettings.enabledRulesets.includes('starforged')) {
 			starforgifyControl(control)
+		}
+		if (IronswornSettings.enabledRulesets.includes('sundered_isles')) {
+			sunderedIslifyControl(control)
+		}
 
 		if (controls[0]) {
 			controls.push(control)


### PR DESCRIPTION
We were restricting the scene buttons unnecessarily. This adds all the buttons from all enabled rulesets.

- [x] Turn on all the buttons
- [x] Update CHANGELOG.md
