### PR TITLE
Add name and description parsing to rolltables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fresh import from datasworn-community data.
 - Widen and lengthen Rollable Table rich text editor. Editing icons no longer wrap around and text box can show multiple lines.
+- Add name and description fields to rollable tables.
 
 ## 1.28.0
 

--- a/json-packs/delve-oracles/Site_Starters_351e5c77fb813f85.json
+++ b/json-packs/delve-oracles/Site_Starters_351e5c77fb813f85.json
@@ -17,7 +17,8 @@
         1,
         5
       ],
-      "text": "Alva's Rest",
+      "name": "Alva's Rest",
+      "description": "<p>Fortified</p><p>Domain</p>",
       "_key": "!tables.results!351e5c77fb813f85.52d47673227aff9d",
       "_id": "52d47673227aff9d"
     },
@@ -26,7 +27,8 @@
         6,
         10
       ],
-      "text": "Bleakroot Depths",
+      "name": "Bleakroot Depths",
+      "description": "<p>Wild</p><p>Frozen Cavern</p>",
       "_key": "!tables.results!351e5c77fb813f85.1bf2473f03659777",
       "_id": "1bf2473f03659777"
     },
@@ -35,7 +37,8 @@
         11,
         15
       ],
-      "text": "Bonewilds",
+      "name": "Bonewilds",
+      "description": "<p>Haunted</p><p>Tanglewood</p>",
       "_key": "!tables.results!351e5c77fb813f85.5bc17e15b512df80",
       "_id": "5bc17e15b512df80"
     },
@@ -44,7 +47,8 @@
         16,
         20
       ],
-      "text": "Darkfall Caves",
+      "name": "Darkfall Caves",
+      "description": "<p>Infested</p><p>Cavern</p>",
       "_key": "!tables.results!351e5c77fb813f85.f855909bf6e7c05f",
       "_id": "f855909bf6e7c05f"
     },
@@ -53,7 +57,8 @@
         21,
         25
       ],
-      "text": "Deeprot Bog",
+      "name": "Deeprot Bog",
+      "description": "<p>Hallowed</p><p>Shadowfen</p>",
       "_key": "!tables.results!351e5c77fb813f85.0b998ab780eb08c1",
       "_id": "0b998ab780eb08c1"
     },
@@ -62,7 +67,8 @@
         26,
         30
       ],
-      "text": "Egan's Folly",
+      "name": "Egan's Folly",
+      "description": "<p>Haunted</p><p>Pass</p>",
       "_key": "!tables.results!351e5c77fb813f85.40d7f7fd3eb9db6c",
       "_id": "40d7f7fd3eb9db6c"
     },
@@ -71,7 +77,8 @@
         31,
         35
       ],
-      "text": "Foulwater Plunge",
+      "name": "Foulwater Plunge",
+      "description": "<p>Corrupted</p><p>Sea Cave</p>",
       "_key": "!tables.results!351e5c77fb813f85.2ec3e86df9d5932c",
       "_id": "2ec3e86df9d5932c"
     },
@@ -80,7 +87,8 @@
         36,
         40
       ],
-      "text": "Frostmark",
+      "name": "Frostmark",
+      "description": "<p>Fortified</p><p>Icereach</p>",
       "_key": "!tables.results!351e5c77fb813f85.a48053ee061f2177",
       "_id": "a48053ee061f2177"
     },
@@ -89,7 +97,8 @@
         41,
         45
       ],
-      "text": "Greathammer Deep",
+      "name": "Greathammer Deep",
+      "description": "<p>Ravaged</p><p>Mine</p>",
       "_key": "!tables.results!351e5c77fb813f85.fb6d8c5d7353850d",
       "_id": "fb6d8c5d7353850d"
     },
@@ -98,7 +107,8 @@
         46,
         50
       ],
-      "text": "Holdfast Barrow",
+      "name": "Holdfast Barrow",
+      "description": "<p>Haunted</p><p>Barrow</p>",
       "_key": "!tables.results!351e5c77fb813f85.ccd72139f9e1c982",
       "_id": "ccd72139f9e1c982"
     },
@@ -107,7 +117,8 @@
         51,
         55
       ],
-      "text": "Hollowmount Island",
+      "name": "Hollowmount Island",
+      "description": "<p>Ancient</p><p>Underkeep</p>",
       "_key": "!tables.results!351e5c77fb813f85.2594dbb3dcd3ace9",
       "_id": "2594dbb3dcd3ace9"
     },
@@ -116,7 +127,8 @@
         56,
         60
       ],
-      "text": "Icebound Reach",
+      "name": "Icebound Reach",
+      "description": "<p>Wild</p><p>Icereach</p>",
       "_key": "!tables.results!351e5c77fb813f85.8ba00eef077d0713",
       "_id": "8ba00eef077d0713"
     },
@@ -125,7 +137,8 @@
         61,
         65
       ],
-      "text": "Lastrock Mine",
+      "name": "Lastrock Mine",
+      "description": "<p>Infested</p><p>Mine</p>",
       "_key": "!tables.results!351e5c77fb813f85.1b68640802343d2d",
       "_id": "1b68640802343d2d"
     },
@@ -134,7 +147,8 @@
         66,
         70
       ],
-      "text": "Redhome Sanctum",
+      "name": "Redhome Sanctum",
+      "description": "<p>Corrupted</p><p>Underkeep</p>",
       "_key": "!tables.results!351e5c77fb813f85.8d3b0ce12fb5e53a",
       "_id": "8d3b0ce12fb5e53a"
     },
@@ -143,7 +157,8 @@
         71,
         74
       ],
-      "text": "Sinking Temple",
+      "name": "Sinking Temple",
+      "description": "<p>Ravaged</p><p>Ruin</p>",
       "_key": "!tables.results!351e5c77fb813f85.e0b2aaacdc69e15e",
       "_id": "e0b2aaacdc69e15e"
     },
@@ -152,7 +167,8 @@
         75,
         80
       ],
-      "text": "Smoldering Wood",
+      "name": "Smoldering Wood",
+      "description": "<p>Ravaged</p><p>Tanglewood</p>",
       "_key": "!tables.results!351e5c77fb813f85.624f36e6733a3470",
       "_id": "624f36e6733a3470"
     },
@@ -161,7 +177,8 @@
         81,
         84
       ],
-      "text": "Stillgrave Mire",
+      "name": "Stillgrave Mire",
+      "description": "<p>Haunted</p><p>Shadowfen</p>",
       "_key": "!tables.results!351e5c77fb813f85.7a130460d7bf7a99",
       "_id": "7a130460d7bf7a99"
     },
@@ -170,7 +187,8 @@
         85,
         90
       ],
-      "text": "Stonesong Spire",
+      "name": "Stonesong Spire",
+      "description": "<p>Hallowed</p><p>Stronghold</p>",
       "_key": "!tables.results!351e5c77fb813f85.6d0463bf85c791ae",
       "_id": "6d0463bf85c791ae"
     },
@@ -179,7 +197,8 @@
         91,
         94
       ],
-      "text": "Topplekeep",
+      "name": "Topplekeep",
+      "description": "<p>Infested</p><p>Ruin</p>",
       "_key": "!tables.results!351e5c77fb813f85.59c86cb1f05b9510",
       "_id": "59c86cb1f05b9510"
     },
@@ -188,7 +207,8 @@
         95,
         100
       ],
-      "text": "Trail of Spirits",
+      "name": "Trail of Spirits",
+      "description": "<p>Ancient</p><p>Pass</p>",
       "_key": "!tables.results!351e5c77fb813f85.1cf3391a49550ec8",
       "_id": "1cf3391a49550ec8"
     }

--- a/json-packs/starforged-oracles/Faction_Type_9a3e1b0020e66ddb.json
+++ b/json-packs/starforged-oracles/Faction_Type_9a3e1b0020e66ddb.json
@@ -18,7 +18,7 @@
         1,
         40
       ],
-      "text": "@Compendium[foundry-ironsworn.starforgedoracles.e6552ca1c08225e6]{Dominion}",
+      "text": "<p>@Compendium[foundry-ironsworn.starforgedoracles.e6552ca1c08225e6]{Dominion}</p><p>Governing power</p>",
       "_key": "!tables.results!9a3e1b0020e66ddb.63bfe95914abc1ae",
       "_id": "63bfe95914abc1ae"
     },
@@ -27,7 +27,7 @@
         41,
         70
       ],
-      "text": "@Compendium[foundry-ironsworn.starforgedoracles.da3a6351fff54ef4]{Guild}",
+      "text": "<p>@Compendium[foundry-ironsworn.starforgedoracles.da3a6351fff54ef4]{Guild}</p><p>Organization of specialists</p>",
       "_key": "!tables.results!9a3e1b0020e66ddb.87384b8b90a7c44c",
       "_id": "87384b8b90a7c44c"
     },
@@ -36,7 +36,7 @@
         71,
         100
       ],
-      "text": "@Compendium[foundry-ironsworn.starforgedoracles.f3403e14e9e6bd71]{Fringe Group}",
+      "text": "<p>@Compendium[foundry-ironsworn.starforgedoracles.f3403e14e9e6bd71]{Fringe Group}</p><p>Band of outlaws, outcasts, or rogues</p>",
       "_key": "!tables.results!9a3e1b0020e66ddb.ff40a33f485ffff6",
       "_id": "ff40a33f485ffff6"
     }

--- a/json-packs/starforged-oracles/Influence_5f8eb805b526f608.json
+++ b/json-packs/starforged-oracles/Influence_5f8eb805b526f608.json
@@ -18,7 +18,8 @@
         1,
         10
       ],
-      "text": "Forsaken",
+      "name": "Forsaken",
+      "description": "<p>Banished or forgotten</p>",
       "_key": "!tables.results!5f8eb805b526f608.a10362d3c9f29336",
       "_id": "a10362d3c9f29336"
     },
@@ -27,7 +28,8 @@
         11,
         30
       ],
-      "text": "Isolated",
+      "name": "Isolated",
+      "description": "<p>Limited influence in a remote location</p>",
       "_key": "!tables.results!5f8eb805b526f608.03b9fe5b34f487fd",
       "_id": "03b9fe5b34f487fd"
     },
@@ -36,7 +38,8 @@
         31,
         50
       ],
-      "text": "Localized",
+      "name": "Localized",
+      "description": "<p>Marginal influence in a single sector</p>",
       "_key": "!tables.results!5f8eb805b526f608.ecfda2b73cbe459f",
       "_id": "ecfda2b73cbe459f"
     },
@@ -45,7 +48,8 @@
         51,
         70
       ],
-      "text": "Established",
+      "name": "Established",
+      "description": "<p>Strong influence in a single sector</p>",
       "_key": "!tables.results!5f8eb805b526f608.d47e0b5a16bc7096",
       "_id": "d47e0b5a16bc7096"
     },
@@ -54,7 +58,8 @@
         71,
         85
       ],
-      "text": "Notable",
+      "name": "Notable",
+      "description": "<p>Dispersed influence across a few sectors</p>",
       "_key": "!tables.results!5f8eb805b526f608.2c7dcf5408cade34",
       "_id": "2c7dcf5408cade34"
     },
@@ -63,7 +68,8 @@
         86,
         95
       ],
-      "text": "Dominant",
+      "name": "Dominant",
+      "description": "<p>Far-reaching influence across many sectors</p>",
       "_key": "!tables.results!5f8eb805b526f608.2c15d3b9411880be",
       "_id": "2c15d3b9411880be"
     },
@@ -72,7 +78,8 @@
         96,
         100
       ],
-      "text": "Inescapable",
+      "name": "Inescapable",
+      "description": "<p>Pervasive influence across inhabited space</p>",
       "_key": "!tables.results!5f8eb805b526f608.b34d2a568d9a6cc3",
       "_id": "b34d2a568d9a6cc3"
     }

--- a/json-packs/starforged-oracles/Starship_Type_91227527cece2d20.json
+++ b/json-packs/starforged-oracles/Starship_Type_91227527cece2d20.json
@@ -18,7 +18,8 @@
         1,
         2
       ],
-      "text": "Carrier",
+      "name": "Carrier",
+      "description": "<p>Launches fighters</p>",
       "_key": "!tables.results!91227527cece2d20.98cd2f4a86915d83",
       "_id": "98cd2f4a86915d83"
     },
@@ -27,7 +28,8 @@
         3,
         6
       ],
-      "text": "Corvette",
+      "name": "Corvette",
+      "description": "<p>Light attack ship</p>",
       "_key": "!tables.results!91227527cece2d20.5ba1a9c288568474",
       "_id": "5ba1a9c288568474"
     },
@@ -36,7 +38,8 @@
         7,
         11
       ],
-      "text": "Courier",
+      "name": "Courier",
+      "description": "<p>Fast transport</p>",
       "_key": "!tables.results!91227527cece2d20.930f1d9cdfee5a07",
       "_id": "930f1d9cdfee5a07"
     },
@@ -45,7 +48,8 @@
         12,
         14
       ],
-      "text": "Cruiser",
+      "name": "Cruiser",
+      "description": "<p>Medium attack ship</p>",
       "_key": "!tables.results!91227527cece2d20.d9832afc336b00fd",
       "_id": "d9832afc336b00fd"
     },
@@ -54,7 +58,8 @@
         15,
         16
       ],
-      "text": "Dreadnought",
+      "name": "Dreadnought",
+      "description": "<p>Heavy attack ship</p>",
       "_key": "!tables.results!91227527cece2d20.19f0ddd0bf03bc97",
       "_id": "19f0ddd0bf03bc97"
     },
@@ -63,7 +68,8 @@
         17,
         19
       ],
-      "text": "Escape pod",
+      "name": "Escape pod",
+      "description": "<p>Survival craft</p>",
       "_key": "!tables.results!91227527cece2d20.3654e1ed86f5b04c",
       "_id": "3654e1ed86f5b04c"
     },
@@ -72,7 +78,8 @@
         20,
         22
       ],
-      "text": "Foundry",
+      "name": "Foundry",
+      "description": "<p>Mobile construction platform</p>",
       "_key": "!tables.results!91227527cece2d20.b201cdd61b409074",
       "_id": "b201cdd61b409074"
     },
@@ -81,7 +88,8 @@
         23,
         27
       ],
-      "text": "Harvester",
+      "name": "Harvester",
+      "description": "<p>Fuel or energy excavator</p>",
       "_key": "!tables.results!91227527cece2d20.fb7d7404eb4a363d",
       "_id": "fb7d7404eb4a363d"
     },
@@ -90,7 +98,8 @@
         28,
         33
       ],
-      "text": "Hauler",
+      "name": "Hauler",
+      "description": "<p>Heavy transport</p>",
       "_key": "!tables.results!91227527cece2d20.1d06e2dcd7c7630e",
       "_id": "1d06e2dcd7c7630e"
     },
@@ -99,7 +108,8 @@
         34,
         36
       ],
-      "text": "Hunter",
+      "name": "Hunter",
+      "description": "<p>Stealthy attack ship</p>",
       "_key": "!tables.results!91227527cece2d20.8d5cc0b7535a7801",
       "_id": "8d5cc0b7535a7801"
     },
@@ -108,7 +118,8 @@
         37,
         38
       ],
-      "text": "Ironhome",
+      "name": "Ironhome",
+      "description": "<p>Habitat</p>",
       "_key": "!tables.results!91227527cece2d20.b2b23b8b1923083d",
       "_id": "b2b23b8b1923083d"
     },
@@ -117,7 +128,8 @@
         39,
         42
       ],
-      "text": "Mender",
+      "name": "Mender",
+      "description": "<p>Utility or repair</p>",
       "_key": "!tables.results!91227527cece2d20.6aabd219f067ecca",
       "_id": "6aabd219f067ecca"
     },
@@ -126,7 +138,8 @@
         43,
         47
       ],
-      "text": "Outbounder",
+      "name": "Outbounder",
+      "description": "<p>Remote survey or research</p>",
       "_key": "!tables.results!91227527cece2d20.293574267ff31135",
       "_id": "293574267ff31135"
     },
@@ -135,7 +148,8 @@
         48,
         50
       ],
-      "text": "Pennant",
+      "name": "Pennant",
+      "description": "<p>Command ship</p>",
       "_key": "!tables.results!91227527cece2d20.159df41a5277498f",
       "_id": "159df41a5277498f"
     },
@@ -144,7 +158,8 @@
         51,
         56
       ],
-      "text": "Prospector",
+      "name": "Prospector",
+      "description": "<p>Mineral excavator</p>",
       "_key": "!tables.results!91227527cece2d20.9609aa879e099b73",
       "_id": "9609aa879e099b73"
     },
@@ -153,7 +168,8 @@
         57,
         61
       ],
-      "text": "Reclaimer",
+      "name": "Reclaimer",
+      "description": "<p>Salvage or rescue</p>",
       "_key": "!tables.results!91227527cece2d20.ac1cd214f3ee15fc",
       "_id": "ac1cd214f3ee15fc"
     },
@@ -162,7 +178,8 @@
         62,
         64
       ],
-      "text": "Shuttle",
+      "name": "Shuttle",
+      "description": "<p>Short-range transport</p>",
       "_key": "!tables.results!91227527cece2d20.a918944bd0c20241",
       "_id": "a918944bd0c20241"
     },
@@ -171,7 +188,8 @@
         65,
         67
       ],
-      "text": "Snub fighter",
+      "name": "Snub fighter",
+      "description": "<p>Small attack craft</p>",
       "_key": "!tables.results!91227527cece2d20.a93e55b7cf3b963b",
       "_id": "a93e55b7cf3b963b"
     },
@@ -180,7 +198,8 @@
         68,
         82
       ],
-      "text": "Multipurpose",
+      "name": "Multipurpose",
+      "description": "<p><p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/starship/mission\">\n    <i class=\"fa fa-caret-right\"></i> Starship Mission\n</a></p></p>",
       "_key": "!tables.results!91227527cece2d20.deeacc41b75cd3d9",
       "_id": "deeacc41b75cd3d9"
     },

--- a/json-packs/starforged-oracles/Step_2__Choose_Two_Paths_eb992ccf692d8592.json
+++ b/json-packs/starforged-oracles/Step_2__Choose_Two_Paths_eb992ccf692d8592.json
@@ -18,7 +18,8 @@
         1,
         5
       ],
-      "text": "Battlefield Medic",
+      "name": "Battlefield Medic",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.4fafc93fdd8873ce]{Healer}; @Compendium[foundry-ironsworn.starforgedassets.5b517486f8722fdb]{Veteran}</p>",
       "_key": "!tables.results!eb992ccf692d8592.82e175afedd6b33e",
       "_id": "82e175afedd6b33e"
     },
@@ -27,7 +28,8 @@
         6,
         10
       ],
-      "text": "Delegate",
+      "name": "Delegate",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.92c1672053d9fba4]{Bannersworn}; @Compendium[foundry-ironsworn.starforgedassets.bcc219b0ebfb5c68]{Diplomat}</p>",
       "_key": "!tables.results!eb992ccf692d8592.1bdcf36ea866f321",
       "_id": "1bdcf36ea866f321"
     },
@@ -36,7 +38,8 @@
         11,
         15
       ],
-      "text": "Exobiologist",
+      "name": "Exobiologist",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.ce347bbfcee2e8ae]{Lore Hunter}; @Compendium[foundry-ironsworn.starforgedassets.6830f088164f3c60]{Naturalist}</p>",
       "_key": "!tables.results!eb992ccf692d8592.699d91be88cd4181",
       "_id": "699d91be88cd4181"
     },
@@ -45,7 +48,8 @@
         16,
         20
       ],
-      "text": "Far Trader",
+      "name": "Far Trader",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.4692e18baff8bd18]{Navigator}; @Compendium[foundry-ironsworn.starforgedassets.f64df27e8f9083bd]{Trader}</p>",
       "_key": "!tables.results!eb992ccf692d8592.8c0a8d6730d8096a",
       "_id": "8c0a8d6730d8096a"
     },
@@ -54,7 +58,8 @@
         21,
         25
       ],
-      "text": "Fugitive Hunter",
+      "name": "Fugitive Hunter",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.3bd3cddf27041c08]{Armored}; @Compendium[foundry-ironsworn.starforgedassets.9e8a91f52b96c95b]{Bounty Hunter}</p>",
       "_key": "!tables.results!eb992ccf692d8592.8bf2e4226bc5ef95",
       "_id": "8bf2e4226bc5ef95"
     },
@@ -63,7 +68,8 @@
         26,
         30
       ],
-      "text": "Hacker",
+      "name": "Hacker",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.1e03c8d44d0b3ffc]{Infiltrator}; @Compendium[foundry-ironsworn.starforgedassets.fd358fb5b9dcad41]{Tech}</p>",
       "_key": "!tables.results!eb992ccf692d8592.0ef7f0a1012fbc79",
       "_id": "0ef7f0a1012fbc79"
     },
@@ -72,7 +78,8 @@
         31,
         35
       ],
-      "text": "Hotshot Pilot",
+      "name": "Hotshot Pilot",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.c7a0220765d0b579]{Ace}; @Compendium[foundry-ironsworn.starforgedassets.4692e18baff8bd18]{Navigator}</p>",
       "_key": "!tables.results!eb992ccf692d8592.891d1ee0dbcba5e2",
       "_id": "891d1ee0dbcba5e2"
     },
@@ -81,7 +88,8 @@
         36,
         40
       ],
-      "text": "Interstellar Scout",
+      "name": "Interstellar Scout",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.62c8297fab069013]{Explorer}; @Compendium[foundry-ironsworn.starforgedassets.77b99abd50137354]{Voidborn}</p>",
       "_key": "!tables.results!eb992ccf692d8592.1413b51c7c4cf5d0",
       "_id": "1413b51c7c4cf5d0"
     },
@@ -90,7 +98,8 @@
         41,
         45
       ],
-      "text": "Monster Hunter",
+      "name": "Monster Hunter",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.e6dd0f7e6ac6e3cc]{Gunner}; @Compendium[foundry-ironsworn.starforgedassets.b01dc7301d7d8fb3]{Slayer}</p>",
       "_key": "!tables.results!eb992ccf692d8592.7743c2a79329fac1",
       "_id": "7743c2a79329fac1"
     },
@@ -99,7 +108,8 @@
         46,
         50
       ],
-      "text": "Occultist",
+      "name": "Occultist",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.085d80b933598615]{Outcast}; @Compendium[foundry-ironsworn.starforgedassets.12a922e088c35efa]{Shade}</p>",
       "_key": "!tables.results!eb992ccf692d8592.e52a293ec1d36406",
       "_id": "e52a293ec1d36406"
     },
@@ -108,7 +118,8 @@
         51,
         55
       ],
-      "text": "Operative",
+      "name": "Operative",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.1e03c8d44d0b3ffc]{Infiltrator}; @Compendium[foundry-ironsworn.starforgedassets.82cb2564aae5bf0f]{Blademaster}</p>",
       "_key": "!tables.results!eb992ccf692d8592.91b36f87041f5eed",
       "_id": "91b36f87041f5eed"
     },
@@ -117,7 +128,8 @@
         56,
         60
       ],
-      "text": "Outlaw",
+      "name": "Outlaw",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.93b030423d23059d]{Fugitive}; @Compendium[foundry-ironsworn.starforgedassets.0b42a1e32bdb10c9]{Gunslinger}</p>",
       "_key": "!tables.results!eb992ccf692d8592.376b7531d6adb93f",
       "_id": "376b7531d6adb93f"
     },
@@ -126,7 +138,8 @@
         61,
         65
       ],
-      "text": "Private Investigator",
+      "name": "Private Investigator",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.6e439be2dd0bd5a4]{Brawler}; @Compendium[foundry-ironsworn.starforgedassets.26787f46840c03ad]{Sleuth}</p>",
       "_key": "!tables.results!eb992ccf692d8592.72380acb4340a57f",
       "_id": "72380acb4340a57f"
     },
@@ -135,7 +148,8 @@
         66,
         70
       ],
-      "text": "Prophet",
+      "name": "Prophet",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.14c1e6ecd4680fee]{Devotant}; @Compendium[foundry-ironsworn.starforgedassets.98f1ff9b338b5695]{Seer}</p>",
       "_key": "!tables.results!eb992ccf692d8592.919fc01b4584c5e2",
       "_id": "919fc01b4584c5e2"
     },
@@ -144,7 +158,8 @@
         71,
         75
       ],
-      "text": "Psionicist",
+      "name": "Psionicist",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.fd7a1b4ec8ae5771]{Kinetic}; @Compendium[foundry-ironsworn.starforgedassets.d68e04a72dd54d32]{Vestige}</p>",
       "_key": "!tables.results!eb992ccf692d8592.7e5e28c5ada4692a",
       "_id": "7e5e28c5ada4692a"
     },
@@ -153,7 +168,8 @@
         76,
         80
       ],
-      "text": "Smuggler",
+      "name": "Smuggler",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.87222132d6c0379b]{Courier}; @Compendium[foundry-ironsworn.starforgedassets.d7fbe5fded75531c]{Scoundrel}</p>",
       "_key": "!tables.results!eb992ccf692d8592.37f74668315b24d9",
       "_id": "37f74668315b24d9"
     },
@@ -162,7 +178,8 @@
         81,
         85
       ],
-      "text": "Spiritualist",
+      "name": "Spiritualist",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.7fdebd942b7163b6]{Haunted}; @Compendium[foundry-ironsworn.starforgedassets.db0df04af3ca4cc4]{Empath}</p>",
       "_key": "!tables.results!eb992ccf692d8592.bb1d7ca439aa640c",
       "_id": "bb1d7ca439aa640c"
     },
@@ -171,7 +188,8 @@
         86,
         90
       ],
-      "text": "Starship Engineer",
+      "name": "Starship Engineer",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.2d9f63e491a880c8]{Gearhead}; @Compendium[foundry-ironsworn.starforgedassets.fd358fb5b9dcad41]{Tech}</p>",
       "_key": "!tables.results!eb992ccf692d8592.787ebabee8cfb0b6",
       "_id": "787ebabee8cfb0b6"
     },
@@ -180,7 +198,8 @@
         91,
         95
       ],
-      "text": "Supersoldier",
+      "name": "Supersoldier",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.4c75d631a38fd3b8]{Augmented}; @Compendium[foundry-ironsworn.starforgedassets.9530a642ebdca5a5]{Mercenary}</p>",
       "_key": "!tables.results!eb992ccf692d8592.c887e07cc3f2f707",
       "_id": "c887e07cc3f2f707"
     },
@@ -189,7 +208,8 @@
         96,
         100
       ],
-      "text": "Tomb Raider",
+      "name": "Tomb Raider",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.11de92d262291440]{Scavenger}; @Compendium[foundry-ironsworn.starforgedassets.d7fbe5fded75531c]{Scoundrel}</p>",
       "_key": "!tables.results!eb992ccf692d8592.042d0f1b6e2d22d3",
       "_id": "042d0f1b6e2d22d3"
     }

--- a/json-packs/starforged-oracles/Theme_Type_66d9a8128885e14e.json
+++ b/json-packs/starforged-oracles/Theme_Type_66d9a8128885e14e.json
@@ -18,7 +18,7 @@
         1,
         15
       ],
-      "text": "<p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/chaotic\">\n    <i class=\"fa fa-caret-right\"></i> Chaotic\n</a></p>",
+      "text": "<p><p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/chaotic\">\n    <i class=\"fa fa-caret-right\"></i> Chaotic\n</a></p></p><p>Reality is corrupted or warped in this place.</p>",
       "_key": "!tables.results!66d9a8128885e14e.65d82a4e40f876b2",
       "_id": "65d82a4e40f876b2"
     },
@@ -27,7 +27,7 @@
         16,
         25
       ],
-      "text": "<p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/fortified\">\n    <i class=\"fa fa-caret-right\"></i> Fortified\n</a></p>",
+      "text": "<p><p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/fortified\">\n    <i class=\"fa fa-caret-right\"></i> Fortified\n</a></p></p><p>Enemies defend this place against intruders.</p>",
       "_key": "!tables.results!66d9a8128885e14e.adc273cc6cebdcf5",
       "_id": "adc273cc6cebdcf5"
     },
@@ -36,7 +36,7 @@
         26,
         35
       ],
-      "text": "<p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/haunted\">\n    <i class=\"fa fa-caret-right\"></i> Haunted\n</a></p>",
+      "text": "<p><p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/haunted\">\n    <i class=\"fa fa-caret-right\"></i> Haunted\n</a></p></p><p>Restless spirits are bound to this place.</p>",
       "_key": "!tables.results!66d9a8128885e14e.1032754f48ff2c8f",
       "_id": "1032754f48ff2c8f"
     },
@@ -45,7 +45,7 @@
         36,
         50
       ],
-      "text": "<p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/infested\">\n    <i class=\"fa fa-caret-right\"></i> Infested\n</a></p>",
+      "text": "<p><p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/infested\">\n    <i class=\"fa fa-caret-right\"></i> Infested\n</a></p></p><p>Foul creatures have overrun this place.</p>",
       "_key": "!tables.results!66d9a8128885e14e.dbed96ff07629d32",
       "_id": "dbed96ff07629d32"
     },
@@ -54,7 +54,7 @@
         51,
         60
       ],
-      "text": "<p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/inhabited\">\n    <i class=\"fa fa-caret-right\"></i> Inhabited\n</a></p>",
+      "text": "<p><p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/inhabited\">\n    <i class=\"fa fa-caret-right\"></i> Inhabited\n</a></p></p><p>People have built a community in this place.</p>",
       "_key": "!tables.results!66d9a8128885e14e.e2eb1d986b6a1970",
       "_id": "e2eb1d986b6a1970"
     },
@@ -63,7 +63,7 @@
         61,
         75
       ],
-      "text": "<p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/mechanical\">\n    <i class=\"fa fa-caret-right\"></i> Mechanical\n</a></p>",
+      "text": "<p><p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/mechanical\">\n    <i class=\"fa fa-caret-right\"></i> Mechanical\n</a></p></p><p>Machines and technology hold sway in this place.</p>",
       "_key": "!tables.results!66d9a8128885e14e.8d90bc2c3b078dd8",
       "_id": "8d90bc2c3b078dd8"
     },
@@ -72,7 +72,7 @@
         76,
         90
       ],
-      "text": "<p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/ruined\">\n    <i class=\"fa fa-caret-right\"></i> Ruined\n</a></p>",
+      "text": "<p><p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/ruined\">\n    <i class=\"fa fa-caret-right\"></i> Ruined\n</a></p></p><p>Time, disaster, or war have ravaged this place.</p>",
       "_key": "!tables.results!66d9a8128885e14e.976dd4e819aad1af",
       "_id": "976dd4e819aad1af"
     },
@@ -81,7 +81,7 @@
         91,
         100
       ],
-      "text": "<p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/sacred\">\n    <i class=\"fa fa-caret-right\"></i> Sacred\n</a></p>",
+      "text": "<p><p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/location_theme/sacred\">\n    <i class=\"fa fa-caret-right\"></i> Sacred\n</a></p></p><p>Worshipers glorify strange powers in this place.</p>",
       "_key": "!tables.results!66d9a8128885e14e.61db78c5874e678e",
       "_id": "61db78c5874e678e"
     }

--- a/json-packs/sundered-isles-oracles/Beasts_of_the_Land_e19b4bb0e6f8c5a6.json
+++ b/json-packs/sundered-isles-oracles/Beasts_of_the_Land_e19b4bb0e6f8c5a6.json
@@ -17,7 +17,8 @@
         1,
         25
       ],
-      "text": "Predatory Big Cat",
+      "name": "Predatory Big Cat",
+      "description": "<p>Various Ranks</p><p>Big cats are the most common land predator in the isles. Some live among the high branches of jungle canopies, climbing and leaping with ease. Others dwell within the shadows of the forest floor or amid the rocks and crags of highland terrain, stalking their prey with deadly skill.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.1ddcccd97673aae8",
       "_id": "1ddcccd97673aae8"
     },
@@ -26,7 +27,8 @@
         26,
         35
       ],
-      "text": "Reaper",
+      "name": "Reaper",
+      "description": "<p>Formidable</p><p>Reapers are bipedal, cunning reptiles who move in packs, striking unseen from the shadows and chasing prey into flanking ambushes. They dispatch their quarry with wicked, sickle-shaped claws.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.39447ac1fc7df3b8",
       "_id": "39447ac1fc7df3b8"
     },
@@ -35,7 +37,8 @@
         36,
         40
       ],
-      "text": "Great Ape",
+      "name": "Great Ape",
+      "description": "<p>Epic</p><p>The towering great apes of the isles live in the most rugged and remote jungles. They are reclusive creatures and do not abide rivals or trespassers. Their long lives are marked by the innumerable scars of fights with other beasts.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.9d72a866f1be1a1c",
       "_id": "9d72a866f1be1a1c"
     },
@@ -44,7 +47,8 @@
         41,
         45
       ],
-      "text": "Thundermaw",
+      "name": "Thundermaw",
+      "description": "<p>Extreme</p><p>This bipedal reptile is feared for its towering size, toothy maw, and dreadful roar. A small circlet of bone rings the beast’s skull, leading some to name the thundermaw a king among the isles. Despite its legendary reputation, the thundermaw prefers to scavenge its meals, and tires easily when giving chase.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.c9b7613321b656c7",
       "_id": "c9b7613321b656c7"
     },
@@ -53,7 +57,8 @@
         46,
         50
       ],
-      "text": "Primordial",
+      "name": "Primordial",
+      "description": "<p>Epic</p><p>This titanic, reptilian beast dwells within deep jungles and mountainous highlands. It is a creature of the ancient world, unconcerned with the petty affairs of island folk but protective of its mist-shrouded domain. It is taller than the highest jungle canopy, and leaves trails of splintered trees and sundered earth in its wake.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.701d8efa974ea57d",
       "_id": "701d8efa974ea57d"
     },
@@ -62,7 +67,8 @@
         51,
         55
       ],
-      "text": "Avithor",
+      "name": "Avithor",
+      "description": "<p>Dangerous</p><p>These person-sized, flightless birds are drawn to shiny things, and collect bits of stone, metal, and trinkets in their nests. They are jealously protective of this hoard. When a trespasser comes near, they use a chittering call and display of colorful plumage to warn them away. If that fails, their surprising jumping ability, razor-like claws, and sharp beak make quick work of any threat.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.9e77a30359dc7f55",
       "_id": "9e77a30359dc7f55"
     },
@@ -71,7 +77,8 @@
         56,
         60
       ],
-      "text": "Verdant Mammoth",
+      "name": "Verdant Mammoth",
+      "description": "<p>Extreme</p><p>These majestic, nomadic creatures have prehensile trunks, long tusks, and spiraling horns. The largest and oldest of a herd, the matriarch, is covered in a layer of moss, lichen, and plant sprigs—it wears this lush garden like an elaborate, earthy cape. Birds roost along the matriarch’s back and circle above while the herd travels, providing a squawking alarm when danger is near.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.c54ef9b79a688d55",
       "_id": "c54ef9b79a688d55"
     },
@@ -80,7 +87,8 @@
         61,
         65
       ],
-      "text": "Serrabrus",
+      "name": "Serrabrus",
+      "description": "<p>Formidable</p><p>The serrabrus is a large boar-like beast. It is an industrious creature, felling trees, gathering deadwood, and building crude barriers with its sweeping, sawtooth tusks. To find oneself lost within the strange, meandering fences of the serrabrus is to incite the rage of the builder.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.b55e20f7964eb8ec",
       "_id": "b55e20f7964eb8ec"
     },
@@ -89,7 +97,8 @@
         66,
         70
       ],
-      "text": "Night Weaver",
+      "name": "Night Weaver",
+      "description": "<p>Formidable</p><p>These enormous spiders have a sleek, obsidian exoskeleton and slender legs tipped with razor-sharp hooks. They lurk in shadowy places—such as grounded shipwrecks, deep caves, and dense woodlands—building elaborate webs as traps for unwary prey.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.e92a166ef5aad59a",
       "_id": "e92a166ef5aad59a"
     },
@@ -98,7 +107,8 @@
         71,
         75
       ],
-      "text": "Sylvan Strider",
+      "name": "Sylvan Strider",
+      "description": "<p>Extreme</p><p>This gargantuan, insect-like creature moves through woodlands on multi-jointed legs the size of tree trunks. It often stands perfectly still while lying in wait for prey, indiscernible from the surrounding wilds.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.3c0491fd2b50f415",
       "_id": "3c0491fd2b50f415"
     },
@@ -107,7 +117,8 @@
         76,
         80
       ],
-      "text": "Mimic Serpent",
+      "name": "Mimic Serpent",
+      "description": "<p>Extreme</p><p>The scales of this massive, canopy-dwelling snake can shift in hue and texture, allowing it to blend invisibly within its surroundings. After grasping its unaware prey, the mimic serpent coils around its victim, stealing air and crushing bones.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.4b26d19b87ffe0a0",
       "_id": "4b26d19b87ffe0a0"
     },
@@ -116,7 +127,8 @@
         81,
         85
       ],
-      "text": "Ghost Rat",
+      "name": "Ghost Rat",
+      "description": "<p>Dangerous</p><p>These pale rats of unusual size are accustomed to life within lightless caves. Ghost rats are blind, and use their keen sense of smell to navigate the depths. They pursue potential meals with hound-like persistence.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.bcff97027fa7fcbd",
       "_id": "bcff97027fa7fcbd"
     },
@@ -125,7 +137,8 @@
         86,
         90
       ],
-      "text": "Gangle",
+      "name": "Gangle",
+      "description": "<p>Formidable</p><p>This large, cave-dwelling insect contorts its long limbs with uncanny flexibility—the joints cracking like breaking bones—to navigate the smallest crevices. These limbs, equipped with delicate sensory organs, enable the creature to perceive the subtlest vibrations and detect prey or threats from afar. After unfolding itself from its hiding place, the gangle attacks with a spray of burning saliva.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.f88700d6e85b7e67",
       "_id": "f88700d6e85b7e67"
     },
@@ -134,7 +147,8 @@
         91,
         95
       ],
-      "text": "Deep Dragon",
+      "name": "Deep Dragon",
+      "description": "<p>Epic</p><p>These ancient dragons lair in volcanic chambers, hibernating for centuries amid superheated steam and gases. They are flightless, with only vestigial wings, but their titanic scale and molten breath mark them as the greatest of dragon-kind. The rare emergence of a deep dragon from its burrow is a catastrophic reckoning for the surface world.</p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.013a87965eb4245f",
       "_id": "013a87965eb4245f"
     },
@@ -143,7 +157,8 @@
         96,
         100
       ],
-      "text": "Abomination",
+      "name": "Abomination",
+      "description": "<p>Various Ranks</p><p><p>Generate this beast using the Starforged \n<a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/creature\">\n    <i class=\"fa fa-caret-right\"></i> creature oracles\n</a>, giving it a @Compendium[foundry-ironsworn.starforgedoracles.5dee17188d87278c]{land} form.</p></p>",
       "_key": "!tables.results!e19b4bb0e6f8c5a6.3903321a99bcd35e",
       "_id": "3903321a99bcd35e"
     }

--- a/json-packs/sundered-isles-oracles/Beasts_of_the_Sea_6653429d8eec04d8.json
+++ b/json-packs/sundered-isles-oracles/Beasts_of_the_Sea_6653429d8eec04d8.json
@@ -17,7 +17,8 @@
         1,
         15
       ],
-      "text": "Predatory Shark",
+      "name": "Predatory Shark",
+      "description": "<p>Various Ranks</p><p>Most sharks offer little threat, but certain species of large, aggressive sharks are properly feared and respected by seagoing folk. Mariners also speak of ancient sharks, relentless hunters the size of whales whose teeth splinter hull and bone alike.</p>",
       "_key": "!tables.results!6653429d8eec04d8.ab3b1eb16ae19575",
       "_id": "ab3b1eb16ae19575"
     },
@@ -26,7 +27,8 @@
         16,
         30
       ],
-      "text": "Great Whale",
+      "name": "Great Whale",
+      "description": "<p>Various Ranks</p><p>The seas teem with whales of all sorts. Even the largest of them, the great whales, are generally friendly and curious. They are nevertheless under threat by whalers and despoilers, and some islanders sail in defense of these gentle creatures.</p>",
       "_key": "!tables.results!6653429d8eec04d8.6794148c56ff376f",
       "_id": "6794148c56ff376f"
     },
@@ -35,7 +37,8 @@
         31,
         35
       ],
-      "text": "Leviathan",
+      "name": "Leviathan",
+      "description": "<p>Epic</p><p>These ancient whales are far larger and more aggressive than their common kin. Their bone-white hide bears the scars of harpoon strikes and hard-won battles with other beasts. They are keenly intelligent, have long memories, and do not forgive or forget.</p>",
       "_key": "!tables.results!6653429d8eec04d8.69ce6e649cd29e2f",
       "_id": "69ce6e649cd29e2f"
     },
@@ -44,7 +47,8 @@
         36,
         40
       ],
-      "text": "Rothulk",
+      "name": "Rothulk",
+      "description": "<p>Extreme</p><p>Circling carrion birds and the stench of death often forewarn the appearance of a rothulk, a cadaverous but still animate great whale. These unfortunate beasts are infested by a multitude of parasites that bind grasping tendrils to flesh and bone. The small creatures steal the life of their host and puppeteer what remains.</p>",
       "_key": "!tables.results!6653429d8eec04d8.042dddda31567328",
       "_id": "042dddda31567328"
     },
@@ -53,7 +57,8 @@
         41,
         45
       ],
-      "text": "Giant Squid",
+      "name": "Giant Squid",
+      "description": "<p>Formidable</p><p>The largest of these creatures can easily crush a longboat with their powerful tentacles, but they only reluctantly emerge from the lightless depths that is their preferred hunting grounds.</p>",
       "_key": "!tables.results!6653429d8eec04d8.f83eeb886d6edaac",
       "_id": "f83eeb886d6edaac"
     },
@@ -62,7 +67,8 @@
         46,
         50
       ],
-      "text": "The Kraken",
+      "name": "The Kraken",
+      "description": "<p>Epic</p><p>The Kraken is the singular master of the seas, a beast of horrific scale, cunning, and ferocity. It has the sleek form and speed of a giant whale, but is armed with powerful tentacles and a gaping, toothy maw. Along its flank are rows of luminescent eyes; doom lights, mariners call them, for they are a presage of certain death.</p>",
       "_key": "!tables.results!6653429d8eec04d8.d3e3e04f6fe05f54",
       "_id": "d3e3e04f6fe05f54"
     },
@@ -71,7 +77,8 @@
         51,
         55
       ],
-      "text": "Sea Dragon",
+      "name": "Sea Dragon",
+      "description": "<p>Formidable</p><p>These aquatic dragons have glittering scales, toothy jaws, and long, bladed tails. Their winglike fins propel them through the water at amazing speeds, and send them leaping and gliding over the waves.</p>",
       "_key": "!tables.results!6653429d8eec04d8.5ce79fe7789290d9",
       "_id": "5ce79fe7789290d9"
     },
@@ -80,7 +87,8 @@
         56,
         60
       ],
-      "text": "Elder Ray",
+      "name": "Elder Ray",
+      "description": "<p>Extreme</p><p>Like their lesser brethren, these creatures have flattened bodies and broad fins. They are inherently gentle, often traveling with seafolk who recognize individual rays by their luminescent markings.</p>",
       "_key": "!tables.results!6653429d8eec04d8.73a16a1b4f25800b",
       "_id": "73a16a1b4f25800b"
     },
@@ -89,7 +97,8 @@
         61,
         65
       ],
-      "text": "Whipneck",
+      "name": "Whipneck",
+      "description": "<p>Formidable</p><p>These creatures are about the length of a sloop, with long necks, broad bodies, and turtle-like fins. They are not overly aggressive, but often hound fishing boats in hopes of stealing their catch.</p>",
       "_key": "!tables.results!6653429d8eec04d8.4308307ff72dfa1c",
       "_id": "4308307ff72dfa1c"
     },
@@ -98,7 +107,8 @@
         66,
         70
       ],
-      "text": "Eel Swarm",
+      "name": "Eel Swarm",
+      "description": "<p>Formidable</p><p>These masses of black-eyed, sharp-toothed eels rely on sheer numbers to overwhelm larger prey. Some say they are capable of chewing through a ship’s hull, and pour into a breached vessel in a slithering, biting torrent.</p>",
       "_key": "!tables.results!6653429d8eec04d8.77a3bcf8b15155be",
       "_id": "77a3bcf8b15155be"
     },
@@ -107,7 +117,8 @@
         71,
         75
       ],
-      "text": "Sea Serpent",
+      "name": "Sea Serpent",
+      "description": "<p>Epic</p><p>These titanic beasts have sinuous bodies, glittering scales, and spiny red fins larger than the greatest mainsail. They are largely ambivalent to the presence of most seagoing folk—all but the largest ship passes beneath their notice.</p>",
       "_key": "!tables.results!6653429d8eec04d8.93838769dbdad0b5",
       "_id": "93838769dbdad0b5"
     },
@@ -116,7 +127,8 @@
         76,
         80
       ],
-      "text": "Reefstrider",
+      "name": "Reefstrider",
+      "description": "<p>Extreme</p><p>The shells of these gigantic, squat crustaceans are encrusted with coral and sea life, camouflaging them among reef systems. They are territorial and protective of their habitats.</p>",
       "_key": "!tables.results!6653429d8eec04d8.4dc00ebda155e044",
       "_id": "4dc00ebda155e044"
     },
@@ -125,7 +137,8 @@
         81,
         85
       ],
-      "text": "Starlume",
+      "name": "Starlume",
+      "description": "<p>Dangerous</p><p>Hundreds of pinpoint lights shimmer within the translucent form of these gigantic jellyfish. According to legend, the lights of a starlume reveal complex celestial maps. Those who look deeply into those alluring lights may find themselves gifted—or cursed—with visions of lost seas and hidden places.</p>",
       "_key": "!tables.results!6653429d8eec04d8.5984cf53b0ffca55",
       "_id": "5984cf53b0ffca55"
     },
@@ -134,7 +147,8 @@
         86,
         90
       ],
-      "text": "Vortex Forge",
+      "name": "Vortex Forge",
+      "description": "<p>Epic</p><p>From a distance, this titanic entity might be mistaken for a great whale, but it is a crewless metal construct that wanders the seas on an inscrutable mission. Its rotating maw generates powerful whirlpools to draw in prey, sending ship and sailor alike into an ever-burning furnace deep within its mechanical gullet.</p>",
       "_key": "!tables.results!6653429d8eec04d8.ac02eeefc0522b65",
       "_id": "ac02eeefc0522b65"
     },
@@ -143,7 +157,8 @@
         91,
         95
       ],
-      "text": "Herald",
+      "name": "Herald",
+      "description": "<p>Epic</p><p>These colossal tortoise-like beings are the longest-lived creatures of the isles—perhaps as ancient as the world itself. Islanders interpret wondrous and grim portents from the sighting of a herald, but these creatures often go unseen; their craggy shell is easily mistaken for a small, rocky island.</p>",
       "_key": "!tables.results!6653429d8eec04d8.1b89532e467eaa10",
       "_id": "1b89532e467eaa10"
     },
@@ -152,7 +167,8 @@
         96,
         100
       ],
-      "text": "Abomination",
+      "name": "Abomination",
+      "description": "<p>Various Ranks</p><p><p>Generate this beast using the Starforged \n<a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/creature\">\n    <i class=\"fa fa-caret-right\"></i> creature oracles\n</a>, giving it a @Compendium[foundry-ironsworn.starforgedoracles.3e5b84fccec6c789]{water} form.</p></p>",
       "_key": "!tables.results!6653429d8eec04d8.3193a9a6de49db81",
       "_id": "3193a9a6de49db81"
     }

--- a/json-packs/sundered-isles-oracles/Beasts_of_the_Shore_and_River_d6345a7d8b548623.json
+++ b/json-packs/sundered-isles-oracles/Beasts_of_the_Shore_and_River_d6345a7d8b548623.json
@@ -17,7 +17,8 @@
         1,
         20
       ],
-      "text": "Great Crocodile",
+      "name": "Great Crocodile",
+      "description": "<p>Various Ranks</p><p>Large crocodiles dwell in waters throughout the isles, including coastal wetlands, rivers, and the depths of tidal caves. The greatest and fiercest of them are the size of a sloop­­ —armed with dagger-like teeth, impenetrable hides, and powerful tails capable of shattering stone.</p>",
       "_key": "!tables.results!d6345a7d8b548623.d5d77f8c1d61886e",
       "_id": "d5d77f8c1d61886e"
     },
@@ -26,7 +27,8 @@
         21,
         35
       ],
-      "text": "Tenebrous Squid",
+      "name": "Tenebrous Squid",
+      "description": "<p>Extreme</p><p>This beast dwells within shoreline hollows and sea caves. It is a cunning and patient creature, slumbering for months or years until hapless prey wanders into its dark lair. As it awakens, its orb-like eyes glimmer with a foul, hungry light, and its barbed tentacles prepare to strike.</p>",
       "_key": "!tables.results!d6345a7d8b548623.05e75f0f6ff98dfd",
       "_id": "05e75f0f6ff98dfd"
     },
@@ -35,7 +37,8 @@
         36,
         50
       ],
-      "text": "Diving Spider",
+      "name": "Diving Spider",
+      "description": "<p>Dangerous</p><p>These semi-aquatic arachnids trap air with their silk, enabling them to hunt along riverbeds and coastal shallows, or lurk along the shore in wait of prey. They occasionally get caught up in nets, an unlucky catch for fisher folk.</p>",
       "_key": "!tables.results!d6345a7d8b548623.f602285f80a6716b",
       "_id": "f602285f80a6716b"
     },
@@ -44,7 +47,8 @@
         51,
         65
       ],
-      "text": "Muck Toad",
+      "name": "Muck Toad",
+      "description": "<p>Formidable</p><p>This creature lurks within the mire of swamps and muddy rivers. What the muck toad lacks in speed and agility, it makes up for in strength and scale, grasping prey with its prehensile tongue and swallowing it whole with its cavernous maw.</p>",
       "_key": "!tables.results!d6345a7d8b548623.aa368aad8763cbd8",
       "_id": "aa368aad8763cbd8"
     },
@@ -53,7 +57,8 @@
         66,
         75
       ],
-      "text": "Sand Dragon",
+      "name": "Sand Dragon",
+      "description": "<p>Formidable</p><p>Sand dragons are the smallest of dragon-kind, but are still a fearsome foe. Burrowing beneath shoreline dunes, it stirs at the telltale vibrations of footfalls upon its lair. It attacks with dagger-like claws, teeth as long and wicked as cutlasses, and breath of scalding steam.</p>",
       "_key": "!tables.results!d6345a7d8b548623.4b038850edecd362",
       "_id": "4b038850edecd362"
     },
@@ -62,7 +67,8 @@
         76,
         85
       ],
-      "text": "Keelback Crab",
+      "name": "Keelback Crab",
+      "description": "<p>Extreme</p><p>The keelback crab uses a scavenged ship as a protective shell for its soft exoskeleton. Reports of ghost ships can often be attributed to keelbacks, scuttling along coastal waters with wrecks on their backs. As it grows, a keelback must commandeer vessels of increasing size.</p>",
       "_key": "!tables.results!d6345a7d8b548623.bb5c090a5f3f324a",
       "_id": "bb5c090a5f3f324a"
     },
@@ -71,7 +77,8 @@
         86,
         95
       ],
-      "text": "Jade Crab",
+      "name": "Jade Crab",
+      "description": "<p>Extreme</p><p>The jade crab is the largest and most aggressive of the crustaceans, able to snap a longboat or even a small ship in two with its vice-like pincers. At rest, their shell is slate gray, easily mistaken for rocks or reefs. On the hunt, they shimmer with an iridescent blue-green. Fiercely territorial, these creatures often claim a waterway, cove, or sea cave as their lair.</p>",
       "_key": "!tables.results!d6345a7d8b548623.5a28717fbf7efea6",
       "_id": "5a28717fbf7efea6"
     },
@@ -80,7 +87,8 @@
         96,
         100
       ],
-      "text": "Abomination",
+      "name": "Abomination",
+      "description": "<p>Various Ranks</p><p><p>Generate this beast using the Starforged \n<a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/creature\">\n    <i class=\"fa fa-caret-right\"></i> creature oracles\n</a>, giving it a @Compendium[foundry-ironsworn.starforgedoracles.5dee17188d87278c]{land} or @Compendium[foundry-ironsworn.starforgedoracles.3e5b84fccec6c789]{water} form.</p></p>",
       "_key": "!tables.results!d6345a7d8b548623.318c9f782abd98b0",
       "_id": "318c9f782abd98b0"
     }

--- a/json-packs/sundered-isles-oracles/Beasts_of_the_Sky_294bb6937be1cbfd.json
+++ b/json-packs/sundered-isles-oracles/Beasts_of_the_Sky_294bb6937be1cbfd.json
@@ -17,7 +17,8 @@
         1,
         20
       ],
-      "text": "Great Hawk",
+      "name": "Great Hawk",
+      "description": "<p>Various Ranks</p><p>Various types of enormous hawks hunt among the isles, including the mangrove-dwelling ash hawk and the coastal wind reaver. The greatest of them, the fabled vastwing, is said to be capable of grasping and lifting a fully loaded longboat in its enormous talons.</p>",
       "_key": "!tables.results!294bb6937be1cbfd.2bcb4486103b3888",
       "_id": "2bcb4486103b3888"
     },
@@ -26,7 +27,8 @@
         21,
         35
       ],
-      "text": "Iron Dragon",
+      "name": "Iron Dragon",
+      "description": "<p>Extreme</p><p>The most common dragon of the isles, the iron dragon dwells in a variety of environments, from rocky coasts to deep inland jungles. They have a tough hide the color of weathered iron, dreadful claws, and a long, powerful tail. But their most potent weapon is their fiery breath, the bane of any wooden ship that earns their ire. Some island folk revere these creatures. But others harness them and ride into battle, launching from a seaside fort or a ship’s deck to lay waste to their enemies.</p>",
       "_key": "!tables.results!294bb6937be1cbfd.78009040110050ae",
       "_id": "78009040110050ae"
     },
@@ -35,7 +37,8 @@
         36,
         50
       ],
-      "text": "Wave Skimmer",
+      "name": "Wave Skimmer",
+      "description": "<p>Formidable</p><p>These winged reptilian beasts nest along waterside cliffs, and are adept at diving to spear fish with barbed beaks. Fishing boats and cargo ships often fall prey to wave skimmer ambushes, as the cunning predators have learned of the great bounties hidden within those vessels.</p>",
       "_key": "!tables.results!294bb6937be1cbfd.b3d9f2a6b3920a05",
       "_id": "b3d9f2a6b3920a05"
     },
@@ -44,7 +47,8 @@
         51,
         65
       ],
-      "text": "Goregull",
+      "name": "Goregull",
+      "description": "<p>Dangerous</p><p>Scavengers by nature, the vulture-sized goregulls feed primarily on dead sea life, but are known to harass the crews of floundering ships.</p>",
       "_key": "!tables.results!294bb6937be1cbfd.120057bd43f61d10",
       "_id": "120057bd43f61d10"
     },
@@ -53,7 +57,8 @@
         66,
         75
       ],
-      "text": "Monarch Bat",
+      "name": "Monarch Bat",
+      "description": "<p>Formidable</p><p>These oversized bats, large enough to carry off an unlucky islander, dwell in caves and amid jungle canopies. As the sun sets, they leave their roosts to hunt. They are particularly dangerous on moonless nights when their swift, silent approach goes unnoticed.</p>",
       "_key": "!tables.results!294bb6937be1cbfd.55b6d1b0afa99413",
       "_id": "55b6d1b0afa99413"
     },
@@ -62,7 +67,8 @@
         76,
         85
       ],
-      "text": "Bloodmite",
+      "name": "Bloodmite",
+      "description": "<p>Dangerous</p><p>Bloodmites are hound-sized, flying insects. They primarily cling to the hide of titanic beasts, feeding through a blade-tipped proboscis, but are not averse to preying upon smaller targets.</p>",
       "_key": "!tables.results!294bb6937be1cbfd.6591f5a8a0155400",
       "_id": "6591f5a8a0155400"
     },
@@ -71,7 +77,8 @@
         86,
         95
       ],
-      "text": "Thanatoi",
+      "name": "Thanatoi",
+      "description": "<p>Dangerous</p><p>These moth-like creatures are unsettlingly large but harmless. They are often seen on nights when Wraith is full—they shimmer with a strange, ethereal glow, as if reflecting the light of the moon. Many islanders believe they escort souls into the world beyond. Look too long into their alluring glow, they say, and you suffer a glimpse of your own death.</p>",
       "_key": "!tables.results!294bb6937be1cbfd.44f727a15f604a95",
       "_id": "44f727a15f604a95"
     },
@@ -80,7 +87,8 @@
         96,
         100
       ],
-      "text": "Abomination",
+      "name": "Abomination",
+      "description": "<p>Various Ranks</p><p><p>Generate this beast using the Starforged \n<a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:starforged/creature\">\n    <i class=\"fa fa-caret-right\"></i> creature oracles\n</a>, giving it an @Compendium[foundry-ironsworn.starforgedoracles.16fbeb54dfe52e19]{air} form.</p></p>",
       "_key": "!tables.results!294bb6937be1cbfd.49f873ab7cf345f0",
       "_id": "49f873ab7cf345f0"
     }

--- a/json-packs/sundered-isles-oracles/Cave_Type_6ff831d368b8ed49.json
+++ b/json-packs/sundered-isles-oracles/Cave_Type_6ff831d368b8ed49.json
@@ -17,7 +17,8 @@
         1,
         60
       ],
-      "text": "Sea Cave",
+      "name": "Sea Cave",
+      "description": "<p>Caves of watery passages; carved by the tides</p>",
       "_key": "!tables.results!6ff831d368b8ed49.87c52ac6d5cf4295",
       "_id": "87c52ac6d5cf4295"
     },
@@ -26,7 +27,8 @@
         61,
         100
       ],
-      "text": "Inland Cave",
+      "name": "Inland Cave",
+      "description": "<p>Caves of echoing stone; plunging deep into the earth</p>",
       "_key": "!tables.results!6ff831d368b8ed49.1d3e3ca7f5f392e8",
       "_id": "1d3e3ca7f5f392e8"
     }

--- a/json-packs/sundered-isles-oracles/Cursed_Location_Details_a040017098c4b011.json
+++ b/json-packs/sundered-isles-oracles/Cursed_Location_Details_a040017098c4b011.json
@@ -17,7 +17,8 @@
         1,
         5
       ],
-      "text": "Area of endless dead calm",
+      "name": "Area of endless dead calm",
+      "description": "<p>What ship is trapped in these waters?</p>",
       "_key": "!tables.results!a040017098c4b011.5636c582bfa0a93d",
       "_id": "5636c582bfa0a93d"
     },
@@ -26,7 +27,8 @@
         6,
         10
       ],
-      "text": "Colossal bones",
+      "name": "Colossal bones",
+      "description": "<p>Who lives in the shadow of this age-old corpse?</p>",
       "_key": "!tables.results!a040017098c4b011.087f04e5cf33434e",
       "_id": "087f04e5cf33434e"
     },
@@ -35,7 +37,8 @@
         11,
         15
       ],
-      "text": "Corrupted cave",
+      "name": "Corrupted cave",
+      "description": "<p>What cult is said to practice foul rites here?</p>",
       "_key": "!tables.results!a040017098c4b011.b782615a33234343",
       "_id": "b782615a33234343"
     },
@@ -44,7 +47,8 @@
         16,
         20
       ],
-      "text": "Eldritch monument",
+      "name": "Eldritch monument",
+      "description": "<p>What forsaken god or entity does this monument honor?</p>",
       "_key": "!tables.results!a040017098c4b011.22aa0e3469686dea",
       "_id": "22aa0e3469686dea"
     },
@@ -53,7 +57,8 @@
         21,
         25
       ],
-      "text": "Forsaken settlement",
+      "name": "Forsaken settlement",
+      "description": "<p>What foul creatures now dwell here?</p>",
       "_key": "!tables.results!a040017098c4b011.9356e4927fd3b471",
       "_id": "9356e4927fd3b471"
     },
@@ -62,7 +67,8 @@
         26,
         30
       ],
-      "text": "Frozen wastes",
+      "name": "Frozen wastes",
+      "description": "<p>What long-lost ship lies trapped here?</p>",
       "_key": "!tables.results!a040017098c4b011.115af4ce0cd102ba",
       "_id": "115af4ce0cd102ba"
     },
@@ -71,7 +77,8 @@
         31,
         35
       ],
-      "text": "Ghost-haunted waters",
+      "name": "Ghost-haunted waters",
+      "description": "<p>What infamous cursed ship sails these waters?</p>",
       "_key": "!tables.results!a040017098c4b011.7b49d5442d442c2f",
       "_id": "7b49d5442d442c2f"
     },
@@ -80,7 +87,8 @@
         36,
         40
       ],
-      "text": "Ghost-plagued ruins",
+      "name": "Ghost-plagued ruins",
+      "description": "<p>What sad fate befell these people?</p>",
       "_key": "!tables.results!a040017098c4b011.032ae2af0b13ee60",
       "_id": "032ae2af0b13ee60"
     },
@@ -89,7 +97,8 @@
         41,
         45
       ],
-      "text": "Haunted battlefield",
+      "name": "Haunted battlefield",
+      "description": "<p>What force or faction was defeated in this battle?</p>",
       "_key": "!tables.results!a040017098c4b011.c796a741801c55f4",
       "_id": "c796a741801c55f4"
     },
@@ -98,7 +107,8 @@
         46,
         50
       ],
-      "text": "Hidden island",
+      "name": "Hidden island",
+      "description": "<p>On what rare event does this mystical island reappear?</p>",
       "_key": "!tables.results!a040017098c4b011.0cff2ae3a591b822",
       "_id": "0cff2ae3a591b822"
     },
@@ -107,7 +117,8 @@
         51,
         55
       ],
-      "text": "Inscrutable iron pillars",
+      "name": "Inscrutable iron pillars",
+      "description": "<p>What faction worships these mysterious relics?</p>",
       "_key": "!tables.results!a040017098c4b011.c4a42e50345c63a9",
       "_id": "c4a42e50345c63a9"
     },
@@ -116,7 +127,8 @@
         56,
         60
       ],
-      "text": "Lair of a beast",
+      "name": "Lair of a beast",
+      "description": "<p>What beast is reputed to dwell here?</p>",
       "_key": "!tables.results!a040017098c4b011.c6ed4241654f9e9b",
       "_id": "c6ed4241654f9e9b"
     },
@@ -125,7 +137,8 @@
         61,
         65
       ],
-      "text": "Perpetual fog bank",
+      "name": "Perpetual fog bank",
+      "description": "<p>What is said to lie on the other side of this mist?</p>",
       "_key": "!tables.results!a040017098c4b011.578743259a28538a",
       "_id": "578743259a28538a"
     },
@@ -134,7 +147,8 @@
         66,
         70
       ],
-      "text": "Powerful maelstrom",
+      "name": "Powerful maelstrom",
+      "description": "<p>Who do you know that was lost to this swirling vortex?</p>",
       "_key": "!tables.results!a040017098c4b011.6b63ae395b97710a",
       "_id": "6b63ae395b97710a"
     },
@@ -143,7 +157,8 @@
         71,
         75
       ],
-      "text": "Ship graveyard",
+      "name": "Ship graveyard",
+      "description": "<p>What monstrous creature lurks here?</p>",
       "_key": "!tables.results!a040017098c4b011.9f29067854601a8a",
       "_id": "9f29067854601a8a"
     },
@@ -152,7 +167,8 @@
         76,
         80
       ],
-      "text": "Shipwreck on high ground",
+      "name": "Shipwreck on high ground",
+      "description": "<p>To which faction did this ship belong?</p>",
       "_key": "!tables.results!a040017098c4b011.99aaa8f92db60e3b",
       "_id": "99aaa8f92db60e3b"
     },
@@ -161,7 +177,8 @@
         81,
         85
       ],
-      "text": "Skull-shaped outcrop",
+      "name": "Skull-shaped outcrop",
+      "description": "<p>Why does this place haunt your dreams?</p>",
       "_key": "!tables.results!a040017098c4b011.5db7b58f42ebe9c0",
       "_id": "5db7b58f42ebe9c0"
     },
@@ -170,7 +187,8 @@
         86,
         90
       ],
-      "text": "Sorcerous nexus",
+      "name": "Sorcerous nexus",
+      "description": "<p>Who has gathered to reap the chaotic energy of this place?</p>",
       "_key": "!tables.results!a040017098c4b011.b81608f7cd7929d3",
       "_id": "b81608f7cd7929d3"
     },
@@ -179,7 +197,8 @@
         91,
         95
       ],
-      "text": "Titanic machinery",
+      "name": "Titanic machinery",
+      "description": "<p>Who seeks to reactivate this ancient machine?</p>",
       "_key": "!tables.results!a040017098c4b011.2fc3139ee7cd8daa",
       "_id": "2fc3139ee7cd8daa"
     },
@@ -188,7 +207,8 @@
         96,
         100
       ],
-      "text": "Unending cyclonic storm",
+      "name": "Unending cyclonic storm",
+      "description": "<p>What is said to lie at this storm's center?</p>",
       "_key": "!tables.results!a040017098c4b011.a341b9bf6c124122",
       "_id": "a341b9bf6c124122"
     }

--- a/json-packs/sundered-isles-oracles/Cursed_Lurking_Threat_17174b1f2af8bb1e.json
+++ b/json-packs/sundered-isles-oracles/Cursed_Lurking_Threat_17174b1f2af8bb1e.json
@@ -17,7 +17,8 @@
         1,
         25
       ],
-      "text": "Dark-dwelling beings",
+      "name": "Dark-dwelling beings",
+      "description": "<p>Sense of being watched; skulking shadows</p><p>Denizens defend their domain!</p>",
       "_key": "!tables.results!17174b1f2af8bb1e.162bb42da7f2e2a8",
       "_id": "162bb42da7f2e2a8"
     },
@@ -26,7 +27,8 @@
         26,
         50
       ],
-      "text": "Eldritch cultists",
+      "name": "Eldritch cultists",
+      "description": "<p>Accursed symbols; ritualistic artifacts or remains</p><p>The cultists strike!</p>",
       "_key": "!tables.results!17174b1f2af8bb1e.7f42025372497eee",
       "_id": "7f42025372497eee"
     },
@@ -35,7 +37,8 @@
         51,
         70
       ],
-      "text": "Mighty beast",
+      "name": "Mighty beast",
+      "description": "<p>Territorial markings; signs or sounds of a beast on the hunt</p><p>The beast attacks!</p>",
       "_key": "!tables.results!17174b1f2af8bb1e.2b5692a26eccd46e",
       "_id": "2b5692a26eccd46e"
     },
@@ -44,7 +47,8 @@
         71,
         85
       ],
-      "text": "Monstrous infestation",
+      "name": "Monstrous infestation",
+      "description": "<p>Skitters or splashes; foul nests</p><p>A vile swarm appears!</p>",
       "_key": "!tables.results!17174b1f2af8bb1e.a6f0284ba6953050",
       "_id": "a6f0284ba6953050"
     },
@@ -53,7 +57,8 @@
         86,
         100
       ],
-      "text": "Restless dead",
+      "name": "Restless dead",
+      "description": "<p>Phantom whispers; glimpses of spectral forms</p><p>The wrathful dead manifest!</p>",
       "_key": "!tables.results!17174b1f2af8bb1e.539b60f3fafb5ce8",
       "_id": "539b60f3fafb5ce8"
     }

--- a/json-packs/sundered-isles-oracles/Cursed_Ruin_Mystery_f365e8799129fa6b.json
+++ b/json-packs/sundered-isles-oracles/Cursed_Ruin_Mystery_f365e8799129fa6b.json
@@ -17,7 +17,8 @@
         1,
         10
       ],
-      "text": "Corrupted religion",
+      "name": "Corrupted religion",
+      "description": "<p>What does an eldritch cult seek to accomplish in this place?</p>",
       "_key": "!tables.results!f365e8799129fa6b.2c628906572176e7",
       "_id": "2c628906572176e7"
     },
@@ -26,7 +27,8 @@
         11,
         20
       ],
-      "text": "Cursed artifact",
+      "name": "Cursed artifact",
+      "description": "<p>What eldritch relic or treasure is held here?</p>",
       "_key": "!tables.results!f365e8799129fa6b.8c84e1e41d0339cb",
       "_id": "8c84e1e41d0339cb"
     },
@@ -35,7 +37,8 @@
         21,
         30
       ],
-      "text": "Eternal defenders",
+      "name": "Eternal defenders",
+      "description": "<p>What beings or creatures are cursed to forever guard this place?</p>",
       "_key": "!tables.results!f365e8799129fa6b.e4e15c945c4d007e",
       "_id": "e4e15c945c4d007e"
     },
@@ -44,7 +47,8 @@
         31,
         40
       ],
-      "text": "Grim portent",
+      "name": "Grim portent",
+      "description": "<p>What new calamity does this place forebode?</p>",
       "_key": "!tables.results!f365e8799129fa6b.7b8a4a626e698c54",
       "_id": "7b8a4a626e698c54"
     },
@@ -53,7 +57,8 @@
         41,
         50
       ],
-      "text": "Imprisoned entity",
+      "name": "Imprisoned entity",
+      "description": "<p>What eldritch being or beast is bound to this site?</p>",
       "_key": "!tables.results!f365e8799129fa6b.d6d99292699d39f0",
       "_id": "d6d99292699d39f0"
     },
@@ -62,7 +67,8 @@
         51,
         60
       ],
-      "text": "Infernal machines",
+      "name": "Infernal machines",
+      "description": "<p>What strange technology did these people unleash?</p>",
       "_key": "!tables.results!f365e8799129fa6b.ae4f534d3069249f",
       "_id": "ae4f534d3069249f"
     },
@@ -71,7 +77,8 @@
         61,
         70
       ],
-      "text": "Lingering curse",
+      "name": "Lingering curse",
+      "description": "<p>What is the secret to breaking this site's curse?</p>",
       "_key": "!tables.results!f365e8799129fa6b.c1c195bd703a41d5",
       "_id": "c1c195bd703a41d5"
     },
@@ -80,7 +87,8 @@
         71,
         80
       ],
-      "text": "Mystic gateway",
+      "name": "Mystic gateway",
+      "description": "<p>What otherworldly realm does this place connect to?</p>",
       "_key": "!tables.results!f365e8799129fa6b.8e1806bfc633d5d6",
       "_id": "8e1806bfc633d5d6"
     },
@@ -89,7 +97,8 @@
         81,
         90
       ],
-      "text": "Sorcerous nexus",
+      "name": "Sorcerous nexus",
+      "description": "<p>What dangerous arcane powers are harnessed here?</p>",
       "_key": "!tables.results!f365e8799129fa6b.be64a3d4aa677122",
       "_id": "be64a3d4aa677122"
     },
@@ -98,7 +107,8 @@
         91,
         100
       ],
-      "text": "Tormented undead",
+      "name": "Tormented undead",
+      "description": "<p>What is the key to putting these souls to rest?</p>",
       "_key": "!tables.results!f365e8799129fa6b.3e26dae32c6ade57",
       "_id": "3e26dae32c6ade57"
     }

--- a/json-packs/sundered-isles-oracles/Cursed_Weather_06955e6338aac9c1.json
+++ b/json-packs/sundered-isles-oracles/Cursed_Weather_06955e6338aac9c1.json
@@ -17,7 +17,8 @@
         1,
         5
       ],
-      "text": "Ash storm",
+      "name": "Ash storm",
+      "description": "<p>Churning, low-level clouds of gray ash</p>",
       "_key": "!tables.results!06955e6338aac9c1.84e6539d161c2a30",
       "_id": "84e6539d161c2a30"
     },
@@ -26,7 +27,8 @@
         6,
         10
       ],
-      "text": "Blighting muck",
+      "name": "Blighting muck",
+      "description": "<p>Rain of corrosive, mucous-like ooze</p>",
       "_key": "!tables.results!06955e6338aac9c1.43064e344ec1855f",
       "_id": "43064e344ec1855f"
     },
@@ -35,7 +37,8 @@
         11,
         15
       ],
-      "text": "Blood rain",
+      "name": "Blood rain",
+      "description": "<p>Ghastly, crimson rain</p>",
       "_key": "!tables.results!06955e6338aac9c1.39598617c03a281e",
       "_id": "39598617c03a281e"
     },
@@ -44,7 +47,8 @@
         16,
         20
       ],
-      "text": "Cinder rain",
+      "name": "Cinder rain",
+      "description": "<p>Storm of fiery rock and ash</p>",
       "_key": "!tables.results!06955e6338aac9c1.1376910311d6a426",
       "_id": "1376910311d6a426"
     },
@@ -53,7 +57,8 @@
         21,
         25
       ],
-      "text": "Creeping mist",
+      "name": "Creeping mist",
+      "description": "<p>Slithering, grasping fog</p>",
       "_key": "!tables.results!06955e6338aac9c1.38a3078cc13079bd",
       "_id": "38a3078cc13079bd"
     },
@@ -62,7 +67,8 @@
         26,
         30
       ],
-      "text": "Crimson mist",
+      "name": "Crimson mist",
+      "description": "<p>Slow-moving fog that burns like acid</p>",
       "_key": "!tables.results!06955e6338aac9c1.6fb3ea648318d191",
       "_id": "6fb3ea648318d191"
     },
@@ -71,7 +77,8 @@
         31,
         35
       ],
-      "text": "Dead calm",
+      "name": "Dead calm",
+      "description": "<p>Disquieting stillness</p>",
       "_key": "!tables.results!06955e6338aac9c1.d2dd99c22baaa550",
       "_id": "d2dd99c22baaa550"
     },
@@ -80,7 +87,8 @@
         36,
         40
       ],
-      "text": "Fisher's feast",
+      "name": "Fisher's feast",
+      "description": "<p>Shower of fish</p>",
       "_key": "!tables.results!06955e6338aac9c1.9f3e53828b5bff78",
       "_id": "9f3e53828b5bff78"
     },
@@ -89,7 +97,8 @@
         41,
         45
       ],
-      "text": "Forge's fury",
+      "name": "Forge's fury",
+      "description": "<p>Fast-moving storm of scorching heat</p>",
       "_key": "!tables.results!06955e6338aac9c1.7ee3c1eb85916805",
       "_id": "7ee3c1eb85916805"
     },
@@ -98,7 +107,8 @@
         46,
         50
       ],
-      "text": "Gloam tide",
+      "name": "Gloam tide",
+      "description": "<p>Unnatural darkness that moves with the tide</p>",
       "_key": "!tables.results!06955e6338aac9c1.bed9c5a429446275",
       "_id": "bed9c5a429446275"
     },
@@ -107,7 +117,8 @@
         51,
         55
       ],
-      "text": "Ice fall",
+      "name": "Ice fall",
+      "description": "<p>Uncanny cold that leaves surfaces enveloped in thick ice</p>",
       "_key": "!tables.results!06955e6338aac9c1.33b499479fb3ce98",
       "_id": "33b499479fb3ce98"
     },
@@ -116,7 +127,8 @@
         56,
         60
       ],
-      "text": "Iron wind",
+      "name": "Iron wind",
+      "description": "<p>Strong wind that sends ships along an inevitable, fatebound course</p>",
       "_key": "!tables.results!06955e6338aac9c1.798120da749d97c9",
       "_id": "798120da749d97c9"
     },
@@ -125,7 +137,8 @@
         61,
         65
       ],
-      "text": "Knowing mist",
+      "name": "Knowing mist",
+      "description": "<p>Fog that manifests visions of dark secrets and painful memories</p>",
       "_key": "!tables.results!06955e6338aac9c1.5cf56ebc953c8825",
       "_id": "5cf56ebc953c8825"
     },
@@ -134,7 +147,8 @@
         66,
         70
       ],
-      "text": "Phantom mist",
+      "name": "Phantom mist",
+      "description": "<p>Ghost-haunted fog</p>",
       "_key": "!tables.results!06955e6338aac9c1.10ede9080938a9b0",
       "_id": "10ede9080938a9b0"
     },
@@ -143,7 +157,8 @@
         71,
         75
       ],
-      "text": "Rot wind",
+      "name": "Rot wind",
+      "description": "<p>Wind that carries the foul stench of death</p>",
       "_key": "!tables.results!06955e6338aac9c1.0986ce8be14e9ebf",
       "_id": "0986ce8be14e9ebf"
     },
@@ -152,7 +167,8 @@
         76,
         80
       ],
-      "text": "Sand storm",
+      "name": "Sand storm",
+      "description": "<p>Clouds of pelting, stinging sand, ripped from a now-barren island</p>",
       "_key": "!tables.results!06955e6338aac9c1.6c01f8e27f1188e6",
       "_id": "6c01f8e27f1188e6"
     },
@@ -161,7 +177,8 @@
         81,
         85
       ],
-      "text": "Seeking spouts",
+      "name": "Seeking spouts",
+      "description": "<p>Waterspouts and tornadoes that move with dreadful purpose</p>",
       "_key": "!tables.results!06955e6338aac9c1.eee5998bb61801dc",
       "_id": "eee5998bb61801dc"
     },
@@ -170,7 +187,8 @@
         86,
         90
       ],
-      "text": "Tempest",
+      "name": "Tempest",
+      "description": "<p>Undying storm that prowls the isles in search of prey</p>",
       "_key": "!tables.results!06955e6338aac9c1.a2aa0275d9f68dc3",
       "_id": "a2aa0275d9f68dc3"
     },
@@ -179,7 +197,8 @@
         91,
         95
       ],
-      "text": "Wailing wind",
+      "name": "Wailing wind",
+      "description": "<p>Wind that carries the mournful keen of the lost and the drowned</p>",
       "_key": "!tables.results!06955e6338aac9c1.1336ce4773e58e47",
       "_id": "1336ce4773e58e47"
     },
@@ -188,7 +207,8 @@
         96,
         100
       ],
-      "text": "Witch fire",
+      "name": "Witch fire",
+      "description": "<p>Low clouds suffused with tendrils of chaotic, arcane energy</p>",
       "_key": "!tables.results!06955e6338aac9c1.896a8abfd7ae0429",
       "_id": "896a8abfd7ae0429"
     }

--- a/json-packs/sundered-isles-oracles/Empires_73b7d502dba5af34.json
+++ b/json-packs/sundered-isles-oracles/Empires_73b7d502dba5af34.json
@@ -17,7 +17,8 @@
         1,
         10
       ],
-      "text": "Argosy Company",
+      "name": "Argosy Company",
+      "description": "<p>Trade company that commands a fleet of beast-hunting ships and pays bounties on beasts to independent captains. Their unscrupulous merchants deal in trophies and resources gathered from slain creatures.</p>",
       "_key": "!tables.results!73b7d502dba5af34.598b62d8ebdec381",
       "_id": "598b62d8ebdec381"
     },
@@ -26,7 +27,8 @@
         11,
         20
       ],
-      "text": "Eldarian Remnants",
+      "name": "Eldarian Remnants",
+      "description": "<p>Loyalists of a fallen empire who seek to restore their former glory among the isles, guided by a charismatic and shrewd military leader. The sails of their ships are emblazoned with a burning phoenix.</p>",
       "_key": "!tables.results!73b7d502dba5af34.183de93e5e401f36",
       "_id": "183de93e5e401f36"
     },
@@ -35,7 +37,8 @@
         21,
         30
       ],
-      "text": "Empire of Solas",
+      "name": "Empire of Solas",
+      "description": "<p>Age-old dominion ruled by an immortal god-emperor. Their ostentatious ships are adorned with gold metalwork and filigreed sails.</p>",
       "_key": "!tables.results!73b7d502dba5af34.5e55b4a16aa8fa56",
       "_id": "5e55b4a16aa8fa56"
     },
@@ -44,7 +47,8 @@
         31,
         40
       ],
-      "text": "Firgovian Regency",
+      "name": "Firgovian Regency",
+      "description": "<p>Fracturing empire facing a succession crisis in the aftermath of the monarch’s assassination. Rival claimants gather their armies and navies to take the crown by force.</p>",
       "_key": "!tables.results!73b7d502dba5af34.60b2af4a1101ed8b",
       "_id": "60b2af4a1101ed8b"
     },
@@ -53,7 +57,8 @@
         41,
         50
       ],
-      "text": "Hand of Theya",
+      "name": "Hand of Theya",
+      "description": "<p>Iron-fisted theocracy under the rule of a council of priests. Their mandates are enforced by red-robed inquisitors.</p>",
       "_key": "!tables.results!73b7d502dba5af34.01fed6fc1c70d7dd",
       "_id": "01fed6fc1c70d7dd"
     },
@@ -62,7 +67,8 @@
         51,
         60
       ],
-      "text": "Kyrody Dominion",
+      "name": "Kyrody Dominion",
+      "description": "<p>Expansive empire with far-flung territories. Their holdings within the isles are overseen by corrupt and squabbling governors, each vying for greater power and wealth.</p>",
       "_key": "!tables.results!73b7d502dba5af34.cc5ac75aca1885bc",
       "_id": "cc5ac75aca1885bc"
     },
@@ -71,7 +77,8 @@
         61,
         70
       ],
-      "text": "Meridian Company",
+      "name": "Meridian Company",
+      "description": "<p>Powerful trade company with diverse holdings and boundless political influence. They function as a shadow government behind other powers.</p>",
       "_key": "!tables.results!73b7d502dba5af34.6d0dd750b9677d18",
       "_id": "6d0dd750b9677d18"
     },
@@ -80,7 +87,8 @@
         71,
         80
       ],
-      "text": "Norish Empire",
+      "name": "Norish Empire",
+      "description": "<p>War-mongering clans newly united under a powerful warlord. Their warships are fitted with imposing rams and heavy boarding ramps.</p>",
       "_key": "!tables.results!73b7d502dba5af34.4c1495b856b513f5",
       "_id": "4c1495b856b513f5"
     },
@@ -89,7 +97,8 @@
         81,
         90
       ],
-      "text": "Skulde Alliance",
+      "name": "Skulde Alliance",
+      "description": "<p>Ambitious empire that wields a powerful military. At the vanguard of their fleets are the dragon-riders of the Crimson Guard, who house their steeds and launch their attacks from colossal carrier ships.</p>",
       "_key": "!tables.results!73b7d502dba5af34.7c79bdf4443ae390",
       "_id": "7c79bdf4443ae390"
     },
@@ -98,7 +107,8 @@
         91,
         100
       ],
-      "text": "Sovereign States",
+      "name": "Sovereign States",
+      "description": "<p>Industrialist power formed from the remnants of warring nations. They are governed by an oligarchical council whose members scheme and backstab to advance their own interests.</p>",
       "_key": "!tables.results!73b7d502dba5af34.82d686b9b3f0e423",
       "_id": "82d686b9b3f0e423"
     }

--- a/json-packs/sundered-isles-oracles/Faction_Influence_66110f9a7d08cf74.json
+++ b/json-packs/sundered-isles-oracles/Faction_Influence_66110f9a7d08cf74.json
@@ -17,7 +17,8 @@
         1,
         10
       ],
-      "text": "Forsaken",
+      "name": "Forsaken",
+      "description": "<p>Banished or forgotten</p>",
       "_key": "!tables.results!66110f9a7d08cf74.d0bea7e5d68acdb7",
       "_id": "d0bea7e5d68acdb7"
     },
@@ -26,7 +27,8 @@
         11,
         30
       ],
-      "text": "Isolated",
+      "name": "Isolated",
+      "description": "<p>Limited influence in a remote location</p>",
       "_key": "!tables.results!66110f9a7d08cf74.2cc64bd7d8a2df40",
       "_id": "2cc64bd7d8a2df40"
     },
@@ -35,7 +37,8 @@
         31,
         50
       ],
-      "text": "Localized",
+      "name": "Localized",
+      "description": "<p>Marginal influence in a small area</p>",
       "_key": "!tables.results!66110f9a7d08cf74.a67039aa408f1e85",
       "_id": "a67039aa408f1e85"
     },
@@ -44,7 +47,8 @@
         51,
         70
       ],
-      "text": "Established",
+      "name": "Established",
+      "description": "<p>Strong influence in a small area</p>",
       "_key": "!tables.results!66110f9a7d08cf74.0a9b92c5da7b4950",
       "_id": "0a9b92c5da7b4950"
     },
@@ -53,7 +57,8 @@
         71,
         85
       ],
-      "text": "Notable",
+      "name": "Notable",
+      "description": "<p>Dispersed influence across a moderate area</p>",
       "_key": "!tables.results!66110f9a7d08cf74.c17174a34418e9f7",
       "_id": "c17174a34418e9f7"
     },
@@ -62,7 +67,8 @@
         86,
         95
       ],
-      "text": "Dominant",
+      "name": "Dominant",
+      "description": "<p>Far-reaching influence across a large area</p>",
       "_key": "!tables.results!66110f9a7d08cf74.56c6882634a1d448",
       "_id": "56c6882634a1d448"
     },
@@ -71,7 +77,8 @@
         96,
         100
       ],
-      "text": "Inescapable",
+      "name": "Inescapable",
+      "description": "<p>Pervasive influence across a vast area</p>",
       "_key": "!tables.results!66110f9a7d08cf74.10d0bd2863f5b6b7",
       "_id": "10d0bd2863f5b6b7"
     }

--- a/json-packs/sundered-isles-oracles/Faction_Type_b4383db857ca3b34.json
+++ b/json-packs/sundered-isles-oracles/Faction_Type_b4383db857ca3b34.json
@@ -17,7 +17,7 @@
         1,
         50
       ],
-      "text": "<p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:sundered_isles/faction/society\">\n    <i class=\"fa fa-caret-right\"></i> Society\n</a></p>",
+      "text": "<p><p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:sundered_isles/faction/society\">\n    <i class=\"fa fa-caret-right\"></i> Society\n</a></p></p><p>People who share traditions and a way of life</p>",
       "_key": "!tables.results!b4383db857ca3b34.2c6b850ef55c3deb",
       "_id": "2c6b850ef55c3deb"
     },
@@ -26,7 +26,7 @@
         51,
         80
       ],
-      "text": "<p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:sundered_isles/faction/organization\">\n    <i class=\"fa fa-caret-right\"></i> Organization\n</a></p>",
+      "text": "<p><p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:sundered_isles/faction/organization\">\n    <i class=\"fa fa-caret-right\"></i> Organization\n</a></p></p><p>People joined in a collective trade, pursuit, or goal</p>",
       "_key": "!tables.results!b4383db857ca3b34.607975cf0b9b8907",
       "_id": "607975cf0b9b8907"
     },
@@ -35,7 +35,7 @@
         81,
         100
       ],
-      "text": "<p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:sundered_isles/faction/empire\">\n    <i class=\"fa fa-caret-right\"></i> Empire\n</a></p>",
+      "text": "<p><p><a class=\"entity-link oracle-category-link\" data-dsid=\"oracle_collection:sundered_isles/faction/empire\">\n    <i class=\"fa fa-caret-right\"></i> Empire\n</a></p></p><p>People seeking dominion over the isles</p>",
       "_key": "!tables.results!b4383db857ca3b34.9f471cf313a06954",
       "_id": "9f471cf313a06954"
     }

--- a/json-packs/sundered-isles-oracles/Foul_Weather_cec9db2f0aaf8cfe.json
+++ b/json-packs/sundered-isles-oracles/Foul_Weather_cec9db2f0aaf8cfe.json
@@ -18,7 +18,8 @@
         1,
         10
       ],
-      "text": "Stifling",
+      "name": "Stifling",
+      "description": "<p>Windless, oppressive heat</p>",
       "_key": "!tables.results!cec9db2f0aaf8cfe.f91ac13308465d56",
       "_id": "f91ac13308465d56"
     },
@@ -27,7 +28,8 @@
         11,
         25
       ],
-      "text": "Listless",
+      "name": "Listless",
+      "description": "<p>Light winds and sweltering heat</p>",
       "_key": "!tables.results!cec9db2f0aaf8cfe.cf5c0f8ad114f0f1",
       "_id": "cf5c0f8ad114f0f1"
     },
@@ -36,7 +38,8 @@
         26,
         40
       ],
-      "text": "Misty",
+      "name": "Misty",
+      "description": "<p>Light winds and damp fog</p>",
       "_key": "!tables.results!cec9db2f0aaf8cfe.996927c5349eef36",
       "_id": "996927c5349eef36"
     },
@@ -45,7 +48,8 @@
         41,
         55
       ],
-      "text": "Foggy",
+      "name": "Foggy",
+      "description": "<p>Light winds and dense fog</p>",
       "_key": "!tables.results!cec9db2f0aaf8cfe.ec12ed2ef7d6bf3f",
       "_id": "ec12ed2ef7d6bf3f"
     },
@@ -54,7 +58,8 @@
         56,
         75
       ],
-      "text": "Heavy",
+      "name": "Heavy",
+      "description": "<p>High winds, steady rain, and rough waters</p>",
       "_key": "!tables.results!cec9db2f0aaf8cfe.bea9a57220cad206",
       "_id": "bea9a57220cad206"
     },
@@ -63,7 +68,8 @@
         76,
         90
       ],
-      "text": "Stormy",
+      "name": "Stormy",
+      "description": "<p>Powerful winds, pelting rain, and high seas</p>",
       "_key": "!tables.results!cec9db2f0aaf8cfe.c45684e7e662100d",
       "_id": "c45684e7e662100d"
     },
@@ -72,7 +78,8 @@
         91,
         100
       ],
-      "text": "Raging",
+      "name": "Raging",
+      "description": "<p>Destructive winds, torrential rain, and monstrous waves</p>",
       "_key": "!tables.results!cec9db2f0aaf8cfe.a4961648278d840f",
       "_id": "a4961648278d840f"
     }

--- a/json-packs/sundered-isles-oracles/Inland_94bc6ec7323d8745.json
+++ b/json-packs/sundered-isles-oracles/Inland_94bc6ec7323d8745.json
@@ -18,7 +18,8 @@
         1,
         2
       ],
-      "text": "Alcohol Production",
+      "name": "Alcohol Production",
+      "description": "<p>Breweries, distilleries, wineries</p>",
       "_key": "!tables.results!94bc6ec7323d8745.d645de3655d03ff7",
       "_id": "d645de3655d03ff7"
     },
@@ -27,7 +28,8 @@
         3,
         3
       ],
-      "text": "Archeology",
+      "name": "Archeology",
+      "description": "<p>Excavation sites, field camps, relic hunters</p>",
       "_key": "!tables.results!94bc6ec7323d8745.f5ee12d324c7ad6a",
       "_id": "f5ee12d324c7ad6a"
     },
@@ -36,7 +38,8 @@
         4,
         5
       ],
-      "text": "Crafts",
+      "name": "Crafts",
+      "description": "<p>Artisans, markets, workshops</p>",
       "_key": "!tables.results!94bc6ec7323d8745.39a0c97c3cc5573f",
       "_id": "39a0c97c3cc5573f"
     },
@@ -45,7 +48,8 @@
         6,
         11
       ],
-      "text": "Culture",
+      "name": "Culture",
+      "description": "<p>Archives, festivals, historical sites</p>",
       "_key": "!tables.results!94bc6ec7323d8745.e9c4505cdb0bbd0a",
       "_id": "e9c4505cdb0bbd0a"
     },
@@ -54,7 +58,8 @@
         12,
         13
       ],
-      "text": "Defense",
+      "name": "Defense",
+      "description": "<p>Armories, fortifications, militia</p>",
       "_key": "!tables.results!94bc6ec7323d8745.8a57a750d594ad44",
       "_id": "8a57a750d594ad44"
     },
@@ -63,7 +68,8 @@
         14,
         14
       ],
-      "text": "Dueling",
+      "name": "Dueling",
+      "description": "<p>Dueling grounds, fencing schools</p>",
       "_key": "!tables.results!94bc6ec7323d8745.e0770aefd3e663f1",
       "_id": "e0770aefd3e663f1"
     },
@@ -72,7 +78,8 @@
         15,
         16
       ],
-      "text": "Education",
+      "name": "Education",
+      "description": "<p>Libraries, universities</p>",
       "_key": "!tables.results!94bc6ec7323d8745.64c069dc5077561c",
       "_id": "64c069dc5077561c"
     },
@@ -81,7 +88,8 @@
         17,
         17
       ],
-      "text": "Entertainment",
+      "name": "Entertainment",
+      "description": "<p>Arenas, fairs, street performers, theaters</p>",
       "_key": "!tables.results!94bc6ec7323d8745.7c2be060a4a1ebcd",
       "_id": "7c2be060a4a1ebcd"
     },
@@ -90,7 +98,8 @@
         18,
         18
       ],
-      "text": "Espionage",
+      "name": "Espionage",
+      "description": "<p>Assassin guild, spy network</p>",
       "_key": "!tables.results!94bc6ec7323d8745.2287c98fd35f8d0a",
       "_id": "2287c98fd35f8d0a"
     },
@@ -99,7 +108,8 @@
         19,
         20
       ],
-      "text": "Exploration",
+      "name": "Exploration",
+      "description": "<p>Navigators guild, outfitters, scouts</p>",
       "_key": "!tables.results!94bc6ec7323d8745.3499c7c46f0dce08",
       "_id": "3499c7c46f0dce08"
     },
@@ -108,7 +118,8 @@
         21,
         32
       ],
-      "text": "Farming",
+      "name": "Farming",
+      "description": "<p>Fields, granaries, mills, orchards</p>",
       "_key": "!tables.results!94bc6ec7323d8745.f29ed5cc66819839",
       "_id": "f29ed5cc66819839"
     },
@@ -117,7 +128,8 @@
         33,
         34
       ],
-      "text": "Hospitality",
+      "name": "Hospitality",
+      "description": "<p>Bath houses, brothels, inns, taverns</p>",
       "_key": "!tables.results!94bc6ec7323d8745.bd8345ee70b908f6",
       "_id": "bd8345ee70b908f6"
     },
@@ -126,7 +138,8 @@
         35,
         40
       ],
-      "text": "Hunting",
+      "name": "Hunting",
+      "description": "<p>Animal trainers, taxidermists, tanners</p>",
       "_key": "!tables.results!94bc6ec7323d8745.1bb3d59f6d09b36d",
       "_id": "1bb3d59f6d09b36d"
     },
@@ -135,7 +148,8 @@
         41,
         41
       ],
-      "text": "Law",
+      "name": "Law",
+      "description": "<p>Courts, gallows, patrols, prisons</p>",
       "_key": "!tables.results!94bc6ec7323d8745.fe66f0885dcded8d",
       "_id": "fe66f0885dcded8d"
     },
@@ -144,7 +158,8 @@
         42,
         49
       ],
-      "text": "Livestock / horses",
+      "name": "Livestock / horses",
+      "description": "<p>Ranches, slaughterhouses, stables</p>",
       "_key": "!tables.results!94bc6ec7323d8745.a7b4fe04d922e6c2",
       "_id": "a7b4fe04d922e6c2"
     },
@@ -153,7 +168,8 @@
         50,
         53
       ],
-      "text": "Logging",
+      "name": "Logging",
+      "description": "<p>Logging camps, sawmills</p>",
       "_key": "!tables.results!94bc6ec7323d8745.a64beeddb2a0daa5",
       "_id": "a64beeddb2a0daa5"
     },
@@ -162,7 +178,8 @@
         54,
         55
       ],
-      "text": "Medicine",
+      "name": "Medicine",
+      "description": "<p>Apothecaries, herbalists, infirmaries</p>",
       "_key": "!tables.results!94bc6ec7323d8745.f479cb7fd0ad350c",
       "_id": "f479cb7fd0ad350c"
     },
@@ -171,7 +188,8 @@
         56,
         61
       ],
-      "text": "Metalworking",
+      "name": "Metalworking",
+      "description": "<p>Artificers, blacksmiths, forges</p>",
       "_key": "!tables.results!94bc6ec7323d8745.17ddee16ae8588dd",
       "_id": "17ddee16ae8588dd"
     },
@@ -180,7 +198,8 @@
         62,
         67
       ],
-      "text": "Mining",
+      "name": "Mining",
+      "description": "<p>Foundries, mines, smelters</p>",
       "_key": "!tables.results!94bc6ec7323d8745.115c1cd6f1a2acbb",
       "_id": "115c1cd6f1a2acbb"
     },
@@ -189,7 +208,8 @@
         68,
         69
       ],
-      "text": "Mysticism",
+      "name": "Mysticism",
+      "description": "<p>Alchemists, curio dealers, enclaves, mystics</p>",
       "_key": "!tables.results!94bc6ec7323d8745.8310449007a7d097",
       "_id": "8310449007a7d097"
     },
@@ -198,7 +218,8 @@
         70,
         71
       ],
-      "text": "Nature",
+      "name": "Nature",
+      "description": "<p>Animal sanctuaries, gardens, groves</p>",
       "_key": "!tables.results!94bc6ec7323d8745.49aba4c29669161e",
       "_id": "49aba4c29669161e"
     },
@@ -207,7 +228,8 @@
         72,
         73
       ],
-      "text": "Religion",
+      "name": "Religion",
+      "description": "<p>Monasteries, sacred sites, temples</p>",
       "_key": "!tables.results!94bc6ec7323d8745.6d7bbf8bb53594be",
       "_id": "6d7bbf8bb53594be"
     },
@@ -216,7 +238,8 @@
         74,
         75
       ],
-      "text": "Science",
+      "name": "Science",
+      "description": "<p>Academies, naturalist guild, observatories</p>",
       "_key": "!tables.results!94bc6ec7323d8745.fcfea9956db3c630",
       "_id": "fcfea9956db3c630"
     },
@@ -225,7 +248,8 @@
         76,
         76
       ],
-      "text": "Smuggling",
+      "name": "Smuggling",
+      "description": "<p>Black market, fences, smugglers</p>",
       "_key": "!tables.results!94bc6ec7323d8745.cd728778ba03d56d",
       "_id": "cd728778ba03d56d"
     },
@@ -234,7 +258,8 @@
         77,
         77
       ],
-      "text": "Society",
+      "name": "Society",
+      "description": "<p>Balls, boutiques, social clubs, tailors</p>",
       "_key": "!tables.results!94bc6ec7323d8745.51d5aa7c1ef04372",
       "_id": "51d5aa7c1ef04372"
     },
@@ -243,7 +268,8 @@
         78,
         78
       ],
-      "text": "Statecraft",
+      "name": "Statecraft",
+      "description": "<p>Embassies, envoys, court or council</p>",
       "_key": "!tables.results!94bc6ec7323d8745.3ecf00664555ab98",
       "_id": "3ecf00664555ab98"
     },
@@ -252,7 +278,8 @@
         79,
         84
       ],
-      "text": "Stoneworking",
+      "name": "Stoneworking",
+      "description": "<p>Masons, quarries, stone yards</p>",
       "_key": "!tables.results!94bc6ec7323d8745.11700d5ecd46e329",
       "_id": "11700d5ecd46e329"
     },
@@ -261,7 +288,8 @@
         85,
         90
       ],
-      "text": "Trade",
+      "name": "Trade",
+      "description": "<p>Auction house, markets, merchant guild</p>",
       "_key": "!tables.results!94bc6ec7323d8745.a35f7dca73a7180a",
       "_id": "a35f7dca73a7180a"
     },
@@ -270,7 +298,8 @@
         91,
         91
       ],
-      "text": "Vices",
+      "name": "Vices",
+      "description": "<p>Brothels, drug dens, gambling halls, taverns</p>",
       "_key": "!tables.results!94bc6ec7323d8745.4a5939ca3ace5a6e",
       "_id": "4a5939ca3ace5a6e"
     },
@@ -279,7 +308,8 @@
         92,
         93
       ],
-      "text": "Warfare",
+      "name": "Warfare",
+      "description": "<p>Armies or fleets, command post, forts</p>",
       "_key": "!tables.results!94bc6ec7323d8745.fd8e3d77a1d8dc1c",
       "_id": "fd8e3d77a1d8dc1c"
     },
@@ -288,7 +318,8 @@
         94,
         95
       ],
-      "text": "Weaponry",
+      "name": "Weaponry",
+      "description": "<p>Cannon foundries, gunsmiths, powder mills</p>",
       "_key": "!tables.results!94bc6ec7323d8745.6564af4ba0c56240",
       "_id": "6564af4ba0c56240"
     },

--- a/json-packs/sundered-isles-oracles/Inland_Cave_6c1cbe7865765efd.json
+++ b/json-packs/sundered-isles-oracles/Inland_Cave_6c1cbe7865765efd.json
@@ -17,7 +17,8 @@
         1,
         20
       ],
-      "text": "Troublesome",
+      "name": "Troublesome",
+      "description": "<p>Minor cave system</p>",
       "_key": "!tables.results!6c1cbe7865765efd.a1b9b32652b02a12",
       "_id": "a1b9b32652b02a12"
     },
@@ -26,7 +27,8 @@
         21,
         50
       ],
-      "text": "Dangerous",
+      "name": "Dangerous",
+      "description": "<p>Limited cave system</p>",
       "_key": "!tables.results!6c1cbe7865765efd.d7835a76d4248d9d",
       "_id": "d7835a76d4248d9d"
     },
@@ -35,7 +37,8 @@
         51,
         75
       ],
-      "text": "Formidable",
+      "name": "Formidable",
+      "description": "<p>Extensive cave system</p>",
       "_key": "!tables.results!6c1cbe7865765efd.b487009864467ddb",
       "_id": "b487009864467ddb"
     },
@@ -44,7 +47,8 @@
         76,
         90
       ],
-      "text": "Extreme",
+      "name": "Extreme",
+      "description": "<p>Vast cave system</p>",
       "_key": "!tables.results!6c1cbe7865765efd.45bdd2e6febde0c5",
       "_id": "45bdd2e6febde0c5"
     },
@@ -53,7 +57,8 @@
         91,
         100
       ],
-      "text": "Epic",
+      "name": "Epic",
+      "description": "<p>Fathomless cave system</p>",
       "_key": "!tables.results!6c1cbe7865765efd.42a89be3df84f17e",
       "_id": "42a89be3df84f17e"
     }

--- a/json-packs/sundered-isles-oracles/Interlude_Scene_915f8d4f02c33d8e.json
+++ b/json-packs/sundered-isles-oracles/Interlude_Scene_915f8d4f02c33d8e.json
@@ -17,7 +17,8 @@
         1,
         4
       ],
-      "text": "Chronicle your adventures",
+      "name": "Chronicle your adventures",
+      "description": "<p>What do you describe within logs, journals, or maps? What adventure still calls to you?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.85b098b9739d798c",
       "_id": "85b098b9739d798c"
     },
@@ -26,7 +27,8 @@
         5,
         8
       ],
-      "text": "Commune with nature",
+      "name": "Commune with nature",
+      "description": "<p>What flora or fauna do you encounter? What inspiration do you draw from the experience?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.6699f10fc0bf4eb9",
       "_id": "6699f10fc0bf4eb9"
     },
@@ -35,7 +37,8 @@
         9,
         11
       ],
-      "text": "Concoct a plan",
+      "name": "Concoct a plan",
+      "description": "<p>What new strategy do you devise? How will you put this plan in motion?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.3b20bb033718954e",
       "_id": "3b20bb033718954e"
     },
@@ -44,7 +47,8 @@
         12,
         14
       ],
-      "text": "Conduct research",
+      "name": "Conduct research",
+      "description": "<p>What is the nature of the research? What information or insight do you gain?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.7b9aeb3edb223c9c",
       "_id": "7b9aeb3edb223c9c"
     },
@@ -53,7 +57,8 @@
         15,
         17
       ],
-      "text": "Conduct training",
+      "name": "Conduct training",
+      "description": "<p>What skills or knowledge do you share? Who accepts the guidance, and who resists it?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.d2735d7f0a652851",
       "_id": "d2735d7f0a652851"
     },
@@ -62,7 +67,8 @@
         18,
         20
       ],
-      "text": "Confess a secret",
+      "name": "Confess a secret",
+      "description": "<p>What do you reveal of your nature or background? How do others respond?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.613879cddad7bfcd",
       "_id": "613879cddad7bfcd"
     },
@@ -71,7 +77,8 @@
         21,
         24
       ],
-      "text": "Conjure up the past",
+      "name": "Conjure up the past",
+      "description": "<p>What is the subject of this reminiscence? Why is it meaningful in this moment?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.651fc6d11048db57",
       "_id": "651fc6d11048db57"
     },
@@ -80,7 +87,8 @@
         25,
         27
       ],
-      "text": "Create an object or artwork",
+      "name": "Create an object or artwork",
+      "description": "<p>What do you create? What is it intended for?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.203c9a5cef2c4a02",
       "_id": "203c9a5cef2c4a02"
     },
@@ -89,7 +97,8 @@
         28,
         31
       ],
-      "text": "Experience a dream or vision",
+      "name": "Experience a dream or vision",
+      "description": "<p>What is the nature of the dream or vision? What meaning do you draw from it?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.4f4be899ae6dc72d",
       "_id": "4f4be899ae6dc72d"
     },
@@ -98,7 +107,8 @@
         32,
         34
       ],
-      "text": "Fight in a sparring match",
+      "name": "Fight in a sparring match",
+      "description": "<p>Who do you spar with? What issues do you provoke or resolve during the match?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.975e706c525fca52",
       "_id": "975e706c525fca52"
     },
@@ -107,7 +117,8 @@
         35,
         37
       ],
-      "text": "Find peace",
+      "name": "Find peace",
+      "description": "<p>How do you reflect, meditate, or pray? What enlightenment do you gain?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.bfc37b23430d3c4c",
       "_id": "bfc37b23430d3c4c"
     },
@@ -116,7 +127,8 @@
         38,
         40
       ],
-      "text": "Hear a confession",
+      "name": "Hear a confession",
+      "description": "<p>Who shares an aspect of their nature or background? What do they reveal?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.06565d051b7930cc",
       "_id": "06565d051b7930cc"
     },
@@ -125,7 +137,8 @@
         41,
         43
       ],
-      "text": "Indulge a vice",
+      "name": "Indulge a vice",
+      "description": "<p>What weakness or need do you indulge? How is this viewed by others?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.888ee5b85f4a9a79",
       "_id": "888ee5b85f4a9a79"
     },
@@ -134,7 +147,8 @@
         44,
         47
       ],
-      "text": "Join an event",
+      "name": "Join an event",
+      "description": "<p>What is the occasion of this social gathering? How do you participate?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.1593cb8643c95e17",
       "_id": "1593cb8643c95e17"
     },
@@ -143,7 +157,8 @@
         48,
         50
       ],
-      "text": "Lead or join a song",
+      "name": "Lead or join a song",
+      "description": "<p>What is the subject of this song? Why is it meaningful to you or others?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.a87c02580fc41df0",
       "_id": "a87c02580fc41df0"
     },
@@ -152,7 +167,8 @@
         51,
         53
       ],
-      "text": "Motivate others",
+      "name": "Motivate others",
+      "description": "<p>Why is this motivation needed, and what is your approach? How do they respond?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.f1c69a1617d0c852",
       "_id": "f1c69a1617d0c852"
     },
@@ -161,7 +177,8 @@
         54,
         56
       ],
-      "text": "Play a game",
+      "name": "Play a game",
+      "description": "<p>Who do you play with? What is discussed during the game?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.85df7cb5372ab8d7",
       "_id": "85df7cb5372ab8d7"
     },
@@ -170,7 +187,8 @@
         57,
         60
       ],
-      "text": "Practice a skill",
+      "name": "Practice a skill",
+      "description": "<p>What talent do you hone? What do you learn from the exercise?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.229b7d1800e7b84b",
       "_id": "229b7d1800e7b84b"
     },
@@ -179,7 +197,8 @@
         61,
         64
       ],
-      "text": "Ready your gear",
+      "name": "Ready your gear",
+      "description": "<p>How do you maintain your equipment or gear up? What are you preparing for?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.1aebd0d532cd2da4",
       "_id": "1aebd0d532cd2da4"
     },
@@ -188,7 +207,8 @@
         65,
         67
       ],
-      "text": "Record a message",
+      "name": "Record a message",
+      "description": "<p>Who is the message meant for? What news or feelings do you share?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.7c22be4ba3862067",
       "_id": "7c22be4ba3862067"
     },
@@ -197,7 +217,8 @@
         68,
         70
       ],
-      "text": "Reinvent your look",
+      "name": "Reinvent your look",
+      "description": "<p>What inspires you to remake yourself? How do you debut your new look?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.68fcea3411dfd245",
       "_id": "68fcea3411dfd245"
     },
@@ -206,7 +227,8 @@
         71,
         73
       ],
-      "text": "Settle a conflict",
+      "name": "Settle a conflict",
+      "description": "<p>What caused this argument or fight? How do you resolve the situation?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.18f15ecfd2fadd6a",
       "_id": "18f15ecfd2fadd6a"
     },
@@ -215,7 +237,8 @@
         74,
         76
       ],
-      "text": "Share intimacy",
+      "name": "Share intimacy",
+      "description": "<p>Who do you spend time with? How does your relationship evolve?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.801bdf11a71051d0",
       "_id": "801bdf11a71051d0"
     },
@@ -224,7 +247,8 @@
         77,
         79
       ],
-      "text": "Share your heritage",
+      "name": "Share your heritage",
+      "description": "<p>What do you offer of your family's or people's history? What memory or regret does it evoke?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.4a43427df050226f",
       "_id": "4a43427df050226f"
     },
@@ -233,7 +257,8 @@
         80,
         82
       ],
-      "text": "Stay vigilant",
+      "name": "Stay vigilant",
+      "description": "<p>What are you on the lookout for? What do you spot or overhear?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.0c36f8f51056c93a",
       "_id": "0c36f8f51056c93a"
     },
@@ -242,7 +267,8 @@
         83,
         85
       ],
-      "text": "Stir up trouble",
+      "name": "Stir up trouble",
+      "description": "<p>What conflict do you incite or inflame? Why is the situation left unresolved?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.ff0bf071dc0318f2",
       "_id": "ff0bf071dc0318f2"
     },
@@ -251,7 +277,8 @@
         86,
         89
       ],
-      "text": "Take in the view",
+      "name": "Take in the view",
+      "description": "<p>What sublime or dramatic scenery do you witness? What emotion or memory does it inspire?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.982dd645fb7dd937",
       "_id": "982dd645fb7dd937"
     },
@@ -260,7 +287,8 @@
         90,
         92
       ],
-      "text": "Tell a tale",
+      "name": "Tell a tale",
+      "description": "<p>What is the nature of this myth or legend? What emotion or lesson lingers after the telling?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.8c3bf25656262645",
       "_id": "8c3bf25656262645"
     },
@@ -269,7 +297,8 @@
         93,
         96
       ],
-      "text": "Undertake a communal labor",
+      "name": "Undertake a communal labor",
+      "description": "<p>What demanding project do you embark on with others? How does this bring you closer together?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.8a204a89364ed07a",
       "_id": "8a204a89364ed07a"
     },
@@ -278,7 +307,8 @@
         97,
         100
       ],
-      "text": "Undertake a menial task",
+      "name": "Undertake a menial task",
+      "description": "<p>What solitary chore do you perform? What do you daydream about as you work?</p>",
       "_key": "!tables.results!915f8d4f02c33d8e.16f32e4833fffe07",
       "_id": "16f32e4833fffe07"
     }

--- a/json-packs/sundered-isles-oracles/Large_1077269088ed1e39.json
+++ b/json-packs/sundered-isles-oracles/Large_1077269088ed1e39.json
@@ -17,7 +17,8 @@
         1,
         30
       ],
-      "text": "Trifle",
+      "name": "Trifle",
+      "description": "<p>One @Compendium[foundry-ironsworn.sunderedislesoracles.baaff21d3f6897ac]{Precious Item}</p>",
       "_key": "!tables.results!1077269088ed1e39.8c728cbb12fc30bc",
       "_id": "8c728cbb12fc30bc"
     },
@@ -26,7 +27,8 @@
         31,
         98
       ],
-      "text": "Stash",
+      "name": "Stash",
+      "description": "<p>Roll the action die and reveal that many @Compendium[foundry-ironsworn.sunderedislesoracles.baaff21d3f6897ac]{Precious Items}</p>",
       "_key": "!tables.results!1077269088ed1e39.3cbdbe9bd53f3a0d",
       "_id": "3cbdbe9bd53f3a0d"
     },
@@ -35,7 +37,8 @@
         99,
         100
       ],
-      "text": "Trove",
+      "name": "Trove",
+      "description": "<p>Bountiful riches</p>",
       "_key": "!tables.results!1077269088ed1e39.04b16b4678d9c03a",
       "_id": "04b16b4678d9c03a"
     }

--- a/json-packs/sundered-isles-oracles/Location_Details_fcfcb0bceae33bfe.json
+++ b/json-packs/sundered-isles-oracles/Location_Details_fcfcb0bceae33bfe.json
@@ -18,7 +18,8 @@
         1,
         4
       ],
-      "text": "Abyssal sinkhole",
+      "name": "Abyssal sinkhole",
+      "description": "<p>What is rumored to lie at the bottom of these depths?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.b581c16c077d23da",
       "_id": "b581c16c077d23da"
     },
@@ -27,7 +28,8 @@
         5,
         8
       ],
-      "text": "Active volcano",
+      "name": "Active volcano",
+      "description": "<p>What important location does this eruption threaten?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.82eb32647553e51d",
       "_id": "82eb32647553e51d"
     },
@@ -36,7 +38,8 @@
         9,
         12
       ],
-      "text": "Ancient ruins",
+      "name": "Ancient ruins",
+      "description": "<p>Who or what defends this place against intruders?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.4b6d74cd763aff62",
       "_id": "4b6d74cd763aff62"
     },
@@ -45,7 +48,8 @@
         13,
         15
       ],
-      "text": "Colossal monument",
+      "name": "Colossal monument",
+      "description": "<p>What legendary figure does this monument honor?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.ae020c1dcf7f1110",
       "_id": "ae020c1dcf7f1110"
     },
@@ -54,7 +58,8 @@
         16,
         19
       ],
-      "text": "Crucial trade route",
+      "name": "Crucial trade route",
+      "description": "<p>What is disrupting trade along this route?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.0a76b44b3ceceb7b",
       "_id": "0a76b44b3ceceb7b"
     },
@@ -63,7 +68,8 @@
         20,
         23
       ],
-      "text": "Deserted settlement",
+      "name": "Deserted settlement",
+      "description": "<p>Why was this place abandoned?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.17808c59ac43d460",
       "_id": "17808c59ac43d460"
     },
@@ -72,7 +78,8 @@
         24,
         27
       ],
-      "text": "Expansive cave",
+      "name": "Expansive cave",
+      "description": "<p>What treasure is said to lie at the heart of this cave?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.121c0fec0f4dd18c",
       "_id": "121c0fec0f4dd18c"
     },
@@ -81,7 +88,8 @@
         28,
         30
       ],
-      "text": "Floating tradepost",
+      "name": "Floating tradepost",
+      "description": "<p>Who is hounding these traders, demanding tribute?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.6f5b94ce7481abe1",
       "_id": "6f5b94ce7481abe1"
     },
@@ -90,7 +98,8 @@
         31,
         34
       ],
-      "text": "Hull-breaching rocks",
+      "name": "Hull-breaching rocks",
+      "description": "<p>Who or what preys upon careless ships in this area?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.bfe0d474647e3aad",
       "_id": "bfe0d474647e3aad"
     },
@@ -99,7 +108,8 @@
         35,
         38
       ],
-      "text": "Kelp-clogged waters",
+      "name": "Kelp-clogged waters",
+      "description": "<p>What ship went missing here?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.cd78b035d5f1bd59",
       "_id": "cd78b035d5f1bd59"
     },
@@ -108,7 +118,8 @@
         39,
         41
       ],
-      "text": "Meteorite scar",
+      "name": "Meteorite scar",
+      "description": "<p>What prophecy foretold the meteorite's fall?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.042fcecfc8eaae43",
       "_id": "042fcecfc8eaae43"
     },
@@ -117,7 +128,8 @@
         42,
         45
       ],
-      "text": "Military encampment",
+      "name": "Military encampment",
+      "description": "<p>Who is this faction warring against?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.b38f2fd79f6d6566",
       "_id": "b38f2fd79f6d6566"
     },
@@ -126,7 +138,8 @@
         46,
         49
       ],
-      "text": "Military fort",
+      "name": "Military fort",
+      "description": "<p>What notable prisoner is held here?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.37780929c7d30fbd",
       "_id": "37780929c7d30fbd"
     },
@@ -135,7 +148,8 @@
         50,
         52
       ],
-      "text": "Mining operation",
+      "name": "Mining operation",
+      "description": "<p>What danger have these miners unearthed?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.fbb48bd07ab2cccc",
       "_id": "fbb48bd07ab2cccc"
     },
@@ -144,7 +158,8 @@
         53,
         55
       ],
-      "text": "Mist-shrouded peak",
+      "name": "Mist-shrouded peak",
+      "description": "<p>What is said to stand atop this mountain?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.28e13eff02efb003",
       "_id": "28e13eff02efb003"
     },
@@ -153,7 +168,8 @@
         56,
         58
       ],
-      "text": "Navigation beacon",
+      "name": "Navigation beacon",
+      "description": "<p>Why has this lighthouse fallen into disrepair?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.4aa33d79934f9427",
       "_id": "4aa33d79934f9427"
     },
@@ -162,7 +178,8 @@
         59,
         61
       ],
-      "text": "Ongoing naval blockade",
+      "name": "Ongoing naval blockade",
+      "description": "<p>Who seeks an escort through or around this blockade?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.0c1dc7be24b39ee0",
       "_id": "0c1dc7be24b39ee0"
     },
@@ -171,7 +188,8 @@
         62,
         65
       ],
-      "text": "Palatial manor",
+      "name": "Palatial manor",
+      "description": "<p>What lavish event is scheduled to take place here?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.da397b72aa40db37",
       "_id": "da397b72aa40db37"
     },
@@ -180,7 +198,8 @@
         66,
         69
       ],
-      "text": "Pirate conclave",
+      "name": "Pirate conclave",
+      "description": "<p>What opportunity or crisis brings the pirates together?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.90dda5326a503f50",
       "_id": "90dda5326a503f50"
     },
@@ -189,7 +208,8 @@
         70,
         73
       ],
-      "text": "Recently wrecked ship",
+      "name": "Recently wrecked ship",
+      "description": "<p>What prize was this ship rumored to carry?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.56e0acb64eabd028",
       "_id": "56e0acb64eabd028"
     },
@@ -198,7 +218,8 @@
         74,
         76
       ],
-      "text": "Refugee encampment",
+      "name": "Refugee encampment",
+      "description": "<p>What danger or crisis displaced these refugees?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.3def68c06383b003",
       "_id": "3def68c06383b003"
     },
@@ -207,7 +228,8 @@
         77,
         79
       ],
-      "text": "Religious commune",
+      "name": "Religious commune",
+      "description": "<p>Why are these adherents desperate for supplies?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.ce662747c08993e1",
       "_id": "ce662747c08993e1"
     },
@@ -216,7 +238,8 @@
         80,
         83
       ],
-      "text": "Sentinel tree",
+      "name": "Sentinel tree",
+      "description": "<p>What threatens this sacred site?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.d554bd99b6f2c965",
       "_id": "d554bd99b6f2c965"
     },
@@ -225,7 +248,8 @@
         84,
         87
       ],
-      "text": "Sheltered anchorage",
+      "name": "Sheltered anchorage",
+      "description": "<p>What infamous ship lies anchored here?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.0c073de88e985bcf",
       "_id": "0c073de88e985bcf"
     },
@@ -234,7 +258,8 @@
         88,
         91
       ],
-      "text": "Warship patrols",
+      "name": "Warship patrols",
+      "description": "<p>What are these ships hunting?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.6862507dc037d26b",
       "_id": "6862507dc037d26b"
     },
@@ -243,7 +268,8 @@
         92,
         94
       ],
-      "text": "Whale graveyard",
+      "name": "Whale graveyard",
+      "description": "<p>Who seeks to harvest these bones?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.690e6c31141c41ef",
       "_id": "690e6c31141c41ef"
     },
@@ -252,7 +278,8 @@
         95,
         97
       ],
-      "text": "Whaling grounds",
+      "name": "Whaling grounds",
+      "description": "<p>Who or what is hunting these creatures to near-extinction?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.b36c58ab42f0de4f",
       "_id": "b36c58ab42f0de4f"
     },
@@ -261,7 +288,8 @@
         98,
         100
       ],
-      "text": "Wide, navigable river",
+      "name": "Wide, navigable river",
+      "description": "<p>What important location lies upriver?</p>",
       "_key": "!tables.results!fcfcb0bceae33bfe.49a18a862d05804d",
       "_id": "49a18a862d05804d"
     }

--- a/json-packs/sundered-isles-oracles/Lurking_Threat_00b6028d93a842be.json
+++ b/json-packs/sundered-isles-oracles/Lurking_Threat_00b6028d93a842be.json
@@ -18,7 +18,8 @@
         1,
         15
       ],
-      "text": "Chilling cold",
+      "name": "Chilling cold",
+      "description": "<p>Creeping numbness; teeth- chattering shivers</p><p>You are chilled to the bone!</p>",
       "_key": "!tables.results!00b6028d93a842be.205dd9a669b275ac",
       "_id": "205dd9a669b275ac"
     },
@@ -27,7 +28,8 @@
         16,
         25
       ],
-      "text": "Devious trap",
+      "name": "Devious trap",
+      "description": "<p>Minor puzzle; portentous clues</p><p>You face a confounding trap!</p>",
       "_key": "!tables.results!00b6028d93a842be.89ead54c94bd2d9d",
       "_id": "89ead54c94bd2d9d"
     },
@@ -36,7 +38,8 @@
         26,
         35
       ],
-      "text": "Flash flood",
+      "name": "Flash flood",
+      "description": "<p>Dripping water; distant rumbles</p><p>A torrent of water floods in!</p>",
       "_key": "!tables.results!00b6028d93a842be.7e1f13fdf48be7c6",
       "_id": "7e1f13fdf48be7c6"
     },
@@ -45,7 +48,8 @@
         36,
         50
       ],
-      "text": "Oppressive  confinement",
+      "name": "Oppressive  confinement",
+      "description": "<p>Suffocating passages; deepening darkness</p><p>You face confusion or panic!</p>",
       "_key": "!tables.results!00b6028d93a842be.c09e33c41d41b459",
       "_id": "c09e33c41d41b459"
     },
@@ -54,7 +58,8 @@
         51,
         60
       ],
-      "text": "Restless magma",
+      "name": "Restless magma",
+      "description": "<p>Stifling heat; venting steam</p><p>Magma causes destruction!</p>",
       "_key": "!tables.results!00b6028d93a842be.aea6e42a22015134",
       "_id": "aea6e42a22015134"
     },
@@ -63,7 +68,8 @@
         61,
         70
       ],
-      "text": "Rising water",
+      "name": "Rising water",
+      "description": "<p>Surging current; flooding</p><p>The path is submerged!</p>",
       "_key": "!tables.results!00b6028d93a842be.e672df8f7eb9f917",
       "_id": "e672df8f7eb9f917"
     },
@@ -72,7 +78,8 @@
         71,
         80
       ],
-      "text": "Rival explorers",
+      "name": "Rival explorers",
+      "description": "<p>Echoing sounds; signs they passed this way</p><p>Your rivals make their move!</p>",
       "_key": "!tables.results!00b6028d93a842be.511be5c6b5e9193a",
       "_id": "511be5c6b5e9193a"
     },
@@ -81,7 +88,8 @@
         81,
         90
       ],
-      "text": "Stalking predator",
+      "name": "Stalking predator",
+      "description": "<p>Glimpses of the creature; remains of previous kills</p><p>The predator attacks!</p>",
       "_key": "!tables.results!00b6028d93a842be.7f14f2762022f838",
       "_id": "7f14f2762022f838"
     },
@@ -90,7 +98,8 @@
         91,
         100
       ],
-      "text": "Unstable caves",
+      "name": "Unstable caves",
+      "description": "<p>Tremors; minor rockfalls</p><p>The cave collapses!</p>",
       "_key": "!tables.results!00b6028d93a842be.e4dad3f524b70424",
       "_id": "e4dad3f524b70424"
     }

--- a/json-packs/sundered-isles-oracles/Margins_04397febabcb908b.json
+++ b/json-packs/sundered-isles-oracles/Margins_04397febabcb908b.json
@@ -17,7 +17,8 @@
         1,
         60
       ],
-      "text": "Isolated",
+      "name": "Isolated",
+      "description": "<p>No other islands in sight</p>",
       "_key": "!tables.results!04397febabcb908b.674447ce79037d62",
       "_id": "674447ce79037d62"
     },
@@ -26,7 +27,8 @@
         61,
         85
       ],
-      "text": "Island pair",
+      "name": "Island pair",
+      "description": "<p>One other island in sight</p>",
       "_key": "!tables.results!04397febabcb908b.17b6a2f685642f55",
       "_id": "17b6a2f685642f55"
     },
@@ -35,7 +37,8 @@
         86,
         100
       ],
-      "text": "Island group",
+      "name": "Island group",
+      "description": "<p>Several islands in sight</p>",
       "_key": "!tables.results!04397febabcb908b.6504c6b202c4f257",
       "_id": "6504c6b202c4f257"
     }

--- a/json-packs/sundered-isles-oracles/Margins_07e487be5cfc0597.json
+++ b/json-packs/sundered-isles-oracles/Margins_07e487be5cfc0597.json
@@ -17,7 +17,8 @@
         1,
         10
       ],
-      "text": "Devastated",
+      "name": "Devastated",
+      "description": "<p>Ravaged by natural forces or razed by despoilers</p>",
       "_key": "!tables.results!07e487be5cfc0597.4f036301cbd24d90",
       "_id": "4f036301cbd24d90"
     },
@@ -26,7 +27,8 @@
         11,
         20
       ],
-      "text": "Dying",
+      "name": "Dying",
+      "description": "<p>Withered woodlands, blighted scrub, or sickly marshes</p>",
       "_key": "!tables.results!07e487be5cfc0597.66706b97e57b758a",
       "_id": "66706b97e57b758a"
     },
@@ -35,7 +37,8 @@
         21,
         25
       ],
-      "text": "Desolate",
+      "name": "Desolate",
+      "description": "<p>Arid wastes</p>",
       "_key": "!tables.results!07e487be5cfc0597.b94ac8263d4845f7",
       "_id": "b94ac8263d4845f7"
     },
@@ -44,7 +47,8 @@
         26,
         35
       ],
-      "text": "Sparse",
+      "name": "Sparse",
+      "description": "<p>Thin woodlands, bleak scrub, or stagnant marshes</p>",
       "_key": "!tables.results!07e487be5cfc0597.f8a121b8b646ba05",
       "_id": "f8a121b8b646ba05"
     },
@@ -53,7 +57,8 @@
         36,
         85
       ],
-      "text": "Lush",
+      "name": "Lush",
+      "description": "<p>Verdant woodlands, dense jungles, or thriving swamps</p>",
       "_key": "!tables.results!07e487be5cfc0597.b955cd87a087c78b",
       "_id": "b955cd87a087c78b"
     },
@@ -62,7 +67,8 @@
         86,
         100
       ],
-      "text": "Primeval",
+      "name": "Primeval",
+      "description": "<p>Ancient jungles or impenetrable swamps</p>",
       "_key": "!tables.results!07e487be5cfc0597.f35c2a9cf6c71f89",
       "_id": "f35c2a9cf6c71f89"
     }

--- a/json-packs/sundered-isles-oracles/Margins_8e46a88307d5847b.json
+++ b/json-packs/sundered-isles-oracles/Margins_8e46a88307d5847b.json
@@ -17,7 +17,8 @@
         1,
         40
       ],
-      "text": "Village or outpost",
+      "name": "Village or outpost",
+      "description": "<p>Dozens</p>",
       "_key": "!tables.results!8e46a88307d5847b.88de28ad7cc0f254",
       "_id": "88de28ad7cc0f254"
     },
@@ -26,7 +27,8 @@
         41,
         75
       ],
-      "text": "Town",
+      "name": "Town",
+      "description": "<p>Hundreds</p>",
       "_key": "!tables.results!8e46a88307d5847b.1459c59af4528f83",
       "_id": "1459c59af4528f83"
     },
@@ -35,7 +37,8 @@
         76,
         98
       ],
-      "text": "City",
+      "name": "City",
+      "description": "<p>Thousands</p>",
       "_key": "!tables.results!8e46a88307d5847b.1da74a2e98e36728",
       "_id": "1da74a2e98e36728"
     },
@@ -44,7 +47,8 @@
         99,
         100
       ],
-      "text": "City-state",
+      "name": "City-state",
+      "description": "<p>Tens of thousands</p>",
       "_key": "!tables.results!8e46a88307d5847b.b201eeec4d60bf79",
       "_id": "b201eeec4d60bf79"
     }

--- a/json-packs/sundered-isles-oracles/Medium_54ada22a5c08f0d2.json
+++ b/json-packs/sundered-isles-oracles/Medium_54ada22a5c08f0d2.json
@@ -17,7 +17,8 @@
         1,
         60
       ],
-      "text": "Trifle",
+      "name": "Trifle",
+      "description": "<p>One @Compendium[foundry-ironsworn.sunderedislesoracles.baaff21d3f6897ac]{Precious Item}</p>",
       "_key": "!tables.results!54ada22a5c08f0d2.c886e9918d1147e4",
       "_id": "c886e9918d1147e4"
     },
@@ -26,7 +27,8 @@
         61,
         100
       ],
-      "text": "Stash",
+      "name": "Stash",
+      "description": "<p>Roll the action die and reveal that many @Compendium[foundry-ironsworn.sunderedislesoracles.baaff21d3f6897ac]{Precious Items}</p>",
       "_key": "!tables.results!54ada22a5c08f0d2.fc2a2db0ed0a0b65",
       "_id": "fc2a2db0ed0a0b65"
     }

--- a/json-packs/sundered-isles-oracles/Myriads_92112e952165c826.json
+++ b/json-packs/sundered-isles-oracles/Myriads_92112e952165c826.json
@@ -17,7 +17,8 @@
         1,
         50
       ],
-      "text": "Village or outpost",
+      "name": "Village or outpost",
+      "description": "<p>Dozens</p>",
       "_key": "!tables.results!92112e952165c826.a2ea5529460ececc",
       "_id": "a2ea5529460ececc"
     },
@@ -26,7 +27,8 @@
         51,
         80
       ],
-      "text": "Town",
+      "name": "Town",
+      "description": "<p>Hundreds</p>",
       "_key": "!tables.results!92112e952165c826.b00d7083d528c690",
       "_id": "b00d7083d528c690"
     },
@@ -35,7 +37,8 @@
         81,
         98
       ],
-      "text": "City",
+      "name": "City",
+      "description": "<p>Thousands</p>",
       "_key": "!tables.results!92112e952165c826.a2063628322138b4",
       "_id": "a2063628322138b4"
     },
@@ -44,7 +47,8 @@
         99,
         100
       ],
-      "text": "City-state",
+      "name": "City-state",
+      "description": "<p>Tens of thousands</p>",
       "_key": "!tables.results!92112e952165c826.67ed5516220cb1ee",
       "_id": "67ed5516220cb1ee"
     }

--- a/json-packs/sundered-isles-oracles/Myriads_adb214ed14918cc0.json
+++ b/json-packs/sundered-isles-oracles/Myriads_adb214ed14918cc0.json
@@ -17,7 +17,8 @@
         1,
         15
       ],
-      "text": "Devastated",
+      "name": "Devastated",
+      "description": "<p>Ravaged by natural forces or razed by despoilers</p>",
       "_key": "!tables.results!adb214ed14918cc0.3a92c1c9074beddf",
       "_id": "3a92c1c9074beddf"
     },
@@ -26,7 +27,8 @@
         16,
         30
       ],
-      "text": "Dying",
+      "name": "Dying",
+      "description": "<p>Withered woodlands, blighted scrub, or sickly marshes</p>",
       "_key": "!tables.results!adb214ed14918cc0.ac02509b0ba94df2",
       "_id": "ac02509b0ba94df2"
     },
@@ -35,7 +37,8 @@
         31,
         40
       ],
-      "text": "Desolate",
+      "name": "Desolate",
+      "description": "<p>Arid wastes</p>",
       "_key": "!tables.results!adb214ed14918cc0.eb3c05423489c2c2",
       "_id": "eb3c05423489c2c2"
     },
@@ -44,7 +47,8 @@
         41,
         50
       ],
-      "text": "Sparse",
+      "name": "Sparse",
+      "description": "<p>Thin woodlands, bleak scrub, or stagnant marshes</p>",
       "_key": "!tables.results!adb214ed14918cc0.26a6b31bdeb8721b",
       "_id": "26a6b31bdeb8721b"
     },
@@ -53,7 +57,8 @@
         51,
         90
       ],
-      "text": "Lush",
+      "name": "Lush",
+      "description": "<p>Verdant woodlands, dense jungles, or thriving swamps</p>",
       "_key": "!tables.results!adb214ed14918cc0.e2188de020974553",
       "_id": "e2188de020974553"
     },
@@ -62,7 +67,8 @@
         91,
         100
       ],
-      "text": "Primeval",
+      "name": "Primeval",
+      "description": "<p>Ancient jungles or impenetrable swamps</p>",
       "_key": "!tables.results!adb214ed14918cc0.ab914b64a152066e",
       "_id": "ab914b64a152066e"
     }

--- a/json-packs/sundered-isles-oracles/Myriads_f9872156f04012f4.json
+++ b/json-packs/sundered-isles-oracles/Myriads_f9872156f04012f4.json
@@ -17,7 +17,8 @@
         1,
         50
       ],
-      "text": "Isolated",
+      "name": "Isolated",
+      "description": "<p>No other islands in sight</p>",
       "_key": "!tables.results!f9872156f04012f4.84f7558376f23166",
       "_id": "84f7558376f23166"
     },
@@ -26,7 +27,8 @@
         51,
         80
       ],
-      "text": "Island pair",
+      "name": "Island pair",
+      "description": "<p>One other island in sight</p>",
       "_key": "!tables.results!f9872156f04012f4.09f68bc7e4dbe42a",
       "_id": "09f68bc7e4dbe42a"
     },
@@ -35,7 +37,8 @@
         81,
         100
       ],
-      "text": "Island group",
+      "name": "Island group",
+      "description": "<p>Several islands in sight</p>",
       "_key": "!tables.results!f9872156f04012f4.60770ab53b40749d",
       "_id": "60770ab53b40749d"
     }

--- a/json-packs/sundered-isles-oracles/Organizations_9ede74b820bf5ad8.json
+++ b/json-packs/sundered-isles-oracles/Organizations_9ede74b820bf5ad8.json
@@ -17,7 +17,8 @@
         1,
         10
       ],
-      "text": "Bloody Skulls",
+      "name": "Bloody Skulls",
+      "description": "<p>Bands of scavenging shipbreakers who lie in wait along hazardous passages. They believe that painting their faces with a death-like visage protect against retribution by spirits of the dead.</p>",
       "_key": "!tables.results!9ede74b820bf5ad8.ce36eb87dd988756",
       "_id": "ce36eb87dd988756"
     },
@@ -26,7 +27,8 @@
         11,
         20
       ],
-      "text": "Cynosure League",
+      "name": "Cynosure League",
+      "description": "<p>Guild of scientists and naturalists who record their findings in exhaustively-detailed journals. Their works are copied and recorded by archivists at a grand central library.</p>",
       "_key": "!tables.results!9ede74b820bf5ad8.93aa4d0fe92b3e22",
       "_id": "93aa4d0fe92b3e22"
     },
@@ -35,7 +37,8 @@
         21,
         30
       ],
-      "text": "Ebb Tide",
+      "name": "Ebb Tide",
+      "description": "<p>Covert insurgency of spies and saboteurs. They seek to cripple imperial ambitions from within, and use trained gulls to carry vital messages to collaborators.</p>",
       "_key": "!tables.results!9ede74b820bf5ad8.d1dc2fd14f43ab4a",
       "_id": "d1dc2fd14f43ab4a"
     },
@@ -44,7 +47,8 @@
         31,
         40
       ],
-      "text": "Faceless Accord",
+      "name": "Faceless Accord",
+      "description": "<p>Renegades sailing in defiance of imperial powers. They conceal their identities behind iron masks to protect kinfolk still under imperial rule.</p>",
       "_key": "!tables.results!9ede74b820bf5ad8.fe533a6843a339d7",
       "_id": "fe533a6843a339d7"
     },
@@ -53,7 +57,8 @@
         41,
         50
       ],
-      "text": "Forsaken Fleet",
+      "name": "Forsaken Fleet",
+      "description": "<p>Powerful clan of pirates led by a marauder known as the Raven Queen. They recently sacked and seized a major port town and made it a refuge for outlaws and outcasts.</p>",
       "_key": "!tables.results!9ede74b820bf5ad8.7c4f97878be332a4",
       "_id": "7c4f97878be332a4"
     },
@@ -62,7 +67,8 @@
         51,
         60
       ],
-      "text": "Ironmongers",
+      "name": "Ironmongers",
+      "description": "<p>Guild of shipbuilders and arms manufacturers who supply their destructive wares to the highest bidder. They secretly incite wars to expand their fortune.</p>",
       "_key": "!tables.results!9ede74b820bf5ad8.cbd8339d40f556f4",
       "_id": "cbd8339d40f556f4"
     },
@@ -71,7 +77,8 @@
         61,
         70
       ],
-      "text": "Moonsingers",
+      "name": "Moonsingers",
+      "description": "<p>Mystic coven that draw their powers from the dance of the moons and the rhythm of the tides. They recruit and train talented initiates from across the isles.</p>",
       "_key": "!tables.results!9ede74b820bf5ad8.f1467238ee287614",
       "_id": "f1467238ee287614"
     },
@@ -80,7 +87,8 @@
         71,
         80
       ],
-      "text": "Saltblood",
+      "name": "Saltblood",
+      "description": "<p>Mariners bound to an age-old seafaring fellowship. They recognize fellow saltbloods and communicate using complex hand signals.</p>",
       "_key": "!tables.results!9ede74b820bf5ad8.0699f9c261488950",
       "_id": "0699f9c261488950"
     },
@@ -89,7 +97,8 @@
         81,
         90
       ],
-      "text": "Tide Runners",
+      "name": "Tide Runners",
+      "description": "<p>Smugglers who ferry their ill-gotten goods from island to island. They rely on speed, stealth, and the cover of foul weather or moonless nights.</p>",
       "_key": "!tables.results!9ede74b820bf5ad8.aad1e7773d4ff7f7",
       "_id": "aad1e7773d4ff7f7"
     },
@@ -98,7 +107,8 @@
         91,
         100
       ],
-      "text": "Wayfarers",
+      "name": "Wayfarers",
+      "description": "<p>Peddlers who range across the isles and beyond. They transport rare and unusual cargo aboard their vibrantly painted ships.</p>",
       "_key": "!tables.results!9ede74b820bf5ad8.91eb2ee5fb9ea192",
       "_id": "91eb2ee5fb9ea192"
     }

--- a/json-packs/sundered-isles-oracles/Overland_Region_d492a277bfe267fa.json
+++ b/json-packs/sundered-isles-oracles/Overland_Region_d492a277bfe267fa.json
@@ -17,7 +17,7 @@
         1,
         20
       ],
-      "text": "@Compendium[foundry-ironsworn.sunderedislesoracles.22bfe152e86e3b7c]{Highlands}",
+      "text": "<p>@Compendium[foundry-ironsworn.sunderedislesoracles.22bfe152e86e3b7c]{Highlands}</p><p>Hilly or mountainous terrain</p>",
       "_key": "!tables.results!d492a277bfe267fa.273e8a9fb59d0e11",
       "_id": "273e8a9fb59d0e11"
     },
@@ -26,7 +26,7 @@
         21,
         45
       ],
-      "text": "@Compendium[foundry-ironsworn.sunderedislesoracles.cc4be741ca30b038]{Jungle}",
+      "text": "<p>@Compendium[foundry-ironsworn.sunderedislesoracles.cc4be741ca30b038]{Jungle}</p><p>Dense tropical rainforest</p>",
       "_key": "!tables.results!d492a277bfe267fa.10f27a6b8a48e878",
       "_id": "10f27a6b8a48e878"
     },
@@ -35,7 +35,7 @@
         46,
         50
       ],
-      "text": "@Compendium[foundry-ironsworn.sunderedislesoracles.214cc3a5e0062ec3]{Lava Field}",
+      "text": "<p>@Compendium[foundry-ironsworn.sunderedislesoracles.214cc3a5e0062ec3]{Lava Field}</p><p>Lands scarred by volcanic eruptions</p>",
       "_key": "!tables.results!d492a277bfe267fa.c2cfe1983c03aea2",
       "_id": "c2cfe1983c03aea2"
     },
@@ -44,7 +44,7 @@
         51,
         55
       ],
-      "text": "@Compendium[foundry-ironsworn.sunderedislesoracles.5e3a3041a8ae82c0]{Marsh}",
+      "text": "<p>@Compendium[foundry-ironsworn.sunderedislesoracles.5e3a3041a8ae82c0]{Marsh}</p><p>Waterlogged region with grasses and reeds</p>",
       "_key": "!tables.results!d492a277bfe267fa.fddadb5f8f539f03",
       "_id": "fddadb5f8f539f03"
     },
@@ -53,7 +53,7 @@
         56,
         60
       ],
-      "text": "@Compendium[foundry-ironsworn.sunderedislesoracles.e59342f67b015a1f]{River}",
+      "text": "<p>@Compendium[foundry-ironsworn.sunderedislesoracles.e59342f67b015a1f]{River}</p><p>Major inland waterway</p>",
       "_key": "!tables.results!d492a277bfe267fa.bb11f7d9de0aef36",
       "_id": "bb11f7d9de0aef36"
     },
@@ -62,7 +62,7 @@
         61,
         65
       ],
-      "text": "@Compendium[foundry-ironsworn.sunderedislesoracles.4ed7371f0a5b972a]{Scrub}",
+      "text": "<p>@Compendium[foundry-ironsworn.sunderedislesoracles.4ed7371f0a5b972a]{Scrub}</p><p>Open landscape dominated by grass or shrubs</p>",
       "_key": "!tables.results!d492a277bfe267fa.18c86d7e22bfba88",
       "_id": "18c86d7e22bfba88"
     },
@@ -71,7 +71,7 @@
         66,
         75
       ],
-      "text": "@Compendium[foundry-ironsworn.sunderedislesoracles.747f18d37af50737]{Shore}",
+      "text": "<p>@Compendium[foundry-ironsworn.sunderedislesoracles.747f18d37af50737]{Shore}</p><p>Where the land meets the sea</p>",
       "_key": "!tables.results!d492a277bfe267fa.efaba2e9fdb33e50",
       "_id": "efaba2e9fdb33e50"
     },
@@ -80,7 +80,7 @@
         76,
         85
       ],
-      "text": "@Compendium[foundry-ironsworn.sunderedislesoracles.1e3463e94c54d419]{Swamp}",
+      "text": "<p>@Compendium[foundry-ironsworn.sunderedislesoracles.1e3463e94c54d419]{Swamp}</p><p>Flooded forest with thick vegetation</p>",
       "_key": "!tables.results!d492a277bfe267fa.3dc0e7674e744b78",
       "_id": "3dc0e7674e744b78"
     },
@@ -89,7 +89,7 @@
         86,
         90
       ],
-      "text": "@Compendium[foundry-ironsworn.sunderedislesoracles.6aef040657e5a9ec]{Wastes}",
+      "text": "<p>@Compendium[foundry-ironsworn.sunderedislesoracles.6aef040657e5a9ec]{Wastes}</p><p>Arid, rocky terrain</p>",
       "_key": "!tables.results!d492a277bfe267fa.b2763ec9598eef44",
       "_id": "b2763ec9598eef44"
     },
@@ -98,7 +98,7 @@
         91,
         100
       ],
-      "text": "@Compendium[foundry-ironsworn.sunderedislesoracles.51df8b454d349a65]{Woodland}",
+      "text": "<p>@Compendium[foundry-ironsworn.sunderedislesoracles.51df8b454d349a65]{Woodland}</p><p>Forested lands</p>",
       "_key": "!tables.results!d492a277bfe267fa.b6a02dd8a9d47a0b",
       "_id": "b6a02dd8a9d47a0b"
     }

--- a/json-packs/sundered-isles-oracles/Range_32f21a33d475b198.json
+++ b/json-packs/sundered-isles-oracles/Range_32f21a33d475b198.json
@@ -17,7 +17,8 @@
         1,
         40
       ],
-      "text": "Distant",
+      "name": "Distant",
+      "description": "<p>On the horizon and too far to make out details</p>",
       "_key": "!tables.results!32f21a33d475b198.8f8fe9761a89ee8f",
       "_id": "8f8fe9761a89ee8f"
     },
@@ -26,7 +27,8 @@
         41,
         75
       ],
-      "text": "Far",
+      "name": "Far",
+      "description": "<p>Observable but well beyond weapons range</p>",
       "_key": "!tables.results!32f21a33d475b198.cd8d6b7f64d8f0e5",
       "_id": "cd8d6b7f64d8f0e5"
     },
@@ -35,7 +37,8 @@
         76,
         95
       ],
-      "text": "Medium",
+      "name": "Medium",
+      "description": "<p>Easily discernible and nearly within weapons range</p>",
       "_key": "!tables.results!32f21a33d475b198.6a5cd7a2a88268d8",
       "_id": "6a5cd7a2a88268d8"
     },
@@ -44,7 +47,8 @@
         96,
         100
       ],
-      "text": "Near",
+      "name": "Near",
+      "description": "<p>Sighted or revealed at very close range</p>",
       "_key": "!tables.results!32f21a33d475b198.c3daa3d00f9deb48",
       "_id": "c3daa3d00f9deb48"
     }

--- a/json-packs/sundered-isles-oracles/Reaches_716d4031e5978464.json
+++ b/json-packs/sundered-isles-oracles/Reaches_716d4031e5978464.json
@@ -17,7 +17,8 @@
         1,
         70
       ],
-      "text": "Isolated",
+      "name": "Isolated",
+      "description": "<p>No other islands in sight</p>",
       "_key": "!tables.results!716d4031e5978464.569916b30cfcf9a2",
       "_id": "569916b30cfcf9a2"
     },
@@ -26,7 +27,8 @@
         71,
         90
       ],
-      "text": "Island pair",
+      "name": "Island pair",
+      "description": "<p>One other island in sight</p>",
       "_key": "!tables.results!716d4031e5978464.442041495d8f2210",
       "_id": "442041495d8f2210"
     },
@@ -35,7 +37,8 @@
         91,
         100
       ],
-      "text": "Island group",
+      "name": "Island group",
+      "description": "<p>Several islands in sight</p>",
       "_key": "!tables.results!716d4031e5978464.528b0f3c794b5c4f",
       "_id": "528b0f3c794b5c4f"
     }

--- a/json-packs/sundered-isles-oracles/Reaches_8c922cf5448ed04e.json
+++ b/json-packs/sundered-isles-oracles/Reaches_8c922cf5448ed04e.json
@@ -17,7 +17,8 @@
         1,
         5
       ],
-      "text": "Devastated",
+      "name": "Devastated",
+      "description": "<p>Ravaged by natural forces or razed by despoilers</p>",
       "_key": "!tables.results!8c922cf5448ed04e.06af563046d27614",
       "_id": "06af563046d27614"
     },
@@ -26,7 +27,8 @@
         6,
         10
       ],
-      "text": "Dying",
+      "name": "Dying",
+      "description": "<p>Withered woodlands, blighted scrub, or sickly marshes</p>",
       "_key": "!tables.results!8c922cf5448ed04e.95a45661a24a7c4e",
       "_id": "95a45661a24a7c4e"
     },
@@ -35,7 +37,8 @@
         11,
         15
       ],
-      "text": "Desolate",
+      "name": "Desolate",
+      "description": "<p>Arid wastes</p>",
       "_key": "!tables.results!8c922cf5448ed04e.7a82d938cd8a0ac4",
       "_id": "7a82d938cd8a0ac4"
     },
@@ -44,7 +47,8 @@
         16,
         25
       ],
-      "text": "Sparse",
+      "name": "Sparse",
+      "description": "<p>Thin woodlands, bleak scrub, or stagnant marshes</p>",
       "_key": "!tables.results!8c922cf5448ed04e.a0629ddc94986039",
       "_id": "a0629ddc94986039"
     },
@@ -53,7 +57,8 @@
         26,
         75
       ],
-      "text": "Lush",
+      "name": "Lush",
+      "description": "<p>Verdant woodlands, dense jungles, or thriving swamps</p>",
       "_key": "!tables.results!8c922cf5448ed04e.2a71cd661a7c2894",
       "_id": "2a71cd661a7c2894"
     },
@@ -62,7 +67,8 @@
         76,
         100
       ],
-      "text": "Primeval",
+      "name": "Primeval",
+      "description": "<p>Ancient jungles or impenetrable swamps</p>",
       "_key": "!tables.results!8c922cf5448ed04e.57cdbf1bb36c2298",
       "_id": "57cdbf1bb36c2298"
     }

--- a/json-packs/sundered-isles-oracles/Reaches_ed4462477855bbde.json
+++ b/json-packs/sundered-isles-oracles/Reaches_ed4462477855bbde.json
@@ -17,7 +17,8 @@
         1,
         50
       ],
-      "text": "Village or outpost",
+      "name": "Village or outpost",
+      "description": "<p>Dozens</p>",
       "_key": "!tables.results!ed4462477855bbde.0865c18c9aed73d9",
       "_id": "0865c18c9aed73d9"
     },
@@ -26,7 +27,8 @@
         51,
         80
       ],
-      "text": "Town",
+      "name": "Town",
+      "description": "<p>Hundreds</p>",
       "_key": "!tables.results!ed4462477855bbde.0b91af5cc960edc2",
       "_id": "0b91af5cc960edc2"
     },
@@ -35,7 +37,8 @@
         81,
         98
       ],
-      "text": "City",
+      "name": "City",
+      "description": "<p>Thousands</p>",
       "_key": "!tables.results!ed4462477855bbde.df8770b02e0c929f",
       "_id": "df8770b02e0c929f"
     },
@@ -44,7 +47,8 @@
         99,
         100
       ],
-      "text": "City-state",
+      "name": "City-state",
+      "description": "<p>Tens of thousands</p>",
       "_key": "!tables.results!ed4462477855bbde.b0d6a25b7e28b2b0",
       "_id": "b0d6a25b7e28b2b0"
     }

--- a/json-packs/sundered-isles-oracles/Ruin_Condition_8aad29217d56dd51.json
+++ b/json-packs/sundered-isles-oracles/Ruin_Condition_8aad29217d56dd51.json
@@ -17,7 +17,8 @@
         1,
         10
       ],
-      "text": "Devastated",
+      "name": "Devastated",
+      "description": "<p>Ravaged by calamity</p>",
       "_key": "!tables.results!8aad29217d56dd51.cf7a9e1eee730553",
       "_id": "cf7a9e1eee730553"
     },
@@ -26,7 +27,8 @@
         11,
         25
       ],
-      "text": "Unrecognizable",
+      "name": "Unrecognizable",
+      "description": "<p>Reclaimed by nature</p>",
       "_key": "!tables.results!8aad29217d56dd51.3df4064adfdd4a18",
       "_id": "3df4064adfdd4a18"
     },
@@ -35,7 +37,8 @@
         26,
         40
       ],
-      "text": "Collapsed",
+      "name": "Collapsed",
+      "description": "<p>Toppled or in pieces</p>",
       "_key": "!tables.results!8aad29217d56dd51.9d748773e08387ec",
       "_id": "9d748773e08387ec"
     },
@@ -44,7 +47,8 @@
         41,
         60
       ],
-      "text": "Unstable",
+      "name": "Unstable",
+      "description": "<p>Actively crumbling or sinking</p>",
       "_key": "!tables.results!8aad29217d56dd51.31cde1196fe34617",
       "_id": "31cde1196fe34617"
     },
@@ -53,7 +57,8 @@
         61,
         80
       ],
-      "text": "Timeworn",
+      "name": "Timeworn",
+      "description": "<p>Marked by desolation</p>",
       "_key": "!tables.results!8aad29217d56dd51.eab885546649791d",
       "_id": "eab885546649791d"
     },
@@ -62,7 +67,8 @@
         81,
         90
       ],
-      "text": "Whole",
+      "name": "Whole",
+      "description": "<p>Standing the test of time</p>",
       "_key": "!tables.results!8aad29217d56dd51.2b36658d6bfb96c2",
       "_id": "2b36658d6bfb96c2"
     },
@@ -71,7 +77,8 @@
         91,
         95
       ],
-      "text": "Well-preserved",
+      "name": "Well-preserved",
+      "description": "<p>In remarkable condition</p>",
       "_key": "!tables.results!8aad29217d56dd51.0f6ba90fa13ecec0",
       "_id": "0f6ba90fa13ecec0"
     },
@@ -80,7 +87,8 @@
         96,
         100
       ],
-      "text": "Rebuilding",
+      "name": "Rebuilding",
+      "description": "<p>In the process or restoration</p>",
       "_key": "!tables.results!8aad29217d56dd51.d6af10f1a73121d0",
       "_id": "d6af10f1a73121d0"
     }

--- a/json-packs/sundered-isles-oracles/Ruin_Location_35a4000c5160a8c7.json
+++ b/json-packs/sundered-isles-oracles/Ruin_Location_35a4000c5160a8c7.json
@@ -17,7 +17,8 @@
         1,
         20
       ],
-      "text": "Sea",
+      "name": "Sea",
+      "description": "<p>Amid open waters</p>",
       "_key": "!tables.results!35a4000c5160a8c7.0c101e5262b15406",
       "_id": "0c101e5262b15406"
     },
@@ -26,7 +27,8 @@
         21,
         60
       ],
-      "text": "Shore",
+      "name": "Shore",
+      "description": "<p>Where land meets the sea</p>",
       "_key": "!tables.results!35a4000c5160a8c7.5e79b3a8109d47dd",
       "_id": "5e79b3a8109d47dd"
     },
@@ -35,7 +37,8 @@
         61,
         90
       ],
-      "text": "Inland",
+      "name": "Inland",
+      "description": "<p>Away from the sea</p>",
       "_key": "!tables.results!35a4000c5160a8c7.5d5f028fda3e5629",
       "_id": "5d5f028fda3e5629"
     },
@@ -44,7 +47,8 @@
         91,
         100
       ],
-      "text": "Buried",
+      "name": "Buried",
+      "description": "<p>Within cavernous depths</p>",
       "_key": "!tables.results!35a4000c5160a8c7.44dab1fcf8076313",
       "_id": "44dab1fcf8076313"
     }

--- a/json-packs/sundered-isles-oracles/Ruin_Mystery_3e07af2891acbea8.json
+++ b/json-packs/sundered-isles-oracles/Ruin_Mystery_3e07af2891acbea8.json
@@ -18,7 +18,8 @@
         1,
         10
       ],
-      "text": "Calamitous downfall",
+      "name": "Calamitous downfall",
+      "description": "<p>What brought this place to ruin?</p>",
       "_key": "!tables.results!3e07af2891acbea8.7e8535851f53822d",
       "_id": "7e8535851f53822d"
     },
@@ -27,7 +28,8 @@
         11,
         20
       ],
-      "text": "Cultural legacy",
+      "name": "Cultural legacy",
+      "description": "<p>What unique beliefs or customs were practiced here?</p>",
       "_key": "!tables.results!3e07af2891acbea8.fc167ac2b7c9054f",
       "_id": "fc167ac2b7c9054f"
     },
@@ -36,7 +38,8 @@
         21,
         30
       ],
-      "text": "Enemy schemes",
+      "name": "Enemy schemes",
+      "description": "<p>What purpose does a foe or rival have in this place?</p>",
       "_key": "!tables.results!3e07af2891acbea8.81589f526619284f",
       "_id": "81589f526619284f"
     },
@@ -45,7 +48,8 @@
         31,
         40
       ],
-      "text": "Enigmatic waymarker",
+      "name": "Enigmatic waymarker",
+      "description": "<p>What greater site or discovery does this place lead to?</p>",
       "_key": "!tables.results!3e07af2891acbea8.3a0357ebfc1b82e7",
       "_id": "3a0357ebfc1b82e7"
     },
@@ -54,7 +58,8 @@
         41,
         50
       ],
-      "text": "Fabled relic",
+      "name": "Fabled relic",
+      "description": "<p>What legendary artifact or treasure is held here?</p>",
       "_key": "!tables.results!3e07af2891acbea8.1e2902849ff37355",
       "_id": "1e2902849ff37355"
     },
@@ -63,7 +68,8 @@
         51,
         60
       ],
-      "text": "Heroes' rest",
+      "name": "Heroes' rest",
+      "description": "<p>What legendary figure is entombed here?</p>",
       "_key": "!tables.results!3e07af2891acbea8.8965008d92e62619",
       "_id": "8965008d92e62619"
     },
@@ -72,7 +78,8 @@
         61,
         70
       ],
-      "text": "Lost people",
+      "name": "Lost people",
+      "description": "<p>What became of the people who once inhabited this site?</p>",
       "_key": "!tables.results!3e07af2891acbea8.a135fe04354c382e",
       "_id": "a135fe04354c382e"
     },
@@ -81,7 +88,8 @@
         71,
         80
       ],
-      "text": "Personal heritage",
+      "name": "Personal heritage",
+      "description": "<p>What connection does this place have to your culture or calling?</p>",
       "_key": "!tables.results!3e07af2891acbea8.0fbfe9e49880ffb5",
       "_id": "0fbfe9e49880ffb5"
     },
@@ -90,7 +98,8 @@
         81,
         90
       ],
-      "text": "Unfulfilled promise",
+      "name": "Unfulfilled promise",
+      "description": "<p>What forsaken vow or lost destiny hangs heavy over this place?</p>",
       "_key": "!tables.results!3e07af2891acbea8.50574823968daf1d",
       "_id": "50574823968daf1d"
     },
@@ -99,7 +108,8 @@
         91,
         100
       ],
-      "text": "Unusual purpose",
+      "name": "Unusual purpose",
+      "description": "<p>What unexpected function did this site serve?</p>",
       "_key": "!tables.results!3e07af2891acbea8.3d4b2fbe09f0e329",
       "_id": "3d4b2fbe09f0e329"
     }

--- a/json-packs/sundered-isles-oracles/Sea_Cave_5395161489362126.json
+++ b/json-packs/sundered-isles-oracles/Sea_Cave_5395161489362126.json
@@ -17,7 +17,8 @@
         1,
         30
       ],
-      "text": "Troublesome",
+      "name": "Troublesome",
+      "description": "<p>Minor cave system</p>",
       "_key": "!tables.results!5395161489362126.e664e835b9a381d7",
       "_id": "e664e835b9a381d7"
     },
@@ -26,7 +27,8 @@
         31,
         70
       ],
-      "text": "Dangerous",
+      "name": "Dangerous",
+      "description": "<p>Limited cave system</p>",
       "_key": "!tables.results!5395161489362126.77be8db11916fdbb",
       "_id": "77be8db11916fdbb"
     },
@@ -35,7 +37,8 @@
         71,
         85
       ],
-      "text": "Formidable",
+      "name": "Formidable",
+      "description": "<p>Extensive cave system</p>",
       "_key": "!tables.results!5395161489362126.bd726fea081a4c85",
       "_id": "bd726fea081a4c85"
     },
@@ -44,7 +47,8 @@
         86,
         95
       ],
-      "text": "Extreme",
+      "name": "Extreme",
+      "description": "<p>Vast cave system</p>",
       "_key": "!tables.results!5395161489362126.1cf7a0ad0b17dc7e",
       "_id": "1cf7a0ad0b17dc7e"
     },
@@ -53,7 +57,8 @@
         96,
         100
       ],
-      "text": "Epic",
+      "name": "Epic",
+      "description": "<p>Fathomless cave system</p>",
       "_key": "!tables.results!5395161489362126.b1fead2c1f88aa1a",
       "_id": "b1fead2c1f88aa1a"
     }

--- a/json-packs/sundered-isles-oracles/Settlement_Aesthetics_26f21b2c8340b415.json
+++ b/json-packs/sundered-isles-oracles/Settlement_Aesthetics_26f21b2c8340b415.json
@@ -17,7 +17,8 @@
         1,
         10
       ],
-      "text": "Ancient",
+      "name": "Ancient",
+      "description": "<p>Ancestral structures that have stood the test of time</p>",
       "_key": "!tables.results!26f21b2c8340b415.2d903fc7d8cc689e",
       "_id": "2d903fc7d8cc689e"
     },
@@ -26,7 +27,8 @@
         11,
         20
       ],
-      "text": "Dismal",
+      "name": "Dismal",
+      "description": "<p>Gloomy, tightly-packed structures and shadowed paths</p>",
       "_key": "!tables.results!26f21b2c8340b415.f9fe47f2f2cfdcba",
       "_id": "f9fe47f2f2cfdcba"
     },
@@ -35,7 +37,8 @@
         21,
         25
       ],
-      "text": "Earthen",
+      "name": "Earthen",
+      "description": "<p>Carved into the terrain</p>",
       "_key": "!tables.results!26f21b2c8340b415.d9a342a2d85024ac",
       "_id": "d9a342a2d85024ac"
     },
@@ -44,7 +47,8 @@
         26,
         35
       ],
-      "text": "Foreboding",
+      "name": "Foreboding",
+      "description": "<p>Structures with ornate, dramatic forms and cavernous interiors</p>",
       "_key": "!tables.results!26f21b2c8340b415.e4304818631d8ade",
       "_id": "e4304818631d8ade"
     },
@@ -53,7 +57,8 @@
         36,
         45
       ],
-      "text": "Fortified",
+      "name": "Fortified",
+      "description": "<p>Imposing structures hardened against assaults</p>",
       "_key": "!tables.results!26f21b2c8340b415.045458ad23f7701a",
       "_id": "045458ad23f7701a"
     },
@@ -62,7 +67,8 @@
         46,
         50
       ],
-      "text": "Garish",
+      "name": "Garish",
+      "description": "<p>Structures with tacky design and showy adornments</p>",
       "_key": "!tables.results!26f21b2c8340b415.374dea64e92eefa2",
       "_id": "374dea64e92eefa2"
     },
@@ -71,7 +77,8 @@
         51,
         55
       ],
-      "text": "Grand",
+      "name": "Grand",
+      "description": "<p>Majestic structures with opulent details</p>",
       "_key": "!tables.results!26f21b2c8340b415.3f7771baf8c92d02",
       "_id": "3f7771baf8c92d02"
     },
@@ -80,7 +87,8 @@
         56,
         65
       ],
-      "text": "Idyllic",
+      "name": "Idyllic",
+      "description": "<p>Organic forms and materials, at one with the landscape</p>",
       "_key": "!tables.results!26f21b2c8340b415.c99e8099258720ab",
       "_id": "c99e8099258720ab"
     },
@@ -89,7 +97,8 @@
         66,
         70
       ],
-      "text": "Industrial",
+      "name": "Industrial",
+      "description": "<p>Grim, utilitarian structures, built for function over form</p>",
       "_key": "!tables.results!26f21b2c8340b415.e1556e56b9919fb1",
       "_id": "e1556e56b9919fb1"
     },
@@ -98,7 +107,8 @@
         71,
         75
       ],
-      "text": "Makeshift",
+      "name": "Makeshift",
+      "description": "<p>Temporary shelters for nomadic or displaced people</p>",
       "_key": "!tables.results!26f21b2c8340b415.90a7fbe6c1537686",
       "_id": "90a7fbe6c1537686"
     },
@@ -107,7 +117,8 @@
         76,
         85
       ],
-      "text": "Modest",
+      "name": "Modest",
+      "description": "<p>Practical, charming structures</p>",
       "_key": "!tables.results!26f21b2c8340b415.992b5294bc0fe8de",
       "_id": "992b5294bc0fe8de"
     },
@@ -116,7 +127,8 @@
         86,
         95
       ],
-      "text": "Ramshackle",
+      "name": "Ramshackle",
+      "description": "<p>Haphazard structures using scavenged or repurposed materials</p>",
       "_key": "!tables.results!26f21b2c8340b415.b9afc0eccae00783",
       "_id": "b9afc0eccae00783"
     },
@@ -125,7 +137,8 @@
         96,
         100
       ],
-      "text": "Wondrous",
+      "name": "Wondrous",
+      "description": "<p>Enigmatic structures of awe-inspiring design or function</p>",
       "_key": "!tables.results!26f21b2c8340b415.a11eb372793c9d75",
       "_id": "a11eb372793c9d75"
     }

--- a/json-packs/sundered-isles-oracles/Settlement_Location_c0c9c8da265f1348.json
+++ b/json-packs/sundered-isles-oracles/Settlement_Location_c0c9c8da265f1348.json
@@ -17,7 +17,8 @@
         1,
         60
       ],
-      "text": "Shore",
+      "name": "Shore",
+      "description": "<p>Where land meets the sea</p>",
       "_key": "!tables.results!c0c9c8da265f1348.8daf0c3f19345653",
       "_id": "8daf0c3f19345653"
     },
@@ -26,7 +27,8 @@
         61,
         80
       ],
-      "text": "Inland",
+      "name": "Inland",
+      "description": "<p>Within the island interior</p>",
       "_key": "!tables.results!c0c9c8da265f1348.f6f1470cb0aa3825",
       "_id": "f6f1470cb0aa3825"
     },
@@ -35,7 +37,8 @@
         81,
         100
       ],
-      "text": "Waterside",
+      "name": "Waterside",
+      "description": "<p>By a major inland waterway</p>",
       "_key": "!tables.results!c0c9c8da265f1348.953e130662a21c15",
       "_id": "953e130662a21c15"
     }

--- a/json-packs/sundered-isles-oracles/Ship_Damage_999a788dbfc8e923.json
+++ b/json-packs/sundered-isles-oracles/Ship_Damage_999a788dbfc8e923.json
@@ -17,7 +17,8 @@
         1,
         10
       ],
-      "text": "Shaken morale",
+      "name": "Shaken morale",
+      "description": "<p>Breaking morale</p><p>Broken morale</p>",
       "_key": "!tables.results!999a788dbfc8e923.b51cd1166aac71f6",
       "_id": "b51cd1166aac71f6"
     },
@@ -26,7 +27,8 @@
         11,
         20
       ],
-      "text": "Minor casualties",
+      "name": "Minor casualties",
+      "description": "<p>Severe casualties</p><p>Horrible casualties</p>",
       "_key": "!tables.results!999a788dbfc8e923.aa40e66a3cc4d52d",
       "_id": "aa40e66a3cc4d52d"
     },
@@ -35,7 +37,8 @@
         21,
         30
       ],
-      "text": "Tangled rigging",
+      "name": "Tangled rigging",
+      "description": "<p>Fraying rigging</p><p>Broken rigging</p>",
       "_key": "!tables.results!999a788dbfc8e923.2e73552a6a56b866",
       "_id": "2e73552a6a56b866"
     },
@@ -44,7 +47,8 @@
         31,
         40
       ],
-      "text": "Weakened mast",
+      "name": "Weakened mast",
+      "description": "<p>Splintering mast</p><p>Broken mast</p>",
       "_key": "!tables.results!999a788dbfc8e923.bc65e3ffadc0e676",
       "_id": "bc65e3ffadc0e676"
     },
@@ -53,7 +57,8 @@
         41,
         50
       ],
-      "text": "Fouled sail",
+      "name": "Fouled sail",
+      "description": "<p>Torn sail</p><p>Mangled sail</p>",
       "_key": "!tables.results!999a788dbfc8e923.7b15f35f0fcc88ad",
       "_id": "7b15f35f0fcc88ad"
     },
@@ -62,7 +67,8 @@
         51,
         55
       ],
-      "text": "Damaged rudder",
+      "name": "Damaged rudder",
+      "description": "<p>Jammed rudder</p><p>Broken rudder</p>",
       "_key": "!tables.results!999a788dbfc8e923.c42a10dbf10fc560",
       "_id": "c42a10dbf10fc560"
     },
@@ -71,7 +77,8 @@
         56,
         65
       ],
-      "text": "Fire on deck",
+      "name": "Fire on deck",
+      "description": "<p>Fire below decks</p><p>Burning magazine</p>",
       "_key": "!tables.results!999a788dbfc8e923.3c690a35c289836f",
       "_id": "3c690a35c289836f"
     },
@@ -80,7 +87,8 @@
         66,
         75
       ],
-      "text": "Swamped deck",
+      "name": "Swamped deck",
+      "description": "<p>Flooded bilge</p><p>Keeling over</p>",
       "_key": "!tables.results!999a788dbfc8e923.1e25c067fccf52e8",
       "_id": "1e25c067fccf52e8"
     },
@@ -89,7 +97,8 @@
         76,
         80
       ],
-      "text": "Dismounted cannons",
+      "name": "Dismounted cannons",
+      "description": "<p>Damaged cannons</p><p>Destroyed cannons</p>",
       "_key": "!tables.results!999a788dbfc8e923.de542012e4b24ab3",
       "_id": "de542012e4b24ab3"
     },
@@ -98,7 +107,8 @@
         81,
         90
       ],
-      "text": "Battered hull",
+      "name": "Battered hull",
+      "description": "<p>Buckling hull</p><p>Breached hull</p>",
       "_key": "!tables.results!999a788dbfc8e923.2cfc376e24f5a708",
       "_id": "2cfc376e24f5a708"
     },
@@ -107,7 +117,8 @@
         91,
         95
       ],
-      "text": "Damaged compartment,  module, or support vehicle",
+      "name": "Damaged compartment,  module, or support vehicle",
+      "description": "<p>Failing compartment, module, or support vehicle</p><p>Broken compartment, module, or support vehicle</p>",
       "_key": "!tables.results!999a788dbfc8e923.15dd706a3dca2318",
       "_id": "15dd706a3dca2318"
     },

--- a/json-packs/sundered-isles-oracles/Ship_Size_67605afea51ca274.json
+++ b/json-packs/sundered-isles-oracles/Ship_Size_67605afea51ca274.json
@@ -17,7 +17,8 @@
         1,
         30
       ],
-      "text": "Small",
+      "name": "Small",
+      "description": "<p><ul>\n<li>Such as: Cutter, Sloop</li>\n<li>Rigging: One or two masts</li>\n<li>Crew: 5–25</li>\n<li>Rank: Troublesome or Dangerous</li>\n</ul></p>",
       "_key": "!tables.results!67605afea51ca274.7b8cfd87b2751ce3",
       "_id": "7b8cfd87b2751ce3"
     },
@@ -26,7 +27,8 @@
         31,
         60
       ],
-      "text": "Medium",
+      "name": "Medium",
+      "description": "<p><ul>\n<li>Such as: Corvette, Schooner</li>\n<li>Rigging: Two or three masts</li>\n<li>Crew: 25–50</li>\n<li>Rank: Dangerous or Formidable</li>\n</ul></p>",
       "_key": "!tables.results!67605afea51ca274.2baaee05b2be6a58",
       "_id": "2baaee05b2be6a58"
     },
@@ -35,7 +37,8 @@
         61,
         80
       ],
-      "text": "Large",
+      "name": "Large",
+      "description": "<p><ul>\n<li>Such as: Frigate, Galleon</li>\n<li>Rigging: Three or more masts</li>\n<li>Crew: 50–200</li>\n<li>Rank: Formidable or Extreme</li>\n</ul></p>",
       "_key": "!tables.results!67605afea51ca274.bd940d31d2e1de92",
       "_id": "bd940d31d2e1de92"
     },
@@ -44,7 +47,8 @@
         81,
         85
       ],
-      "text": "Colossal",
+      "name": "Colossal",
+      "description": "<p><ul>\n<li>Such as: Dreadnought, Titan</li>\n<li>Rigging: Four or more masts</li>\n<li>Crew: 200–500</li>\n<li>Rank: Extreme or Epic</li>\n</ul></p>",
       "_key": "!tables.results!67605afea51ca274.cad4762f39390725",
       "_id": "cad4762f39390725"
     },
@@ -53,7 +57,8 @@
         86,
         95
       ],
-      "text": "Flotilla",
+      "name": "Flotilla",
+      "description": "<p>Medium flagship and a few other ships</p>",
       "_key": "!tables.results!67605afea51ca274.adc7b9f78cf056b1",
       "_id": "adc7b9f78cf056b1"
     },
@@ -62,7 +67,8 @@
         96,
         99
       ],
-      "text": "Fleet",
+      "name": "Fleet",
+      "description": "<p>Large flagship and many other ships</p>",
       "_key": "!tables.results!67605afea51ca274.aca31226fb327e1d",
       "_id": "aca31226fb327e1d"
     },
@@ -71,7 +77,8 @@
         100,
         100
       ],
-      "text": "Armada",
+      "name": "Armada",
+      "description": "<p>Colossal flagship and countless other ships</p>",
       "_key": "!tables.results!67605afea51ca274.3f510b3e7501776a",
       "_id": "3f510b3e7501776a"
     }

--- a/json-packs/sundered-isles-oracles/Shipwreck_Location_9870230fb41c1fce.json
+++ b/json-packs/sundered-isles-oracles/Shipwreck_Location_9870230fb41c1fce.json
@@ -17,7 +17,8 @@
         1,
         25
       ],
-      "text": "Sea",
+      "name": "Sea",
+      "description": "<p>Amid open waters</p>",
       "_key": "!tables.results!9870230fb41c1fce.20a1ca9088666b5f",
       "_id": "20a1ca9088666b5f"
     },
@@ -26,7 +27,8 @@
         26,
         65
       ],
-      "text": "Shore",
+      "name": "Shore",
+      "description": "<p>Where the land meets the sea</p>",
       "_key": "!tables.results!9870230fb41c1fce.42781f9c4c5d4ff8",
       "_id": "42781f9c4c5d4ff8"
     },
@@ -35,7 +37,8 @@
         66,
         75
       ],
-      "text": "Sea Cave",
+      "name": "Sea Cave",
+      "description": "<p>Within a tidal cave</p>",
       "_key": "!tables.results!9870230fb41c1fce.68407e7a19dd3c2f",
       "_id": "68407e7a19dd3c2f"
     },
@@ -44,7 +47,8 @@
         76,
         85
       ],
-      "text": "Swamp",
+      "name": "Swamp",
+      "description": "<p>Mired in wetlands</p>",
       "_key": "!tables.results!9870230fb41c1fce.56f3eee559ee8681",
       "_id": "56f3eee559ee8681"
     },
@@ -53,7 +57,8 @@
         86,
         98
       ],
-      "text": "River",
+      "name": "River",
+      "description": "<p>Along an inland waterway</p>",
       "_key": "!tables.results!9870230fb41c1fce.6311800acb1ae5d5",
       "_id": "6311800acb1ae5d5"
     },
@@ -62,7 +67,8 @@
         99,
         100
       ],
-      "text": "Inland",
+      "name": "Inland",
+      "description": "<p>Away from the sea</p>",
       "_key": "!tables.results!9870230fb41c1fce.642dede90854084b",
       "_id": "642dede90854084b"
     }

--- a/json-packs/sundered-isles-oracles/Shore_4add7b7073d92003.json
+++ b/json-packs/sundered-isles-oracles/Shore_4add7b7073d92003.json
@@ -18,7 +18,8 @@
         1,
         3
       ],
-      "text": "Piracy",
+      "name": "Piracy",
+      "description": "<p>Pirate court, smuggler dens, taverns</p>",
       "_key": "!tables.results!4add7b7073d92003.2a5f7912a9bca17e",
       "_id": "2a5f7912a9bca17e"
     },
@@ -27,7 +28,8 @@
         4,
         6
       ],
-      "text": "Whaling",
+      "name": "Whaling",
+      "description": "<p>Whaling ships, processing plants, wharfs</p>",
       "_key": "!tables.results!4add7b7073d92003.41481f3de6a2d2af",
       "_id": "41481f3de6a2d2af"
     },
@@ -36,7 +38,8 @@
         7,
         8
       ],
-      "text": "Wrecking",
+      "name": "Wrecking",
+      "description": "<p>Ship graveyard</p>",
       "_key": "!tables.results!4add7b7073d92003.ae657c6b094639ae",
       "_id": "ae657c6b094639ae"
     },
@@ -45,7 +48,8 @@
         9,
         14
       ],
-      "text": "Shipbuilding",
+      "name": "Shipbuilding",
+      "description": "<p>Dry docks, lumber mills, shipwrights</p>",
       "_key": "!tables.results!4add7b7073d92003.57e78502f4ef5aee",
       "_id": "57e78502f4ef5aee"
     },
@@ -54,7 +58,8 @@
         15,
         22
       ],
-      "text": "Fishing",
+      "name": "Fishing",
+      "description": "<p>Boatwrights, fishmongers, net makers</p>",
       "_key": "!tables.results!4add7b7073d92003.8cb5cb44dd641e63",
       "_id": "8cb5cb44dd641e63"
     },
@@ -63,7 +68,8 @@
         23,
         24
       ],
-      "text": "Alcohol Production",
+      "name": "Alcohol Production",
+      "description": "<p>Breweries, distilleries, wineries</p>",
       "_key": "!tables.results!4add7b7073d92003.be08621cf1ef9c12",
       "_id": "be08621cf1ef9c12"
     },
@@ -72,7 +78,8 @@
         25,
         25
       ],
-      "text": "Archeology",
+      "name": "Archeology",
+      "description": "<p>Excavation sites, field camps, relic hunters</p>",
       "_key": "!tables.results!4add7b7073d92003.1667eee14709ce37",
       "_id": "1667eee14709ce37"
     },
@@ -81,7 +88,8 @@
         26,
         27
       ],
-      "text": "Crafts",
+      "name": "Crafts",
+      "description": "<p>Artisans, markets, workshops</p>",
       "_key": "!tables.results!4add7b7073d92003.4e71185c3d6e3b9d",
       "_id": "4e71185c3d6e3b9d"
     },
@@ -90,7 +98,8 @@
         28,
         29
       ],
-      "text": "Culture",
+      "name": "Culture",
+      "description": "<p>Archives, festivals, historical sites</p>",
       "_key": "!tables.results!4add7b7073d92003.84a362636e8b6e4e",
       "_id": "84a362636e8b6e4e"
     },
@@ -99,7 +108,8 @@
         30,
         35
       ],
-      "text": "Defense",
+      "name": "Defense",
+      "description": "<p>Armories, fortifications, militia</p>",
       "_key": "!tables.results!4add7b7073d92003.70ecdc2f0e6c0ec1",
       "_id": "70ecdc2f0e6c0ec1"
     },
@@ -108,7 +118,8 @@
         36,
         36
       ],
-      "text": "Dueling",
+      "name": "Dueling",
+      "description": "<p>Dueling grounds, fencing schools</p>",
       "_key": "!tables.results!4add7b7073d92003.0b0cfdc897c27380",
       "_id": "0b0cfdc897c27380"
     },
@@ -117,7 +128,8 @@
         37,
         38
       ],
-      "text": "Education",
+      "name": "Education",
+      "description": "<p>Libraries, universities</p>",
       "_key": "!tables.results!4add7b7073d92003.3d55946fdc7dc079",
       "_id": "3d55946fdc7dc079"
     },
@@ -126,7 +138,8 @@
         39,
         40
       ],
-      "text": "Entertainment",
+      "name": "Entertainment",
+      "description": "<p>Arenas, fairs, street performers, theaters</p>",
       "_key": "!tables.results!4add7b7073d92003.fc05ed097bfa8c85",
       "_id": "fc05ed097bfa8c85"
     },
@@ -135,7 +148,8 @@
         41,
         42
       ],
-      "text": "Espionage",
+      "name": "Espionage",
+      "description": "<p>Assassin guild, spy network</p>",
       "_key": "!tables.results!4add7b7073d92003.eb3aa28f6ae9d1c2",
       "_id": "eb3aa28f6ae9d1c2"
     },
@@ -144,7 +158,8 @@
         43,
         44
       ],
-      "text": "Exploration",
+      "name": "Exploration",
+      "description": "<p>Navigators guild, outfitters, scouts</p>",
       "_key": "!tables.results!4add7b7073d92003.625e7b15eecbb1e3",
       "_id": "625e7b15eecbb1e3"
     },
@@ -153,7 +168,8 @@
         45,
         48
       ],
-      "text": "Farming",
+      "name": "Farming",
+      "description": "<p>Fields, granaries, mills, orchards</p>",
       "_key": "!tables.results!4add7b7073d92003.842822694d0cd384",
       "_id": "842822694d0cd384"
     },
@@ -162,7 +178,8 @@
         49,
         54
       ],
-      "text": "Hospitality",
+      "name": "Hospitality",
+      "description": "<p>Bath houses, brothels, inns, taverns</p>",
       "_key": "!tables.results!4add7b7073d92003.ce15263930123391",
       "_id": "ce15263930123391"
     },
@@ -171,7 +188,8 @@
         55,
         55
       ],
-      "text": "Hunting",
+      "name": "Hunting",
+      "description": "<p>Animal trainers, taxidermists, tanners</p>",
       "_key": "!tables.results!4add7b7073d92003.7cb551913924981f",
       "_id": "7cb551913924981f"
     },
@@ -180,7 +198,8 @@
         56,
         57
       ],
-      "text": "Law",
+      "name": "Law",
+      "description": "<p>Courts, gallows, patrols, prisons</p>",
       "_key": "!tables.results!4add7b7073d92003.7a00faa6c6096f83",
       "_id": "7a00faa6c6096f83"
     },
@@ -189,7 +208,8 @@
         58,
         58
       ],
-      "text": "Livestock / horses",
+      "name": "Livestock / horses",
+      "description": "<p>Ranches, slaughterhouses, stables</p>",
       "_key": "!tables.results!4add7b7073d92003.219207ec8ce9ae20",
       "_id": "219207ec8ce9ae20"
     },
@@ -198,7 +218,8 @@
         59,
         59
       ],
-      "text": "Logging",
+      "name": "Logging",
+      "description": "<p>Logging camps, sawmills</p>",
       "_key": "!tables.results!4add7b7073d92003.ddf44ab16da59beb",
       "_id": "ddf44ab16da59beb"
     },
@@ -207,7 +228,8 @@
         60,
         61
       ],
-      "text": "Medicine",
+      "name": "Medicine",
+      "description": "<p>Apothecaries, herbalists, infirmaries</p>",
       "_key": "!tables.results!4add7b7073d92003.4311e2f30ca658d4",
       "_id": "4311e2f30ca658d4"
     },
@@ -216,7 +238,8 @@
         62,
         62
       ],
-      "text": "Metalworking",
+      "name": "Metalworking",
+      "description": "<p>Artificers, blacksmiths, forges</p>",
       "_key": "!tables.results!4add7b7073d92003.40998286a9e2f897",
       "_id": "40998286a9e2f897"
     },
@@ -225,7 +248,8 @@
         63,
         63
       ],
-      "text": "Mining",
+      "name": "Mining",
+      "description": "<p>Foundries, mines, smelters</p>",
       "_key": "!tables.results!4add7b7073d92003.6e8a00129ff34f28",
       "_id": "6e8a00129ff34f28"
     },
@@ -234,7 +258,8 @@
         64,
         65
       ],
-      "text": "Mysticism",
+      "name": "Mysticism",
+      "description": "<p>Alchemists, curio dealers, enclaves, mystics</p>",
       "_key": "!tables.results!4add7b7073d92003.79d4d267b53d26f8",
       "_id": "79d4d267b53d26f8"
     },
@@ -243,7 +268,8 @@
         66,
         66
       ],
-      "text": "Nature",
+      "name": "Nature",
+      "description": "<p>Animal sanctuaries, gardens, groves</p>",
       "_key": "!tables.results!4add7b7073d92003.2dd8fd5626b7002e",
       "_id": "2dd8fd5626b7002e"
     },
@@ -252,7 +278,8 @@
         67,
         68
       ],
-      "text": "Religion",
+      "name": "Religion",
+      "description": "<p>Monasteries, sacred sites, temples</p>",
       "_key": "!tables.results!4add7b7073d92003.c4bba73df2bc0975",
       "_id": "c4bba73df2bc0975"
     },
@@ -261,7 +288,8 @@
         69,
         70
       ],
-      "text": "Science",
+      "name": "Science",
+      "description": "<p>Academies, naturalist guild, observatories</p>",
       "_key": "!tables.results!4add7b7073d92003.2df6943e8f439f73",
       "_id": "2df6943e8f439f73"
     },
@@ -270,7 +298,8 @@
         71,
         73
       ],
-      "text": "Smuggling",
+      "name": "Smuggling",
+      "description": "<p>Black market, fences, smugglers</p>",
       "_key": "!tables.results!4add7b7073d92003.67d9ce82b1dc76bc",
       "_id": "67d9ce82b1dc76bc"
     },
@@ -279,7 +308,8 @@
         74,
         75
       ],
-      "text": "Society",
+      "name": "Society",
+      "description": "<p>Balls, boutiques, social clubs, tailors</p>",
       "_key": "!tables.results!4add7b7073d92003.5c0314b31148fffb",
       "_id": "5c0314b31148fffb"
     },
@@ -288,7 +318,8 @@
         76,
         77
       ],
-      "text": "Statecraft",
+      "name": "Statecraft",
+      "description": "<p>Embassies, envoys, court or council</p>",
       "_key": "!tables.results!4add7b7073d92003.8e925b564afca405",
       "_id": "8e925b564afca405"
     },
@@ -297,7 +328,8 @@
         78,
         78
       ],
-      "text": "Stoneworking",
+      "name": "Stoneworking",
+      "description": "<p>Masons, quarries, stone yards</p>",
       "_key": "!tables.results!4add7b7073d92003.1b502dc6f7ec2781",
       "_id": "1b502dc6f7ec2781"
     },
@@ -306,7 +338,8 @@
         79,
         86
       ],
-      "text": "Trade",
+      "name": "Trade",
+      "description": "<p>Auction house, markets, merchant guild</p>",
       "_key": "!tables.results!4add7b7073d92003.0de7e7695a2a6fe7",
       "_id": "0de7e7695a2a6fe7"
     },
@@ -315,7 +348,8 @@
         87,
         89
       ],
-      "text": "Vices",
+      "name": "Vices",
+      "description": "<p>Brothels, drug dens, gambling halls, taverns</p>",
       "_key": "!tables.results!4add7b7073d92003.d8fb13ff0b11b7af",
       "_id": "d8fb13ff0b11b7af"
     },
@@ -324,7 +358,8 @@
         90,
         93
       ],
-      "text": "Warfare",
+      "name": "Warfare",
+      "description": "<p>Armies or fleets, command post, forts</p>",
       "_key": "!tables.results!4add7b7073d92003.565e8b413cdd2fcf",
       "_id": "565e8b413cdd2fcf"
     },
@@ -333,7 +368,8 @@
         94,
         95
       ],
-      "text": "Weaponry",
+      "name": "Weaponry",
+      "description": "<p>Cannon foundries, gunsmiths, powder mills</p>",
       "_key": "!tables.results!4add7b7073d92003.779eb052d40bac32",
       "_id": "779eb052d40bac32"
     },

--- a/json-packs/sundered-isles-oracles/Size_a9a549a0d501f321.json
+++ b/json-packs/sundered-isles-oracles/Size_a9a549a0d501f321.json
@@ -17,7 +17,8 @@
         1,
         30
       ],
-      "text": "Small",
+      "name": "Small",
+      "description": "<p>Hour or two</p>",
       "_key": "!tables.results!a9a549a0d501f321.bc00309536e492b7",
       "_id": "bc00309536e492b7"
     },
@@ -26,7 +27,8 @@
         31,
         70
       ],
-      "text": "Medium",
+      "name": "Medium",
+      "description": "<p>Several hours</p>",
       "_key": "!tables.results!a9a549a0d501f321.a91339a974db8656",
       "_id": "a91339a974db8656"
     },
@@ -35,7 +37,8 @@
         71,
         90
       ],
-      "text": "Large",
+      "name": "Large",
+      "description": "<p>Days</p>",
       "_key": "!tables.results!a9a549a0d501f321.e0a0fca79763c8fc",
       "_id": "e0a0fca79763c8fc"
     },
@@ -44,7 +47,8 @@
         91,
         100
       ],
-      "text": "Vast",
+      "name": "Vast",
+      "description": "<p>Weeks</p>",
       "_key": "!tables.results!a9a549a0d501f321.5a7ba01b7f0bf5a9",
       "_id": "5a7ba01b7f0bf5a9"
     }

--- a/json-packs/sundered-isles-oracles/Small_a1129f68e66db32a.json
+++ b/json-packs/sundered-isles-oracles/Small_a1129f68e66db32a.json
@@ -17,7 +17,8 @@
         1,
         80
       ],
-      "text": "Trifle",
+      "name": "Trifle",
+      "description": "<p>One @Compendium[foundry-ironsworn.sunderedislesoracles.baaff21d3f6897ac]{Precious Item}</p>",
       "_key": "!tables.results!a1129f68e66db32a.504c11c41c608461",
       "_id": "504c11c41c608461"
     },
@@ -26,7 +27,8 @@
         81,
         100
       ],
-      "text": "Stash",
+      "name": "Stash",
+      "description": "<p>Roll the action die and reveal that many @Compendium[foundry-ironsworn.sunderedislesoracles.baaff21d3f6897ac]{Precious Items}</p>",
       "_key": "!tables.results!a1129f68e66db32a.7964bd68183f4a22",
       "_id": "7964bd68183f4a22"
     }

--- a/json-packs/sundered-isles-oracles/Societies_5de0373154d7ce38.json
+++ b/json-packs/sundered-isles-oracles/Societies_5de0373154d7ce38.json
@@ -17,7 +17,8 @@
         1,
         10
       ],
-      "text": "Akiya",
+      "name": "Akiya",
+      "description": "<p>Coalition of clans known for their sleek and speedy ships. They gather each year to celebrate the ebb of the storm season, and hang rows of vibrantly colored flags from their rigging to honor the dead.</p>",
       "_key": "!tables.results!5de0373154d7ce38.f2ef490ff9470ec3",
       "_id": "f2ef490ff9470ec3"
     },
@@ -26,7 +27,8 @@
         11,
         20
       ],
-      "text": "Arsu / Azizos",
+      "name": "Arsu / Azizos",
+      "description": "<p>Once a single tribe, the loyalty of these people is divided between two rulers descended from rival heirs. They often war against one another, but now have a fragile alliance against a mutual foe.</p>",
       "_key": "!tables.results!5de0373154d7ce38.62169a9ece3f28f5",
       "_id": "62169a9ece3f28f5"
     },
@@ -35,7 +37,8 @@
         21,
         30
       ],
-      "text": "Kai",
+      "name": "Kai",
+      "description": "<p>Seagoing folk who build their homes and ships from luminous glimmerwood. This resource is harvested from the coastal swamps of their homeland, an environment under threat of destruction.</p>",
       "_key": "!tables.results!5de0373154d7ce38.6f3b219c66dcaa92",
       "_id": "6f3b219c66dcaa92"
     },
@@ -44,7 +47,8 @@
         31,
         40
       ],
-      "text": "Khazeera",
+      "name": "Khazeera",
+      "description": "<p>Warring people who inhabit an enduring city-state at the edge of an active volcano. Molten rock and slag from this sacred volcano is used in the heated shot for their destructive cannonry, and their soldiers wield blades forged in its fires.</p>",
       "_key": "!tables.results!5de0373154d7ce38.32cf20eaa9268bf3",
       "_id": "32cf20eaa9268bf3"
     },
@@ -53,7 +57,8 @@
         41,
         50
       ],
-      "text": "Morien",
+      "name": "Morien",
+      "description": "<p>Seafolk who forsake cannons and muskets. They sail low-profile catamarans and set upon their foes with stealthy ambushes.</p>",
       "_key": "!tables.results!5de0373154d7ce38.625c2dca8c173547",
       "_id": "625c2dca8c173547"
     },
@@ -62,7 +67,8 @@
         51,
         60
       ],
-      "text": "Otani",
+      "name": "Otani",
+      "description": "<p>People who dwell in island highlands. They largely forsake the sea, but send out seafaring envoys to build ties with other communities.</p>",
       "_key": "!tables.results!5de0373154d7ce38.dad9a60e5b0acfc4",
       "_id": "dad9a60e5b0acfc4"
     },
@@ -71,7 +77,8 @@
         61,
         70
       ],
-      "text": "Sularia",
+      "name": "Sularia",
+      "description": "<p>Beast-bonded people who commune with magnificent elder rays. They are sworn to protect the seas from hunters and despoilers.</p>",
       "_key": "!tables.results!5de0373154d7ce38.972561b83cff9cb7",
       "_id": "972561b83cff9cb7"
     },
@@ -80,7 +87,8 @@
         71,
         80
       ],
-      "text": "Talan",
+      "name": "Talan",
+      "description": "<p>Scrappy seafolk who range far among the islands. They maintain a floating trade settlement open to any who visit with shuttered gunports.</p>",
       "_key": "!tables.results!5de0373154d7ce38.533ca98da1bdb9ef",
       "_id": "533ca98da1bdb9ef"
     },
@@ -89,7 +97,8 @@
         81,
         90
       ],
-      "text": "Thalassa",
+      "name": "Thalassa",
+      "description": "<p>Recent refugees of a cataclysmic war. They are desperate to gain allies against the enemy they believe will follow them to the isles.</p>",
       "_key": "!tables.results!5de0373154d7ce38.11b357f8afe81b36",
       "_id": "11b357f8afe81b36"
     },
@@ -98,7 +107,8 @@
         91,
         100
       ],
-      "text": "Uktanu",
+      "name": "Uktanu",
+      "description": "<p>Reclusive people who trace their lineage to the first inhabitants of the isles. They are sworn to protect the sacred sites and relics of their ancient forebears.</p>",
       "_key": "!tables.results!5de0373154d7ce38.43ae1fd6bb12f520",
       "_id": "43ae1fd6bb12f520"
     }

--- a/json-packs/sundered-isles-oracles/Terrain_abe895cf5a5a3fd1.json
+++ b/json-packs/sundered-isles-oracles/Terrain_abe895cf5a5a3fd1.json
@@ -17,7 +17,8 @@
         1,
         10
       ],
-      "text": "Sodden",
+      "name": "Sodden",
+      "description": "<p>Low-lying wetlands</p>",
       "_key": "!tables.results!abe895cf5a5a3fd1.8d3792ec507e05a4",
       "_id": "8d3792ec507e05a4"
     },
@@ -26,7 +27,8 @@
         11,
         20
       ],
-      "text": "Flat",
+      "name": "Flat",
+      "description": "<p>Expansive plains</p>",
       "_key": "!tables.results!abe895cf5a5a3fd1.024aab4a2bf59613",
       "_id": "024aab4a2bf59613"
     },
@@ -35,7 +37,8 @@
         21,
         30
       ],
-      "text": "Rolling",
+      "name": "Rolling",
+      "description": "<p>Hills or dunes</p>",
       "_key": "!tables.results!abe895cf5a5a3fd1.1adb7a945f493c37",
       "_id": "1adb7a945f493c37"
     },
@@ -44,7 +47,8 @@
         31,
         40
       ],
-      "text": "Elevated",
+      "name": "Elevated",
+      "description": "<p>Sheer cliffs rising to a mesa or plateau</p>",
       "_key": "!tables.results!abe895cf5a5a3fd1.62522d55a07b5189",
       "_id": "62522d55a07b5189"
     },
@@ -53,7 +57,8 @@
         41,
         50
       ],
-      "text": "Sloped",
+      "name": "Sloped",
+      "description": "<p>Terrain rising gradually to a prominent ridge or peak</p>",
       "_key": "!tables.results!abe895cf5a5a3fd1.5929d11dba29fc1b",
       "_id": "5929d11dba29fc1b"
     },
@@ -62,7 +67,8 @@
         51,
         70
       ],
-      "text": "Rugged",
+      "name": "Rugged",
+      "description": "<p>Varied terrain of craggy hills and dramatic rock formations</p>",
       "_key": "!tables.results!abe895cf5a5a3fd1.dae144098d872121",
       "_id": "dae144098d872121"
     },
@@ -71,7 +77,8 @@
         71,
         90
       ],
-      "text": "Mountainous",
+      "name": "Mountainous",
+      "description": "<p>Imposing heights and deep valleys</p>",
       "_key": "!tables.results!abe895cf5a5a3fd1.a7cd8690f7c608c0",
       "_id": "a7cd8690f7c608c0"
     },
@@ -80,7 +87,8 @@
         91,
         100
       ],
-      "text": "Volcanic",
+      "name": "Volcanic",
+      "description": "<p>Active volcanoes and lava fields</p>",
       "_key": "!tables.results!abe895cf5a5a3fd1.7963f3174e2c2e49",
       "_id": "7963f3174e2c2e49"
     }

--- a/json-packs/sundered-isles-oracles/The_Cursed_ec7e88ba5f37d38e.json
+++ b/json-packs/sundered-isles-oracles/The_Cursed_ec7e88ba5f37d38e.json
@@ -17,7 +17,8 @@
         1,
         10
       ],
-      "text": "Acheron’s Armada",
+      "name": "Acheron’s Armada",
+      "description": "<p>Ghost ships under the command of an undead imperial admiral. This vengeful wraith seeks to carry on the war that cost them their life.</p>",
       "_key": "!tables.results!ec7e88ba5f37d38e.348c11baa158642d",
       "_id": "348c11baa158642d"
     },
@@ -26,7 +27,8 @@
         11,
         20
       ],
-      "text": "Blighthulk",
+      "name": "Blighthulk",
+      "description": "<p>Titanic ship cursed with incessant corrosion and rot. Its crew must constantly add wood, sails, and fittings from salvaged wrecks and defeated foes into this massive and unnerving chimera-craft.</p>",
       "_key": "!tables.results!ec7e88ba5f37d38e.d2fa8843ebf28be8",
       "_id": "d2fa8843ebf28be8"
     },
@@ -35,7 +37,8 @@
         21,
         30
       ],
-      "text": "Bloodmarked League",
+      "name": "Bloodmarked League",
+      "description": "<p>An order of occultists, each bearing a blood-red tattoo on their wrist, who are dedicated to hunting and banishing the restless dead.</p>",
       "_key": "!tables.results!ec7e88ba5f37d38e.fb32d1728f53303b",
       "_id": "fb32d1728f53303b"
     },
@@ -44,7 +47,8 @@
         31,
         40
       ],
-      "text": "Brineblessed",
+      "name": "Brineblessed",
+      "description": "<p>Cult of sailors cursed by a drowned god. Their bodies and ships are corrupted by horrible aspects of the sea—riddled with barnacles, rotting seaweed, and brackish slime.</p>",
       "_key": "!tables.results!ec7e88ba5f37d38e.66893f76f92a0c16",
       "_id": "66893f76f92a0c16"
     },
@@ -53,7 +57,8 @@
         41,
         50
       ],
-      "text": "Carrion Fleet",
+      "name": "Carrion Fleet",
+      "description": "<p>Fleet under the command of a necromancer. The dreadful ships are festooned with bones and bloodied sails, crewed by skeletal undead, and escorted by the risen corpse of a slain behemoth.</p>",
       "_key": "!tables.results!ec7e88ba5f37d38e.3655b22958a0b1b0",
       "_id": "3655b22958a0b1b0"
     },
@@ -62,7 +67,8 @@
         51,
         60
       ],
-      "text": "Fireships",
+      "name": "Fireships",
+      "description": "<p>Ships burning with unquenchable fire and crewed by bone-scorched undead. The flagship was set aflame by marauders in a port attack, and its cursed commander seeks to spread the fire to other vessels and expand the accursed fleet.</p>",
       "_key": "!tables.results!ec7e88ba5f37d38e.e217892bd700d97c",
       "_id": "e217892bd700d97c"
     },
@@ -71,7 +77,8 @@
         61,
         70
       ],
-      "text": "Forgeborn",
+      "name": "Forgeborn",
+      "description": "<p>Uncanny metal automatons who are said to embody the stolen souls of dead mariners. They cruise the isles in ironclad ships.</p>",
       "_key": "!tables.results!ec7e88ba5f37d38e.7d684dcbadb444f5",
       "_id": "7d684dcbadb444f5"
     },
@@ -80,7 +87,8 @@
         71,
         80
       ],
-      "text": "Gilded Fleet",
+      "name": "Gilded Fleet",
+      "description": "<p>Pirates who seized a forbidden treasure. They are cursed with a ceaseless, insatiable hunger to hoard riches from all corners of the isles.</p>",
       "_key": "!tables.results!ec7e88ba5f37d38e.6c1c2bf1c1da8c3f",
       "_id": "6c1c2bf1c1da8c3f"
     },
@@ -89,7 +97,8 @@
         81,
         90
       ],
-      "text": "Nightships",
+      "name": "Nightships",
+      "description": "<p>Dread ships of the vampire clans, shrouded in an eternal gloom. Their undead crews leave wrecks and blood-drained corpses in their wake.</p>",
       "_key": "!tables.results!ec7e88ba5f37d38e.230c51faee742226",
       "_id": "230c51faee742226"
     },
@@ -98,7 +107,8 @@
         91,
         100
       ],
-      "text": "Tidebound",
+      "name": "Tidebound",
+      "description": "<p>Devout cultists who were granted eternal life in exchange for unending service to their patron sea god. They must not tarry on land or at anchor, lest death catches up with them to take its toll.</p>",
       "_key": "!tables.results!ec7e88ba5f37d38e.2e549adc1b1184b7",
       "_id": "2e549adc1b1184b7"
     }

--- a/json-packs/sundered-isles-oracles/Treasure_Repository_4f7dcda6a4c1453a.json
+++ b/json-packs/sundered-isles-oracles/Treasure_Repository_4f7dcda6a4c1453a.json
@@ -17,7 +17,8 @@
         1,
         25
       ],
-      "text": "Small",
+      "name": "Small",
+      "description": "<p>Strongbox; desk drawer; bag or pouch</p>",
       "_key": "!tables.results!4f7dcda6a4c1453a.598d5441e27496b7",
       "_id": "598d5441e27496b7"
     },
@@ -26,7 +27,8 @@
         26,
         70
       ],
-      "text": "Medium",
+      "name": "Medium",
+      "description": "<p>Chest; crate; ship cabin; cave alcove</p>",
       "_key": "!tables.results!4f7dcda6a4c1453a.d639d6ac609e5064",
       "_id": "d639d6ac609e5064"
     },
@@ -35,7 +37,8 @@
         71,
         95
       ],
-      "text": "Large",
+      "name": "Large",
+      "description": "<p>Cargo hold; strongroom; cave chamber</p>",
       "_key": "!tables.results!4f7dcda6a4c1453a.688162d93755ba82",
       "_id": "688162d93755ba82"
     },
@@ -44,7 +47,8 @@
         96,
         100
       ],
-      "text": "Vast",
+      "name": "Vast",
+      "description": "<p>Storehouse; great hall; cavern vault</p>",
       "_key": "!tables.results!4f7dcda6a4c1453a.e85e17398c8e59f6",
       "_id": "e85e17398c8e59f6"
     }

--- a/json-packs/sundered-isles-oracles/Vast_5aa4252918a89b8f.json
+++ b/json-packs/sundered-isles-oracles/Vast_5aa4252918a89b8f.json
@@ -17,7 +17,8 @@
         1,
         10
       ],
-      "text": "Trifle",
+      "name": "Trifle",
+      "description": "<p>One @Compendium[foundry-ironsworn.sunderedislesoracles.baaff21d3f6897ac]{Precious Item}</p>",
       "_key": "!tables.results!5aa4252918a89b8f.2689e19780dbcf71",
       "_id": "2689e19780dbcf71"
     },
@@ -26,7 +27,8 @@
         11,
         93
       ],
-      "text": "Stash",
+      "name": "Stash",
+      "description": "<p>Roll the action die and reveal that many @Compendium[foundry-ironsworn.sunderedislesoracles.baaff21d3f6897ac]{Precious Items}</p>",
       "_key": "!tables.results!5aa4252918a89b8f.80b892e0d121659a",
       "_id": "80b892e0d121659a"
     },
@@ -35,7 +37,8 @@
         94,
         98
       ],
-      "text": "Trove",
+      "name": "Trove",
+      "description": "<p>Bountiful riches</p>",
       "_key": "!tables.results!5aa4252918a89b8f.79962a45dd32132c",
       "_id": "79962a45dd32132c"
     },
@@ -44,7 +47,8 @@
         99,
         100
       ],
-      "text": "Hoard",
+      "name": "Hoard",
+      "description": "<p>Immeasurable riches</p>",
       "_key": "!tables.results!5aa4252918a89b8f.6327ec11ffd2afb3",
       "_id": "6327ec11ffd2afb3"
     }

--- a/json-packs/sundered-isles-oracles/Waterside_aa174ccdac648c03.json
+++ b/json-packs/sundered-isles-oracles/Waterside_aa174ccdac648c03.json
@@ -18,7 +18,8 @@
         1,
         3
       ],
-      "text": "Shipbuilding",
+      "name": "Shipbuilding",
+      "description": "<p>Dry docks, lumber mills, shipwrights</p>",
       "_key": "!tables.results!aa174ccdac648c03.3fb4cd51238c0f36",
       "_id": "3fb4cd51238c0f36"
     },
@@ -27,7 +28,8 @@
         4,
         11
       ],
-      "text": "Fishing",
+      "name": "Fishing",
+      "description": "<p>Boatwrights, fishmongers, net makers</p>",
       "_key": "!tables.results!aa174ccdac648c03.14a88ce7f3d89950",
       "_id": "14a88ce7f3d89950"
     },
@@ -36,7 +38,8 @@
         12,
         13
       ],
-      "text": "Alcohol Production",
+      "name": "Alcohol Production",
+      "description": "<p>Breweries, distilleries, wineries</p>",
       "_key": "!tables.results!aa174ccdac648c03.498ffa6acaf1fd2b",
       "_id": "498ffa6acaf1fd2b"
     },
@@ -45,7 +48,8 @@
         14,
         14
       ],
-      "text": "Archeology",
+      "name": "Archeology",
+      "description": "<p>Excavation sites, field camps, relic hunters</p>",
       "_key": "!tables.results!aa174ccdac648c03.141a22c30badcf84",
       "_id": "141a22c30badcf84"
     },
@@ -54,7 +58,8 @@
         15,
         16
       ],
-      "text": "Crafts",
+      "name": "Crafts",
+      "description": "<p>Artisans, markets, workshops</p>",
       "_key": "!tables.results!aa174ccdac648c03.97b701e9a8e3c35d",
       "_id": "97b701e9a8e3c35d"
     },
@@ -63,7 +68,8 @@
         17,
         20
       ],
-      "text": "Culture",
+      "name": "Culture",
+      "description": "<p>Archives, festivals, historical sites</p>",
       "_key": "!tables.results!aa174ccdac648c03.f17269f1213917f8",
       "_id": "f17269f1213917f8"
     },
@@ -72,7 +78,8 @@
         21,
         24
       ],
-      "text": "Defense",
+      "name": "Defense",
+      "description": "<p>Armories, fortifications, militia</p>",
       "_key": "!tables.results!aa174ccdac648c03.4bf8e754754614ae",
       "_id": "4bf8e754754614ae"
     },
@@ -81,7 +88,8 @@
         25,
         25
       ],
-      "text": "Dueling",
+      "name": "Dueling",
+      "description": "<p>Dueling grounds, fencing schools</p>",
       "_key": "!tables.results!aa174ccdac648c03.b256a82aa3c8cd4c",
       "_id": "b256a82aa3c8cd4c"
     },
@@ -90,7 +98,8 @@
         26,
         27
       ],
-      "text": "Education",
+      "name": "Education",
+      "description": "<p>Libraries, universities</p>",
       "_key": "!tables.results!aa174ccdac648c03.ee40ec8077e6c0ff",
       "_id": "ee40ec8077e6c0ff"
     },
@@ -99,7 +108,8 @@
         28,
         28
       ],
-      "text": "Entertainment",
+      "name": "Entertainment",
+      "description": "<p>Arenas, fairs, street performers, theaters</p>",
       "_key": "!tables.results!aa174ccdac648c03.8d6c23446ecd4a1f",
       "_id": "8d6c23446ecd4a1f"
     },
@@ -108,7 +118,8 @@
         29,
         29
       ],
-      "text": "Espionage",
+      "name": "Espionage",
+      "description": "<p>Assassin guild, spy network</p>",
       "_key": "!tables.results!aa174ccdac648c03.1555b422700b3158",
       "_id": "1555b422700b3158"
     },
@@ -117,7 +128,8 @@
         30,
         31
       ],
-      "text": "Exploration",
+      "name": "Exploration",
+      "description": "<p>Navigators guild, outfitters, scouts</p>",
       "_key": "!tables.results!aa174ccdac648c03.c871b2d0609dcebd",
       "_id": "c871b2d0609dcebd"
     },
@@ -126,7 +138,8 @@
         32,
         39
       ],
-      "text": "Farming",
+      "name": "Farming",
+      "description": "<p>Fields, granaries, mills, orchards</p>",
       "_key": "!tables.results!aa174ccdac648c03.1abdfa14939186eb",
       "_id": "1abdfa14939186eb"
     },
@@ -135,7 +148,8 @@
         40,
         43
       ],
-      "text": "Hospitality",
+      "name": "Hospitality",
+      "description": "<p>Bath houses, brothels, inns, taverns</p>",
       "_key": "!tables.results!aa174ccdac648c03.340e22456390395b",
       "_id": "340e22456390395b"
     },
@@ -144,7 +158,8 @@
         44,
         46
       ],
-      "text": "Hunting",
+      "name": "Hunting",
+      "description": "<p>Animal trainers, taxidermists, tanners</p>",
       "_key": "!tables.results!aa174ccdac648c03.0fa5605c5b6e7746",
       "_id": "0fa5605c5b6e7746"
     },
@@ -153,7 +168,8 @@
         47,
         47
       ],
-      "text": "Law",
+      "name": "Law",
+      "description": "<p>Courts, gallows, patrols, prisons</p>",
       "_key": "!tables.results!aa174ccdac648c03.fc951873c34e0313",
       "_id": "fc951873c34e0313"
     },
@@ -162,7 +178,8 @@
         48,
         51
       ],
-      "text": "Livestock / horses",
+      "name": "Livestock / horses",
+      "description": "<p>Ranches, slaughterhouses, stables</p>",
       "_key": "!tables.results!aa174ccdac648c03.7cdf0ed6babdcf60",
       "_id": "7cdf0ed6babdcf60"
     },
@@ -171,7 +188,8 @@
         52,
         57
       ],
-      "text": "Logging",
+      "name": "Logging",
+      "description": "<p>Logging camps, sawmills</p>",
       "_key": "!tables.results!aa174ccdac648c03.0d6e4a807ced22fd",
       "_id": "0d6e4a807ced22fd"
     },
@@ -180,7 +198,8 @@
         58,
         59
       ],
-      "text": "Medicine",
+      "name": "Medicine",
+      "description": "<p>Apothecaries, herbalists, infirmaries</p>",
       "_key": "!tables.results!aa174ccdac648c03.02752f1120d3e065",
       "_id": "02752f1120d3e065"
     },
@@ -189,7 +208,8 @@
         60,
         63
       ],
-      "text": "Metalworking",
+      "name": "Metalworking",
+      "description": "<p>Artificers, blacksmiths, forges</p>",
       "_key": "!tables.results!aa174ccdac648c03.c44e738791b90be7",
       "_id": "c44e738791b90be7"
     },
@@ -198,7 +218,8 @@
         64,
         67
       ],
-      "text": "Mining",
+      "name": "Mining",
+      "description": "<p>Foundries, mines, smelters</p>",
       "_key": "!tables.results!aa174ccdac648c03.46656ed76137ac2c",
       "_id": "46656ed76137ac2c"
     },
@@ -207,7 +228,8 @@
         68,
         69
       ],
-      "text": "Mysticism",
+      "name": "Mysticism",
+      "description": "<p>Alchemists, curio dealers, enclaves, mystics</p>",
       "_key": "!tables.results!aa174ccdac648c03.943682c1fac5902b",
       "_id": "943682c1fac5902b"
     },
@@ -216,7 +238,8 @@
         70,
         71
       ],
-      "text": "Nature",
+      "name": "Nature",
+      "description": "<p>Animal sanctuaries, gardens, groves</p>",
       "_key": "!tables.results!aa174ccdac648c03.566d1edb7c5af6c5",
       "_id": "566d1edb7c5af6c5"
     },
@@ -225,7 +248,8 @@
         72,
         73
       ],
-      "text": "Religion",
+      "name": "Religion",
+      "description": "<p>Monasteries, sacred sites, temples</p>",
       "_key": "!tables.results!aa174ccdac648c03.972ce1daca2d631d",
       "_id": "972ce1daca2d631d"
     },
@@ -234,7 +258,8 @@
         74,
         75
       ],
-      "text": "Science",
+      "name": "Science",
+      "description": "<p>Academies, naturalist guild, observatories</p>",
       "_key": "!tables.results!aa174ccdac648c03.14b475b8e2163e4a",
       "_id": "14b475b8e2163e4a"
     },
@@ -243,7 +268,8 @@
         76,
         77
       ],
-      "text": "Smuggling",
+      "name": "Smuggling",
+      "description": "<p>Black market, fences, smugglers</p>",
       "_key": "!tables.results!aa174ccdac648c03.2b3184e83435025d",
       "_id": "2b3184e83435025d"
     },
@@ -252,7 +278,8 @@
         78,
         78
       ],
-      "text": "Society",
+      "name": "Society",
+      "description": "<p>Balls, boutiques, social clubs, tailors</p>",
       "_key": "!tables.results!aa174ccdac648c03.9c569d91fadf6174",
       "_id": "9c569d91fadf6174"
     },
@@ -261,7 +288,8 @@
         79,
         79
       ],
-      "text": "Statecraft",
+      "name": "Statecraft",
+      "description": "<p>Embassies, envoys, court or council</p>",
       "_key": "!tables.results!aa174ccdac648c03.c701110634f8e593",
       "_id": "c701110634f8e593"
     },
@@ -270,7 +298,8 @@
         80,
         83
       ],
-      "text": "Stoneworking",
+      "name": "Stoneworking",
+      "description": "<p>Masons, quarries, stone yards</p>",
       "_key": "!tables.results!aa174ccdac648c03.1e43359dfccc6c25",
       "_id": "1e43359dfccc6c25"
     },
@@ -279,7 +308,8 @@
         84,
         89
       ],
-      "text": "Trade",
+      "name": "Trade",
+      "description": "<p>Auction house, markets, merchant guild</p>",
       "_key": "!tables.results!aa174ccdac648c03.3d3f68e9db46847e",
       "_id": "3d3f68e9db46847e"
     },
@@ -288,7 +318,8 @@
         90,
         91
       ],
-      "text": "Vices",
+      "name": "Vices",
+      "description": "<p>Brothels, drug dens, gambling halls, taverns</p>",
       "_key": "!tables.results!aa174ccdac648c03.2f6057bc920ed38e",
       "_id": "2f6057bc920ed38e"
     },
@@ -297,7 +328,8 @@
         92,
         93
       ],
-      "text": "Warfare",
+      "name": "Warfare",
+      "description": "<p>Armies or fleets, command post, forts</p>",
       "_key": "!tables.results!aa174ccdac648c03.5e19fe058170b9b8",
       "_id": "5e19fe058170b9b8"
     },
@@ -306,7 +338,8 @@
         94,
         95
       ],
-      "text": "Weaponry",
+      "name": "Weaponry",
+      "description": "<p>Cannon foundries, gunsmiths, powder mills</p>",
       "_key": "!tables.results!aa174ccdac648c03.380d19b5aca38be8",
       "_id": "380d19b5aca38be8"
     },

--- a/json-packs/sundered-isles-oracles/Your_Persona_d292ed147d36f2f4.json
+++ b/json-packs/sundered-isles-oracles/Your_Persona_d292ed147d36f2f4.json
@@ -17,7 +17,8 @@
         1,
         3
       ],
-      "text": "Apothecary",
+      "name": "Apothecary",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.4fafc93fdd8873ce]{Healer}, @Compendium[foundry-ironsworn.sunderedislesassets.19ad0bd745c765c5]{Peddler}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.a1a9e110d161da71",
       "_id": "a1a9e110d161da71"
     },
@@ -26,7 +27,8 @@
         4,
         5
       ],
-      "text": "Apprentice",
+      "name": "Apprentice",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.4314d57a351c8f63]{Shipwright}, @Compendium[foundry-ironsworn.sunderedislesassets.54ffc0e2d8e514b4]{Urchin}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.bb7b39c2a1a49ee8",
       "_id": "bb7b39c2a1a49ee8"
     },
@@ -35,7 +37,8 @@
         6,
         7
       ],
-      "text": "Assassin",
+      "name": "Assassin",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.82cb2564aae5bf0f]{Blademaster}, @Compendium[foundry-ironsworn.starforgedassets.9e8a91f52b96c95b]{Bounty Hunter}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.aae39e2e6c92940b",
       "_id": "aae39e2e6c92940b"
     },
@@ -44,7 +47,8 @@
         8,
         9
       ],
-      "text": "Beast Hunter",
+      "name": "Beast Hunter",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.c26627a81dd578bd]{Harpooner}, @Compendium[foundry-ironsworn.starforgedassets.b01dc7301d7d8fb3]{Slayer}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.b4a160a9cc22a927",
       "_id": "b4a160a9cc22a927"
     },
@@ -53,7 +57,8 @@
         10,
         12
       ],
-      "text": "Blockade Runner",
+      "name": "Blockade Runner",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.87222132d6c0379b]{Courier}, @Compendium[foundry-ironsworn.starforgedassets.4692e18baff8bd18]{Navigator}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.8b81ab18ab36d719",
       "_id": "8b81ab18ab36d719"
     },
@@ -62,7 +67,8 @@
         13,
         15
       ],
-      "text": "Brigand",
+      "name": "Brigand",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.bdfce3738749baff]{Pistoleer}, @Compendium[foundry-ironsworn.starforgedassets.d7fbe5fded75531c]{Scoundrel}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.650e0581f2fb9012",
       "_id": "650e0581f2fb9012"
     },
@@ -71,7 +77,8 @@
         16,
         17
       ],
-      "text": "Buccaneer",
+      "name": "Buccaneer",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.68d3a763f99b8b77]{Swashbuckler}, @Compendium[foundry-ironsworn.sunderedislesassets.3989ffe5d08261bc]{Pirate Captain}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.2b2c7cbf01ef3f9b",
       "_id": "2b2c7cbf01ef3f9b"
     },
@@ -80,7 +87,8 @@
         18,
         20
       ],
-      "text": "Bulwark",
+      "name": "Bulwark",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.6e439be2dd0bd5a4]{Brawler}, @Compendium[foundry-ironsworn.starforgedassets.7978ba0785000e24]{Loyalist}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.cdbf14bd7299ec5f",
       "_id": "cdbf14bd7299ec5f"
     },
@@ -89,7 +97,8 @@
         21,
         23
       ],
-      "text": "Castaway",
+      "name": "Castaway",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.f841c7e14913086a]{Jinx}, @Compendium[foundry-ironsworn.starforgedassets.11de92d262291440]{Scavenger}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.9fe0bd27cf8a1574",
       "_id": "9fe0bd27cf8a1574"
     },
@@ -98,7 +107,8 @@
         24,
         26
       ],
-      "text": "Charlatan",
+      "name": "Charlatan",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.d7fbe5fded75531c]{Scoundrel}, @Compendium[foundry-ironsworn.sunderedislesassets.43b05d08b7b0d77a]{Socialite}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.917d6e5d4d84e28b",
       "_id": "917d6e5d4d84e28b"
     },
@@ -107,7 +117,8 @@
         27,
         28
       ],
-      "text": "Cloak and Dagger",
+      "name": "Cloak and Dagger",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.64cc9fd2fe517619]{Cutthroat}, @Compendium[foundry-ironsworn.sunderedislesassets.a3fbec673ba7bd63]{Spy}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.0a5734a9bbf5bee3",
       "_id": "0a5734a9bbf5bee3"
     },
@@ -116,7 +127,8 @@
         29,
         30
       ],
-      "text": "Cultist",
+      "name": "Cultist",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.14c1e6ecd4680fee]{Devotant}, @Compendium[foundry-ironsworn.sunderedislesassets.df94d23a05e3330d]{Necromancer}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.99a96bc7ae6fffb3",
       "_id": "99a96bc7ae6fffb3"
     },
@@ -125,7 +137,8 @@
         31,
         32
       ],
-      "text": "Deathbound",
+      "name": "Deathbound",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.9ab94d1a123ed80e]{Fated}, @Compendium[foundry-ironsworn.starforgedassets.7fdebd942b7163b6]{Haunted}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.e085b464cb85c9c8",
       "_id": "e085b464cb85c9c8"
     },
@@ -134,7 +147,8 @@
         33,
         34
       ],
-      "text": "Deep One",
+      "name": "Deep One",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.d68e04a72dd54d32]{Vestige}, @Compendium[foundry-ironsworn.sunderedislesassets.5087a0440ba3299e]{Waterborn}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.7ceb6cb2b9050ceb",
       "_id": "7ceb6cb2b9050ceb"
     },
@@ -143,7 +157,8 @@
         35,
         37
       ],
-      "text": "Elementalist",
+      "name": "Elementalist",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.9167e29940b36ec1]{Firebrand}, @Compendium[foundry-ironsworn.sunderedislesassets.a304a030a931cdd7]{Sorcerer}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.089973763d13214e",
       "_id": "089973763d13214e"
     },
@@ -152,7 +167,8 @@
         38,
         40
       ],
-      "text": "Emissary",
+      "name": "Emissary",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.bcc219b0ebfb5c68]{Diplomat}, @Compendium[foundry-ironsworn.sunderedislesassets.a3fbec673ba7bd63]{Spy}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.a8adbaef656798f7",
       "_id": "a8adbaef656798f7"
     },
@@ -161,7 +177,8 @@
         41,
         42
       ],
-      "text": "Gallant",
+      "name": "Gallant",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.8ce3175e11ec3edd]{Duelist}, @Compendium[foundry-ironsworn.sunderedislesassets.43b05d08b7b0d77a]{Socialite}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.36c201a6f15c640a",
       "_id": "36c201a6f15c640a"
     },
@@ -170,7 +187,8 @@
         43,
         44
       ],
-      "text": "Guild Mage",
+      "name": "Guild Mage",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.92c1672053d9fba4]{Bannersworn}, @Compendium[foundry-ironsworn.sunderedislesassets.a304a030a931cdd7]{Sorcerer}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.f785ce74c5a0e801",
       "_id": "f785ce74c5a0e801"
     },
@@ -179,7 +197,8 @@
         45,
         46
       ],
-      "text": "Gunner",
+      "name": "Gunner",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.5e3b215da23a9493]{Cannoneer}, @Compendium[foundry-ironsworn.starforgedassets.5b517486f8722fdb]{Veteran}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.e7dc3efb5f040a4f",
       "_id": "e7dc3efb5f040a4f"
     },
@@ -188,7 +207,8 @@
         47,
         48
       ],
-      "text": "Hired Gun",
+      "name": "Hired Gun",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.9530a642ebdca5a5]{Mercenary}, @Compendium[foundry-ironsworn.sunderedislesassets.7d767f45740b4adf]{Musketeer}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.0a5d37d9f6458eef",
       "_id": "0a5d37d9f6458eef"
     },
@@ -197,7 +217,8 @@
         49,
         50
       ],
-      "text": "Ironclad",
+      "name": "Ironclad",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.3bd3cddf27041c08]{Armored}, @Compendium[foundry-ironsworn.starforgedassets.6e439be2dd0bd5a4]{Brawler}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.0bac87e9f06efbbe",
       "_id": "0bac87e9f06efbbe"
     },
@@ -206,7 +227,8 @@
         51,
         52
       ],
-      "text": "Jury-Rig",
+      "name": "Jury-Rig",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.025095e4809853dd]{Construct}, @Compendium[foundry-ironsworn.starforgedassets.11de92d262291440]{Scavenger}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.b3b30a95776cdb22",
       "_id": "b3b30a95776cdb22"
     },
@@ -215,7 +237,8 @@
         53,
         54
       ],
-      "text": "Lycanthrope",
+      "name": "Lycanthrope",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.085d80b933598615]{Outcast}, @Compendium[foundry-ironsworn.sunderedislesassets.c139fc91f359a129]{Shapechanger}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.67a455cf9886cbc1",
       "_id": "67a455cf9886cbc1"
     },
@@ -224,7 +247,8 @@
         55,
         57
       ],
-      "text": "Monster Hunter",
+      "name": "Monster Hunter",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.82cb2564aae5bf0f]{Blademaster}, @Compendium[foundry-ironsworn.starforgedassets.b01dc7301d7d8fb3]{Slayer}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.51bad82ca33b60a0",
       "_id": "51bad82ca33b60a0"
     },
@@ -233,7 +257,8 @@
         58,
         60
       ],
-      "text": "Naturalist",
+      "name": "Naturalist",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.bee5ddc7feb36f37]{Overlander}, @Compendium[foundry-ironsworn.sunderedislesassets.e5b88e6a5a73260a]{Scholar} (Natural history)</p>",
       "_key": "!tables.results!d292ed147d36f2f4.02152be1b4638f07",
       "_id": "02152be1b4638f07"
     },
@@ -242,7 +267,8 @@
         61,
         62
       ],
-      "text": "Pilgrim",
+      "name": "Pilgrim",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.14c1e6ecd4680fee]{Devotant}, @Compendium[foundry-ironsworn.starforgedassets.4692e18baff8bd18]{Navigator}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.ef60867f0973bf16",
       "_id": "ef60867f0973bf16"
     },
@@ -251,7 +277,8 @@
         63,
         64
       ],
-      "text": "Piper",
+      "name": "Piper",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.1d913e755e8f9352]{Musician}, @Compendium[foundry-ironsworn.starforgedassets.7978ba0785000e24]{Loyalist}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.d388510931579850",
       "_id": "d388510931579850"
     },
@@ -260,7 +287,8 @@
         65,
         67
       ],
-      "text": "Renegade",
+      "name": "Renegade",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.93b030423d23059d]{Fugitive}, @Compendium[foundry-ironsworn.starforgedassets.5b517486f8722fdb]{Veteran}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.98be53bcf3051453",
       "_id": "98be53bcf3051453"
     },
@@ -269,7 +297,8 @@
         68,
         70
       ],
-      "text": "Saboteur",
+      "name": "Saboteur",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.69c86f19e7cbcf43]{Demolitionist}, @Compendium[foundry-ironsworn.sunderedislesassets.a3fbec673ba7bd63]{Spy}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.d29a06de93a6272c",
       "_id": "d29a06de93a6272c"
     },
@@ -278,7 +307,8 @@
         71,
         72
       ],
-      "text": "Sea Witch",
+      "name": "Sea Witch",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.98f1ff9b338b5695]{Seer}, @Compendium[foundry-ironsworn.sunderedislesassets.d4e67aa3e3c3fdb1]{Windbinder}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.ded18e7a205dd339",
       "_id": "ded18e7a205dd339"
     },
@@ -287,7 +317,8 @@
         73,
         74
       ],
-      "text": "Shadow Assassin",
+      "name": "Shadow Assassin",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.64cc9fd2fe517619]{Cutthroat}, @Compendium[foundry-ironsworn.starforgedassets.12a922e088c35efa]{Shade}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.a7b29465f43a9668",
       "_id": "a7b29465f43a9668"
     },
@@ -296,7 +327,8 @@
         75,
         76
       ],
-      "text": "Shipbreaker",
+      "name": "Shipbreaker",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.fd7a1b4ec8ae5771]{Kinetic}, @Compendium[foundry-ironsworn.starforgedassets.11de92d262291440]{Scavenger}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.70ea3f6cefe175f4",
       "_id": "70ea3f6cefe175f4"
     },
@@ -305,7 +337,8 @@
         77,
         78
       ],
-      "text": "Siren",
+      "name": "Siren",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.db0df04af3ca4cc4]{Empath}, @Compendium[foundry-ironsworn.sunderedislesassets.1d913e755e8f9352]{Musician}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.93e4485ba108b39e",
       "_id": "93e4485ba108b39e"
     },
@@ -314,7 +347,8 @@
         79,
         80
       ],
-      "text": "Skipper",
+      "name": "Skipper",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.5700a76b914a881e]{Crew Commander}, @Compendium[foundry-ironsworn.starforgedassets.dabb03f5d0a167f0]{Leader}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.5ff3bb297a0c44ff",
       "_id": "5ff3bb297a0c44ff"
     },
@@ -323,7 +357,8 @@
         81,
         83
       ],
-      "text": "Smuggler",
+      "name": "Smuggler",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.93b030423d23059d]{Fugitive}, @Compendium[foundry-ironsworn.sunderedislesassets.19ad0bd745c765c5]{Peddler}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.b863d3d806523a60",
       "_id": "b863d3d806523a60"
     },
@@ -332,7 +367,8 @@
         84,
         86
       ],
-      "text": "Sole Survivor",
+      "name": "Sole Survivor",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.7fdebd942b7163b6]{Haunted}, @Compendium[foundry-ironsworn.starforgedassets.d68e04a72dd54d32]{Vestige}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.03e4c3cce1816f52",
       "_id": "03e4c3cce1816f52"
     },
@@ -341,7 +377,8 @@
         87,
         88
       ],
-      "text": "Spiritualist",
+      "name": "Spiritualist",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.98f1ff9b338b5695]{Seer}, @Compendium[foundry-ironsworn.starforgedassets.26787f46840c03ad]{Sleuth}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.34cdf618d693c07c",
       "_id": "34cdf618d693c07c"
     },
@@ -350,7 +387,8 @@
         89,
         91
       ],
-      "text": "Stowaway",
+      "name": "Stowaway",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.54ffc0e2d8e514b4]{Urchin}, @Compendium[foundry-ironsworn.starforgedassets.085d80b933598615]{Outcast}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.bcf71141c3914227",
       "_id": "bcf71141c3914227"
     },
@@ -359,7 +397,8 @@
         92,
         94
       ],
-      "text": "Surgeon",
+      "name": "Surgeon",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.4fafc93fdd8873ce]{Healer}, @Compendium[foundry-ironsworn.sunderedislesassets.e5b88e6a5a73260a]{Scholar} (Medicine)</p>",
       "_key": "!tables.results!d292ed147d36f2f4.436900f8839233a7",
       "_id": "436900f8839233a7"
     },
@@ -368,7 +407,8 @@
         95,
         96
       ],
-      "text": "Tinker",
+      "name": "Tinker",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.4c75d631a38fd3b8]{Augmented}, @Compendium[foundry-ironsworn.starforgedassets.2d9f63e491a880c8]{Gearhead}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.858d1cbb33f4d2da",
       "_id": "858d1cbb33f4d2da"
     },
@@ -377,7 +417,8 @@
         97,
         98
       ],
-      "text": "Vanguard",
+      "name": "Vanguard",
+      "description": "<p>@Compendium[foundry-ironsworn.starforgedassets.92c1672053d9fba4]{Bannersworn}, @Compendium[foundry-ironsworn.sunderedislesassets.3267980c4a28e3b4]{Scattershot}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.1ca1d845661f100d",
       "_id": "1ca1d845661f100d"
     },
@@ -386,7 +427,8 @@
         99,
         100
       ],
-      "text": "War Machine",
+      "name": "War Machine",
+      "description": "<p>@Compendium[foundry-ironsworn.sunderedislesassets.025095e4809853dd]{Construct}, @Compendium[foundry-ironsworn.starforgedassets.9530a642ebdca5a5]{Mercenary}</p>",
       "_key": "!tables.results!d292ed147d36f2f4.25c55c97d8d8168c",
       "_id": "25c55c97d8d8168c"
     }

--- a/src/module/datasworn2/import/index.ts
+++ b/src/module/datasworn2/import/index.ts
@@ -405,9 +405,34 @@ const processOracle = async (
 			oracle.rows.map((row) => {
 				if (!row.roll) return undefined
 				const rowId = hash(lookupLegacyId(row._id))
+				const text = renderFragment(row.text)
+				// `name` is rendered as plain text (no HTML, no Foundry
+				// enrichment), so a link there would show as raw markup. When the
+				// primary text contains a compendium link or an oracle-category
+				// link, keep both values together in `text` (which is enriched)
+				// instead of the `name` / `description` split.
+				const hasLink =
+					text.includes('@Compendium[') ||
+					text.includes('entity-link oracle-category-link')
+				// Wrap each present fragment in its own paragraph so they render
+				// on separate lines.
+				const paragraphs = (fragments: Array<string | undefined>) =>
+					fragments
+						.filter((fragment) => fragment)
+						.map(
+							(fragment) => `<p>${renderFragment(fragment as string)}</p>`
+						)
+						.join('')
 				return {
 					range: [row.roll.min, row.roll.max],
-					text: renderFragment(row.text),
+					...(row.text2
+						? hasLink
+							? { text: paragraphs([row.text, row.text2, row.text3]) }
+							: {
+									name: text,
+									description: paragraphs([row.text2, row.text3])
+							  }
+						: { text }),
 					_key: `!tables.results!${fid}.${rowId}`,
 					_id: rowId
 				}


### PR DESCRIPTION
Datasworn oracle rows may carry secondary and tertiary text fragments (`text2`, `text3`) alongside the primary `text`. Populate the table result's `name` and `description` from them instead of collapsing everything into a single `text` value.

`name` renders as plain text, so when the primary text contains a compendium or oracle-category link, all fragments are combined into the enriched `text` field instead — each wrapped in its own paragraph so they render on separate lines.

Also re-import the affected oracle packs from datasworn-community data.

Oracles sometimes contain two or even three results. We can use both `Result Name` and `Result Description` fields in v13 and v14 to display the various results. Datasworn puts the results into `text`, `text2` and `text3`. One issue is that any hyperlinks must be placed in the `Result Description` field.  Currently, foundry-ironsworn puts the single `text` entry into the `Result Description` field.

Logic
* If `text` is literal text and is the only entry, put it into `Result Description`. (current behavior)
* If `text` is literal text and `text2` and/or `text3` exist, then put `text` into `Result Name` and `text2` and `text3` into `Result Description`
* If `text` is a hyperlink, put all `text*` entries into `Result Description`

Oracles for Testing
* Location Themes - Theme Type
* Faction Types
* Faction Influence
* Starship Types
* Starship Fleet
* Delve - Site Starters
