### PR TITLE
Avoid sending name changes when name hasn't changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
+- Fix chat noise when tabbing among the header text fields (name/callsign/pronouns/characteristics) on the SF character sheet ([#1056](https://github.com/ben/foundry-ironsworn/pull/1056))
+
 ## 1.25.1
 
 - Fix scene sidebar buttons in v13 ([#1048](https://github.com/ben/foundry-ironsworn/pull/1048))

--- a/src/module/vue/components/sf-characterheader.vue
+++ b/src/module/vue/components/sf-characterheader.vue
@@ -30,19 +30,13 @@ const pronouns = ref<HTMLInputElement | null>(null)
 const characteristics = ref<HTMLInputElement | null>(null)
 
 function saveName() {
-	$actor?.update({
-		name: name.value?.value
-	})
+	$actor?.update({ name: name.value?.value })
 }
 function saveCallsign() {
-	$actor?.update({
-		'system.callsign': callsign.value?.value
-	})
+	$actor?.update({ 'system.callsign': callsign.value?.value })
 }
 function savePronouns() {
-	$actor?.update({
-		'system.pronouns': pronouns.value?.value
-	})
+	$actor?.update({ 'system.pronouns': pronouns.value?.value })
 }
 function saveCharacteristics() {
 	$actor?.update({

--- a/src/module/vue/components/sf-characterheader.vue
+++ b/src/module/vue/components/sf-characterheader.vue
@@ -2,37 +2,20 @@
 	<SheetHeader class="sf-character-header nogrow">
 		<DocumentImg :document="actor" size="75px" />
 		<section class="header-pc-vitals flexcol">
-			<input
-				ref="name"
-				v-model="actor.name"
-				type="text"
-				:placeholder="$t('Name')"
-				@keyup="save" />
-			<input
-				ref="pronouns"
-				type="text"
-				:placeholder="$t('IRONSWORN.Pronouns')"
-				:value="actor.system.pronouns"
-				@keyup="save" />
-			<input
-				ref="callsign"
-				type="text"
-				:placeholder="$t('IRONSWORN.Callsign')"
-				:value="actor.system.callsign"
-				@keyup="save" />
+			<input ref="name" v-model="actor.name" type="text" :placeholder="$t('Name')" @change="saveName" />
+			<input ref="pronouns" type="text" :placeholder="$t('IRONSWORN.Pronouns')" :value="actor.system.pronouns"
+				@change="savePronouns" />
+			<input ref="callsign" type="text" :placeholder="$t('IRONSWORN.Callsign')" :value="actor.system.callsign"
+				@change="saveCallsign" />
 		</section>
 
-		<textarea
-			ref="characteristics"
-			:value="actor.system.biography"
-			:placeholder="$t('IRONSWORN.Characteristics')"
-			@keyup="save" />
+		<textarea ref="characteristics" :value="actor.system.biography" :placeholder="$t('IRONSWORN.Characteristics')"
+			@change="saveCharacteristics" />
 	</SheetHeader>
 </template>
 
 <script lang="ts" setup>
 import SheetHeader from '../sheet-header.vue'
-import { debounce } from 'lodash-es'
 import type { Ref } from 'vue'
 import { inject, ref } from 'vue'
 import { $ActorKey, ActorKey } from '../provisions'
@@ -46,16 +29,26 @@ const callsign = ref<HTMLInputElement | null>(null)
 const pronouns = ref<HTMLInputElement | null>(null)
 const characteristics = ref<HTMLInputElement | null>(null)
 
-const save = debounce(() => {
+function saveName() {
 	$actor?.update({
-		name: name.value?.value,
-		system: {
-			callsign: callsign.value?.value,
-			pronouns: pronouns.value?.value,
-			biography: characteristics.value?.value
-		}
+		name: name.value?.value
 	})
-}, 500)
+}
+function saveCallsign() {
+	$actor?.update({
+		'system.callsign': callsign.value?.value
+	})
+}
+function savePronouns() {
+	$actor?.update({
+		'system.pronouns': pronouns.value?.value
+	})
+}
+function saveCharacteristics() {
+	$actor?.update({
+		'system.biography': characteristics.value?.value
+	})
+}
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
Reported on discord, tabbing between the header text fields causes "name changed" spam to chat. This changes those field handlers to be "on change" and much more targeted.

- [x] Fix the bug
- [x] Update CHANGELOG.md
