### PR TITLE
Remove obsolete items from system.json that were causing warnings

### DIFF
--- a/system/system.json
+++ b/system/system.json
@@ -29,7 +29,6 @@
       "twitter": "@r_sek"
     }
   ],
-  "manifestPlusVersion": "1.2.0",
   "media": [
     {
       "type": "screenshot",
@@ -73,7 +72,6 @@
   "styles": [
     "ironsworn.css"
   ],
-  "dependencies": [],
   "relationships": {
     "requires": [],
     "recommends": [


### PR DESCRIPTION

Removed `manifestPlusVersion` and `dependencies` from `system.json`. The entries were causing warnings in v13 and above.
